### PR TITLE
docs: refresh READMEs for v2.0.0-alpha.0 + extract self-hosting doc

### DIFF
--- a/.notes/tool-plugin-create.spec.md
+++ b/.notes/tool-plugin-create.spec.md
@@ -1,0 +1,216 @@
+---
+status: draft # draft → proposed (issue filed) → approved (milestone attached) → archived
+issue: 77
+blocked-by: [76, 78]
+---
+
+<!-- editorconfig-checker-disable-file -->
+
+# `holocron plugin create <slug> <vendor>`
+
+> **Blocked.** Design deferred until #76 (per-plugin `transport`
+> option) and #78 (CLI-transport sibling skill) land. Reason: the
+> template shape depends on how transport variants are declared in
+> `holocron.config.json` and what the CLI-transport plugin structure
+> looks like. Designing REST-only templates first would likely bake
+> in the wrong abstractions and force a rewrite once the other two
+> land. Revisit this spec after both are merged.
+
+## Decision
+
+Promote the `holocron-plugin` Claude Code skill (at
+`.claude/skills/holocron-plugin.md`) into a first-class CLI command
+under `@theholocron/cli`. Same template, same verification, same
+non-negotiables — invocable from a plain terminal, no Claude in the
+loop.
+
+Once the CLI ships, the skill file becomes a **stub** that points
+operators at `holocron plugin create`. Two implementations of the
+same template drift; we consolidate on the CLI.
+
+## Why
+
+- Issue #77 makes the case: the skill is fine for AI-assisted
+  scaffolding, but the CLI is what an operator reaches for from a
+  regular shell — and it's what a *downstream* project reaches for
+  when they need to author their own vendor plugin.
+- The scaffolding logic is already codified in the skill; it just
+  needs to be re-hosted as TS code invoked through the existing
+  yargs subcommand plumbing.
+- The 3 plugins built with the skill (Clerk, 1Password, Postman)
+  have surfaced the template well — enough signal to bake it into
+  code without over-fitting to any one plugin.
+
+## Command shape
+
+```bash
+holocron plugin create <slug> <vendor>
+    [--capability <key>]         # source|ci|secrets|environments|issues|
+                                 # deployment|storage|auth|vault|dns|
+                                 # tooling|notifications|analytics|
+                                 # observability
+                                 # (interactive prompt if omitted)
+    [--token-env <ENV>]          # holocron env var name
+                                 # (default: HOLOCRON_<VENDOR_UPPER>_TOKEN)
+    [--vendor-env <ENV>]         # vendor-native env var name
+                                 # (interactive prompt if omitted)
+    [--base-url <URL>]           # REST base URL
+                                 # (interactive prompt if omitted)
+    [--transport <rest|cli>]     # default: rest
+                                 # cli transport blocked pending #78
+    [--dry-run]                  # print the file list, write nothing
+    [--no-verify]                # skip post-scaffold pnpm install/typecheck/lint/test
+```
+
+Positional args (`slug`, `vendor`) are required — everything else has
+a sensible default or prompts. This is symmetric with existing
+orchestrator commands (`holocron setup`, `holocron secrets sync`)
+which also mix positional + interactive prompts.
+
+## Behavior — happy path
+
+1. **Preflight**: verify CWD is a holocron workspace root
+   (`pnpm-workspace.yaml` + `packages/` dir present). If not, error
+   with the same message pnpm gives on out-of-workspace runs.
+2. **Slug collision**: `packages/holocron-plugin-<slug>/` must not
+   exist. If it does, error "already scaffolded, edit in place".
+3. **Prompt for anything missing**: capability key, vendor-native env,
+   base URL — using `@theholocron/cli-utils` prompts.
+4. **Capability sanity**: capability key must be one of the 14; error
+   if not. If capability cardinality is `many` (per `CARDINALITY` in
+   `capabilities/index.ts`), print a warning + confirm — those need
+   different wiring in `holocron.config.json`.
+5. **Generate**: write the 14 template files to
+   `packages/holocron-plugin-<slug>/` (see §Templates below).
+6. **Verify** (unless `--no-verify`): run
+   `pnpm install && pnpm --filter <pkg> typecheck lint test`. If any
+   step fails, surface verbatim and leave the scaffold in place — the
+   operator can inspect + delete if they choose.
+7. **Print next steps**: implement the capability methods, replace
+   `it.todo`, update README, commit.
+
+`--dry-run` skips steps 5–7 and prints the file list only.
+
+## Templates
+
+Template content lives **inline as TS string builders** in
+`packages/cli/src/commands/plugin-create/templates/`:
+
+- `package-json.ts` → returns the `package.json` string given inputs
+- `tsconfig-json.ts` → returns the `tsconfig.json` string
+- `vitest-config.ts` → `vitest.config.ts` string
+- `eslint-config.ts` → `eslint.config.js` string
+- `readme.ts` → `README.md` string
+- `auth.ts` → `src/auth.ts` string
+- `rest.ts` → `src/rest.ts` string
+- `plugin-index.ts` → `src/index.ts` string
+- `capability.ts` → `src/capabilities/<key>.ts` string (stubbed body)
+- `helpers.ts` → `src/__tests__/helpers.ts` string (stubFetch)
+- `auth-test.ts` → `src/__tests__/auth.test.ts` string
+- `rest-test.ts` → `src/__tests__/rest.test.ts` string
+- `capability-test.ts` → `src/__tests__/<key>.test.ts` string (it.todo)
+- `index-test.ts` → `src/__tests__/index.test.ts` string
+
+Inline TS over file-based `.tmpl` templates because:
+- No template engine dep
+- Templates get typechecked against a shared `TemplateInputs` type
+- Editor jumps to the string source directly
+- Small enough surface (14 files, ~800 LOC of templates) that it
+  doesn't overwhelm the codebase
+
+Each template exports `(inputs: TemplateInputs) => string` and takes
+the same input record — a tagged discriminated union for
+REST/CLI-transport variants (CLI-transport variant deferred to #78).
+
+### `TemplateInputs`
+
+```ts
+interface TemplateInputs {
+    slug: string;                       // 'clerk'
+    vendorName: string;                 // 'Clerk' (PascalCase)
+    vendorUpper: string;                // 'CLERK'
+    capability: CapabilityKey;          // 'auth'
+    capabilityClass: string;            // 'ClerkAuth'
+    tokenEnv: string;                   // 'HOLOCRON_CLERK_TOKEN'
+    vendorEnv: string;                  // 'CLERK_SECRET_KEY'
+    baseUrl: string;                    // 'https://api.clerk.com/v1'
+    transport: "rest";                  // 'cli' variant pending #78
+}
+```
+
+## Non-negotiables (mirrored from the skill)
+
+These are hard invariants the templates encode:
+
+- Auth precedence: `--token` → `HOLOCRON_<X>` → `<vendor-native>`.
+  Throw `AuthError` with a message naming both env vars.
+- REST wraps transport failures (`TypeError: fetch failed`) into
+  `ProviderApiError` with `status: 0`. Path in the message.
+- 204 handling: `request<T>` returns `undefined` on 204 OR when
+  `expectNoContent: true`.
+- Tests use `stubFetch` (verbatim from
+  `packages/holocron-plugin-neon/src/__tests__/helpers.ts`).
+- Workspace + catalog deps for the standard dev-deps.
+- `@theholocron/cli` is peer dep + devDep at `workspace:*`.
+- Underscore-prefix unused params (workspace ESLint has
+  `^_` in argsIgnorePattern / varsIgnorePattern).
+- Never `expect(...).toThrow()` twice on the same stubbed call —
+  the templates emit `try/catch + property assertions` instead.
+
+If any of these change in the future, they change in one place (the
+template modules) and every new plugin picks it up.
+
+## Skill deprecation
+
+Once the CLI ships and there's a green e2e test that scaffolds a
+throwaway plugin, `.claude/skills/holocron-plugin.md` becomes a
+~10-line stub:
+
+> The scaffolding logic lives in `holocron plugin create`.
+> Run it directly:
+> ```
+> holocron plugin create <slug> <vendor>
+> ```
+> The skill file itself is deprecated — kept only so old references
+> resolve.
+
+## Test plan
+
+- **Unit**: each template module gets a golden-file test — input
+  record → expected string. Add a template, add a golden.
+- **Integration**: single vitest scenario that spawns
+  `holocron plugin create test-plugin TestVendor` in a temp workspace
+  fixture (with the minimum viable `pnpm-workspace.yaml` +
+  `holocron.config.json`), asserts:
+  1. The 14 files exist and their content matches golden output
+  2. `pnpm --filter @theholocron/holocron-plugin-test-plugin typecheck`
+     passes on the scaffolded package
+- **Skipped on CI initially**: the integration test runs `pnpm install`
+  which is slow — mark it `describe.skip` behind an env flag, run
+  locally + as a periodic job. Similar to Rando's Postgres opt-in
+  tests.
+
+## Roadmap
+
+- **Phase 1** (this issue): Ship `holocron plugin create <slug> <vendor>`
+  REST-only. Templates + prompts + verify.
+- **Phase 2** (needs #76+#78): Add `--transport cli` variant. Requires
+  the `transport` option in `holocron.config.json` (#76) and the
+  CLI-transport skill/design (#78).
+- **Phase 3** (later): Add `--from-rando <path>` flag that reads an
+  existing Rando adapter and pre-fills the template — turns the
+  Rando-porting checklist at the bottom of the skill into a machine
+  step.
+
+## Open questions
+
+1. **Should `--dry-run` also show file *contents*, gated behind
+   `-v`?** Argument for: operator can review before writing. Argument
+   against: prints ~800 lines to the terminal.
+2. **Should there be a `holocron plugin list` complement?** Trivial
+   to add (reads `packages/`, filters for `holocron-plugin-*`) but
+   maybe out of scope until someone asks.
+3. **Naming: `plugin create` vs `plugin new` vs `create-plugin`?**
+   Sketch says `plugin create` (subcommand form, matches
+   `holocron secret set`). Sticking with that unless there's a
+   reason not to.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,43 @@
 A pluggable, capability-based CLI for spinning up and operating
 software projects — your own infrastructure-as-tool.
 
-> **Status:** v2 alpha, in active design. The published v1.x at
-> `@theholocron/cli` is preserved on the `main` branch as an archive
-> while v2 work happens on the `v2` branch. See
+> **Status:** `v2.0.0-alpha.0` — [release notes](https://github.com/theholocron/holocron/releases/tag/v2.0.0-alpha.0).
+> Published under the `alpha` dist-tag on npm. APIs, config shape,
+> and CLI surface may shift before stable v2.0.0. The v1.0.0 line at
+> `@theholocron/cli` (a project-bootstrap CLI) is preserved as an
+> archive under the `v1.0.0` git tag. Design in
 > [`.notes/tech-architecture.spec.md`](./.notes/tech-architecture.spec.md)
-> for the design (tracked in [#74](https://github.com/theholocron/holocron/issues/74)).
+> (tracked in [#74](https://github.com/theholocron/holocron/issues/74)).
+
+## Quickstart
+
+```bash
+# 1. Install the CLI + the two plugins you'll always need
+npm  i -g @theholocron/cli@alpha
+pnpm add -D @theholocron/holocron-plugin-github@alpha \
+			@theholocron/holocron-plugin-1password@alpha
+```
+
+```jsonc
+// 2. Drop a minimal holocron.config.json at your repo root
+{
+	"project": { "name": "my-app" },
+	"providers": {
+		"source": "github",
+		"vault": ["1password", { "vault": "my-app" }],
+	},
+}
+```
+
+```bash
+# 3. Verify the wiring
+export HOLOCRON_GH_TOKEN=ghp_...          # or use --token / a fine-grained PAT
+holocron doctor
+```
+
+Every additional capability (`ci`, `secrets`, `deployment`, `storage`,
+`auth`, …) is one plugin install + one line of config away. The rest
+of this README is the full picture.
 
 ## The idea
 
@@ -101,109 +133,12 @@ holocron.config.json              — this repo's own holocron config (self-host
 .claude/skills/holocron-plugin.md — scaffolding skill for new plugins
 ```
 
-## Self-hosting — npm publishing via Trusted Publishing
+## Self-hosting
 
 This repo carries its own `holocron.config.json` so holocron commands
-work inside it. npm publishing is wired via **Trusted Publishing**
-([GA July 2025](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/))
-— GitHub Actions OIDC, no stored `NPM_TOKEN`, no token rotation.
-
-### The chicken-and-egg + the one-time bootstrap
-
-npm requires a package to already exist before you can configure
-Trusted Publishing for it. So the actual flow is:
-
-1. **One-time manual publish** of `v2.0.0-alpha.0` for every package
-2. **Configure Trusted Publisher** for each package (or org-wide if npm exposes that)
-3. **Push v2 → main** — CI takes over for `v2.0.0-alpha.1` and beyond, via OIDC
-
-After step 3, no operator action is ever needed for releases again.
-
-### Step 1 — one-time manual publish
-
-```bash
-# From the holocron repo root, on a clean checkout.
-# Interactive npm sign-in via the browser (no token stored locally beyond
-# npm's own session cookie):
-npm login --auth-type=web
-
-# Build everything fresh:
-pnpm install --frozen-lockfile
-pnpm build
-
-# Run the holocron one-shot bootstrap publish. Verifies npm auth, runs
-# `pnpm publish -r` with the right filters, prints direct links to each
-# package's Trusted Publisher config page.
-#
-# If your npm account requires 2FA for writes (recommended), grab a
-# one-time password from your authenticator and pass it via --otp. The
-# same code is reused across all 7 publishes — they happen in seconds.
-pnpm exec tsx packages/cli/src/cli.ts npm publish-initial --otp 123456
-```
-
-The bootstrap command does the publish + reminds you exactly which URLs
-to visit for step 2. The session token from `npm login` is local-only;
-never enters CI.
-
-Add `--dry-run` to print what would happen without actually publishing.
-If you forget `--otp` and your account needs it, the command detects
-the `EOTP` error in the output and prints the corrected command.
-
-### Step 2 — configure Trusted Publisher for each package
-
-In the npm web UI, for each `@theholocron/*` package:
-
-1. Sign in at <https://www.npmjs.com>
-2. Navigate to the package → Settings → Trusted Publishers
-3. Configure:
-		- **Publisher**: GitHub Actions
-		- **Organization**: `theholocron`
-		- **Repository**: `holocron`
-		- **Workflow filename**: `release.yml`
-		- **Environment** (optional): leave blank
-
-Repeat for each:
-`@theholocron/cli`,
-`@theholocron/holocron-plugin-github`,
-`@theholocron/holocron-plugin-vercel`,
-`@theholocron/holocron-plugin-neon`,
-`@theholocron/holocron-plugin-clerk`,
-`@theholocron/holocron-plugin-1password`,
-`@theholocron/holocron-plugin-postman`.
-
-(If npm's UI exposes org-level Trusted Publishers, you can configure
-once at the `@theholocron` org and it applies to every package
-published under the scope.)
-
-### Step 3 — flip the switch
-
-```bash
-# From v2:
-gh pr create --base main --head v2 --title "v2 release line" --body "Phase 1-5 complete; auto-publish kicks in."
-# Merge the PR. release.yml fires on push to main.
-```
-
-The release workflow requests an OIDC token from GitHub (permitted by
-`id-token: write` in the workflow), `pnpm publish` exchanges it with
-npm, npm validates against the registered Trusted Publisher, and the
-publish proceeds. Provenance attestations are attached automatically —
-no `--provenance` flag needed. Each version on npm shows a verified
-✓ linking back to the CI run that produced it.
-
-## Ad-hoc secret setting (still useful)
-
-For one-off secrets that ARE token-based (not npm publishing), the
-`secret set` command still helps:
-
-```bash
-# Example: set a Vercel deploy hook secret on the holocron repo (hypothetical)
-DEPLOY_HOOK=https://api.vercel.com/.../v1 HOLOCRON_GH_TOKEN=ghp_xxx \
-	pnpm exec tsx packages/cli/src/cli.ts secret set DEPLOY_HOOK
-```
-
-Replaces clicking through GH Settings → Secrets → Actions → New for
-any CI secret that isn't covered by OIDC. Same pattern across your
-projects, not just this one.
+work inside it, and publishes its own packages via npm Trusted
+Publishing (OIDC — no stored `NPM_TOKEN`). Setup + new-package
+bootstrap live in [`docs/self-hosting.md`](./docs/self-hosting.md).
 
 ## License
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,110 @@
+# Self-hosting — npm publishing via Trusted Publishing
+
+This repo publishes its own `@theholocron/*` packages via **npm Trusted Publishing**
+([GA July 2025](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/))
+— GitHub Actions OIDC, no stored `NPM_TOKEN`, no token rotation.
+
+Steady state is fully automatic: `semantic-release` on push to `main`
+computes the next version, bumps all packages in lockstep, and publishes
+via OIDC. This doc covers **the one-time bootstrap** and the
+**new-package bootstrap** (both hit the same chicken-and-egg problem).
+
+## The chicken-and-egg
+
+npm requires a package to already exist before you can configure
+Trusted Publishing for it. So the actual flow for any new
+`@theholocron/*` package is:
+
+1. **One-time manual publish** to establish the package on npm
+2. **Configure Trusted Publisher** on npmjs.com for that package
+3. **Push to `main`** — subsequent releases go via OIDC
+
+After step 3, no operator action is needed for that package again.
+
+The initial v2 bootstrap ran this for all 7 packages together (via
+`holocron npm publish-initial`, which does step 1 in a single
+invocation across the workspace). Any new plugin added later needs
+to walk through steps 1–2 for itself.
+
+## Step 1 — one-time manual publish
+
+```bash
+# From the holocron repo root, on a clean checkout.
+# Interactive npm sign-in via the browser (no token stored locally beyond
+# npm's own session cookie):
+npm login --auth-type=web
+
+# Build everything fresh:
+pnpm install --frozen-lockfile
+pnpm build
+
+# Run the holocron one-shot bootstrap publish. Verifies npm auth, runs
+# `pnpm publish -r` with the right filters, prints direct links to each
+# package's Trusted Publisher config page.
+#
+# If your npm account requires 2FA for writes (recommended), grab a
+# one-time password from your authenticator and pass it via --otp. The
+# same code is reused across all sequential publishes — they happen in
+# seconds, comfortably inside the TOTP window.
+pnpm exec tsx packages/cli/src/cli.ts npm publish-initial --otp 123456
+```
+
+The bootstrap command does the publish + reminds you exactly which URLs
+to visit for step 2. The session token from `npm login` is local-only;
+never enters CI.
+
+Add `--dry-run` to print what would happen without actually publishing.
+If you forget `--otp` and your account needs it, the command detects
+the `EOTP` error in the output and prints the corrected command.
+
+## Step 2 — configure Trusted Publisher for each package
+
+In the npm web UI, for each `@theholocron/*` package:
+
+1. Sign in at <https://www.npmjs.com>
+2. Navigate to the package → Settings → Trusted Publishers
+3. Configure:
+	- **Publisher**: GitHub Actions
+	- **Organization**: `theholocron`
+	- **Repository**: `holocron`
+	- **Workflow filename**: `release.yml`
+	- **Environment** (optional): leave blank
+
+Currently configured (as of v2.0.0-alpha.0):
+
+- `@theholocron/cli`
+- `@theholocron/holocron-plugin-github`
+- `@theholocron/holocron-plugin-vercel`
+- `@theholocron/holocron-plugin-neon`
+- `@theholocron/holocron-plugin-clerk`
+- `@theholocron/holocron-plugin-1password`
+- `@theholocron/holocron-plugin-postman`
+
+If npm's UI exposes org-level Trusted Publishers in the future, one
+config at the `@theholocron` org will apply to every package under the
+scope — retire the per-package rows in that case.
+
+## Step 3 — subsequent releases run themselves
+
+Push to `main` fires `.github/workflows/release.yml`. The workflow
+requests an OIDC token from GitHub (permitted by `id-token: write`),
+`pnpm publish` exchanges it with npm, npm validates against the
+registered Trusted Publisher, and the publish proceeds. Provenance
+attestations attach automatically — no `--provenance` flag needed.
+Each version on npm shows a verified ✓ linking back to the CI run
+that produced it.
+
+## Ad-hoc secret setting (still useful)
+
+For one-off secrets that ARE token-based (not covered by OIDC), the
+`secret set` command still helps:
+
+```bash
+# Example: set a Vercel deploy hook secret on the holocron repo
+DEPLOY_HOOK=https://api.vercel.com/.../v1 HOLOCRON_GH_TOKEN=ghp_xxx \
+	holocron secret set DEPLOY_HOOK
+```
+
+Replaces clicking through GH Settings → Secrets → Actions → New for
+any CI secret that isn't covered by OIDC. Same pattern across your
+projects, not just this one.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,22 +3,26 @@
 The Holocron CLI — a pluggable, capability-based orchestrator for
 spinning up and operating software projects.
 
-## Status
+## Install
 
-**v2 alpha.** The shape is being built up per
-[`.notes/tech-architecture.spec.md`](../../.notes/tech-architecture.spec.md).
-Most commands aren't wired yet.
+```bash
+npm i -g @theholocron/cli@alpha
+holocron --help
+```
 
 ## What's in here
 
 - `src/capabilities/` — the 14 capability interfaces that providers
 	implement
 - `src/config.ts` — `holocron.config.json` parser + plugin resolution
-- `src/cli.ts` — yargs entry, dispatches subcommands (WIP)
+- `src/cli.ts` — yargs entry, dispatches subcommands
+- `src/commands/` — `setup`, `doctor`, `deploy`, `secret set`,
+	`secrets sync`, `npm publish-initial`
 
-## Install (when published)
+## Status
 
-```bash
-pnpm add -D @theholocron/cli
-pnpm holocron --help
-```
+**`v2.0.0-alpha.0`** — published on npm under the `alpha` dist-tag.
+[Release notes](https://github.com/theholocron/holocron/releases/tag/v2.0.0-alpha.0).
+Design in
+[`.notes/tech-architecture.spec.md`](../../.notes/tech-architecture.spec.md).
+APIs may still shift before stable v2.0.0.

--- a/packages/holocron-plugin-1password/README.md
+++ b/packages/holocron-plugin-1password/README.md
@@ -4,6 +4,14 @@
 `vault` capability via shell-out to the `op` CLI
 (<https://developer.1password.com/docs/cli>).
 
+## Install
+
+```bash
+pnpm add -D @theholocron/holocron-plugin-1password@alpha
+```
+
+Requires the `op` binary on PATH (see [Prerequisite](#prerequisite) below).
+
 ## Why shell-out, not REST
 
 1Password's "REST API" is the **Connect server** — a Docker container
@@ -65,8 +73,11 @@ found.
 
 ## Status
 
-**v0.0.0 — first port.** Ports `rando-id/rando.id`
-`adapters/op-cli.ts`. The stdio shape (`['inherit', 'pipe', 'pipe']`)
-is critical: it gives `op` a TTY signal so it can fire the desktop
+**`v2.0.0-alpha.0`** — published on npm under the `alpha` dist-tag.
+[Release notes](https://github.com/theholocron/holocron/releases/tag/v2.0.0-alpha.0).
+APIs may still shift before stable v2.0.0.
+
+Implementation note: the stdio shape (`['inherit', 'pipe', 'pipe']`)
+is critical — it gives `op` a TTY signal so it can fire the desktop
 biometric unlock dialog when running locally. CI runs see no TTY and
 fall back to whatever auth mode the env var configures.

--- a/packages/holocron-plugin-clerk/README.md
+++ b/packages/holocron-plugin-clerk/README.md
@@ -3,6 +3,12 @@
 Clerk plugin for [Holocron](../cli). Implements the `auth` capability
 against [Clerk's Backend REST API](https://clerk.com/docs/reference/backend-api).
 
+## Install
+
+```bash
+pnpm add -D @theholocron/holocron-plugin-clerk@alpha
+```
+
 ## Auth
 
 Token resolution order:
@@ -42,7 +48,10 @@ for Development, `sk_live_*` for Production.
 
 ## Status
 
-**v0.0.0 — first port.** Capability matches Rando's
-`adapters/clerk-cli.ts` surface plus a holocron-native `describe()`,
-all via direct REST against `api.clerk.com/v1`. No `clerk` CLI binary
-required on the operator's machine.
+**`v2.0.0-alpha.0`** — published on npm under the `alpha` dist-tag.
+[Release notes](https://github.com/theholocron/holocron/releases/tag/v2.0.0-alpha.0).
+APIs may still shift before stable v2.0.0.
+
+Real Svix HMAC verification in `parseWebhook` is deferred to
+[#80](https://github.com/theholocron/holocron/issues/80) — current
+implementation validates shape only.

--- a/packages/holocron-plugin-github/README.md
+++ b/packages/holocron-plugin-github/README.md
@@ -11,6 +11,12 @@ against the GitHub REST API:
 | `environments` | Named deployment environments (reviewers, wait timers)           |
 | `issues`       | GitHub Issues as a tracker (with lifecycle slots)                |
 
+## Install
+
+```bash
+pnpm add -D @theholocron/holocron-plugin-github@alpha
+```
+
 ## Auth
 
 The plugin requires a GitHub token resolved in this order:
@@ -42,7 +48,7 @@ toggles, etc.) — silent fallback would surface as mysterious 403s.
 
 ## Status
 
-**v0.0.0 — scaffolded.** Implementations are being ported from
-[`rando-id/rando.id`](https://github.com/rando-id/rando.id)'s
-`packages/cli/src/adapters/` per the migration plan in
-`.notes/tech-architecture.spec.md`.
+**`v2.0.0-alpha.0`** — published on npm under the `alpha` dist-tag.
+[Release notes](https://github.com/theholocron/holocron/releases/tag/v2.0.0-alpha.0).
+All five capabilities are implemented; APIs may still shift before
+stable v2.0.0.

--- a/packages/holocron-plugin-neon/README.md
+++ b/packages/holocron-plugin-neon/README.md
@@ -3,6 +3,12 @@
 Neon plugin for [Holocron](../cli). Implements the `storage`
 capability against [Neon's REST API](https://api-docs.neon.tech/reference/getting-started-with-neon-api).
 
+## Install
+
+```bash
+pnpm add -D @theholocron/holocron-plugin-neon@alpha
+```
+
 ## Auth
 
 Token resolution order:
@@ -45,4 +51,6 @@ later).
 
 ## Status
 
-**v0.0.0 — first port.**
+**`v2.0.0-alpha.0`** — published on npm under the `alpha` dist-tag.
+[Release notes](https://github.com/theholocron/holocron/releases/tag/v2.0.0-alpha.0).
+APIs may still shift before stable v2.0.0.

--- a/packages/holocron-plugin-postman/README.md
+++ b/packages/holocron-plugin-postman/README.md
@@ -3,6 +3,12 @@
 Postman plugin for [Holocron](../cli). Implements the **multi-cardinality**
 `tooling` capability against [Postman's REST API](https://learning.postman.com/docs/developer/postman-api/).
 
+## Install
+
+```bash
+pnpm add -D @theholocron/holocron-plugin-postman@alpha
+```
+
 ## Why REST, not the CLI
 
 Postman ships a CLI (`postman`, the newer + more capable successor to
@@ -71,7 +77,10 @@ Generate the key at <https://web.postman.co/settings/me/api-keys>.
 
 ## Status
 
-**v0.0.0 — first port.** Surface matches Rando's `adapters/postman.ts`.
+**`v2.0.0-alpha.0`** — published on npm under the `alpha` dist-tag.
+[Release notes](https://github.com/theholocron/holocron/releases/tag/v2.0.0-alpha.0).
+APIs may still shift before stable v2.0.0.
+
 `PostmanPlanLimitError` is thrown when Postman responds with
 `limitReachedError` (e.g., Free-tier "0 APIs" cap) — callers can
 discriminate to render "upgrade required" instead of a raw API dump.

--- a/packages/holocron-plugin-vercel/README.md
+++ b/packages/holocron-plugin-vercel/README.md
@@ -3,6 +3,12 @@
 Vercel plugin for [Holocron](../cli). Implements the `deployment`
 capability against the [Vercel REST API](https://vercel.com/docs/rest-api).
 
+## Install
+
+```bash
+pnpm add -D @theholocron/holocron-plugin-vercel@alpha
+```
+
 ## Auth
 
 Token resolution order:
@@ -31,7 +37,11 @@ always cover what holocron needs at the API level. Explicit token only.
 
 ## Status
 
-**v0.0.0 — first port.** Capability covers:
+**`v2.0.0-alpha.0`** — published on npm under the `alpha` dist-tag.
+[Release notes](https://github.com/theholocron/holocron/releases/tag/v2.0.0-alpha.0).
+APIs may still shift before stable v2.0.0.
+
+Capability covers:
 
 - `listProjects()` / `ensureProject()` — idempotent project create
 - `updateProjectSettings()` — toggle preview deploys, git-creates-deploys
@@ -39,7 +49,7 @@ always cover what holocron needs at the API level. Explicit token only.
 - `triggerDeployment()` — branch deploys with optional named target
 - `getDeployment()` — fetch a deployment by id
 
-Out of scope for v1 (file a follow-up if needed):
+Out of scope for alpha.0 (file a follow-up if needed):
 
 - Domain management (`addDomain` / `removeDomain`)
 - Deletion (`deleteProject`)


### PR DESCRIPTION
## Summary

Docs pass after v2.0.0-alpha.0 shipped — the README banners still said "in active design" and every plugin's Status paragraph said `v0.0.0 — first port`. Also carved the ~80-line Trusted Publishing block out of the root README so the consumer-facing page stays consumer-focused.

- **Root `README.md`**: status banner reflects published alpha (with a link to the release), new **Quickstart** section above the full config example (install → 2-provider config → `holocron doctor`), self-hosting section reduced to a one-paragraph pointer.
- **`docs/self-hosting.md`** (new): all Trusted Publishing bootstrap content, reframed for both the one-time bootstrap (done) and future new-package additions.
- **`packages/cli/README.md`**: consumer install command, command list under "What's in here", updated Status.
- **Every plugin README** (`github`, `vercel`, `neon`, `clerk`, `1password`, `postman`): added `## Install` with `pnpm add -D @theholocron/holocron-plugin-<x>@alpha`, replaced stale Status paragraphs with the published state + release-notes link. GitHub plugin's "being ported" claim replaced with implementation status. Clerk plugin now flags the Svix HMAC deferral to #80.
- **`.notes/tool-plugin-create.spec.md`** (new, draft): parked design spec for #77 with a blocked-by note pointing at #76 + #78 — we shouldn't design plugin scaffolding templates before the transport option lands.

No code changes.

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm lint` green
- [x] `pnpm test` green
- [x] `editorconfig-checker` clean on all touched files
- [x] super-linter (slim) green on the PR
- [x] Root README renders correctly on the PR's Files view
- [x] `docs/self-hosting.md` renders correctly on the PR's Files view