### PR TITLE
ci(release): flip to alpha-prerelease branch + main-stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - main # stable releases (v2.0.0, v2.0.1, …)
+      - alpha # prereleases (v2.1.0-alpha.N, etc.) — see CLAUDE.md
 
 jobs:
   release:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": [{ "name": "main", "prerelease": "alpha" }],
+  "branches": ["main", { "name": "alpha", "prerelease": true }],
   "plugins": [
     [
       "@semantic-release/commit-analyzer",
@@ -38,7 +38,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "node scripts/bump-versions.mjs ${nextRelease.version}",
-        "publishCmd": "pnpm -r --filter='./packages/*' --filter='!@theholocron/cli-utils' publish --access public --no-git-checks --tag alpha"
+        "publishCmd": "pnpm -r --filter='./packages/*' --filter='!@theholocron/cli-utils' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}"
       }
     ],
     [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,10 +96,18 @@ Code into every conversation in this repo.
 
 ## Releases (automated)
 
-- **semantic-release on push to main.** Walks Conventional Commits
-  since the last tag, computes the next version, bumps all 7 public
-  packages in lockstep via `scripts/bump-versions.mjs`, publishes
-  via OIDC, creates a GitHub Release, commits `CHANGELOG.md`.
+- **Two release branches.** `main` is the **stable-release branch**
+  (publishes to npm's `latest` dist-tag); `alpha` is the
+  **prerelease branch** (publishes to the `alpha` dist-tag). All v2
+  alpha work happens on `alpha`; merge `alpha → main` only when
+  cutting a stable release. A `feat`/`fix`/`refactor`/`perf` landing
+  directly on main will publish stable, so keep those PRs targeted at
+  `alpha`. Docs, chore, ci, test are safe on either.
+- **semantic-release on push to main or alpha.** Walks Conventional
+  Commits since the last tag on the branch's channel, computes the
+  next version, bumps all 7 public packages in lockstep via
+  `scripts/bump-versions.mjs`, publishes via OIDC, creates a GitHub
+  Release, commits `CHANGELOG.md`.
 - **npm Trusted Publishing.** OIDC token exchange at publish time —
   no `NPM_TOKEN` secret anywhere. Each package has a Trusted
   Publisher registered on npmjs.com (Publisher: GitHub Actions,


### PR DESCRIPTION
## Summary

semantic-release has been erroring on every push to main since PR #84 — [see the failed run for the docs merge](https://github.com/theholocron/holocron/actions/runs/28544138344/job/84616849876). Root cause: \`.releaserc.json\` had \`main\` declared as a **prerelease** branch with no companion release branch, so the branches validator rejected the config *before* any commit analysis. That's why \`v2.0.0-alpha.0\` was published manually — the automated pipeline never ran.

Flip to the conventional two-branch shape:

- **\`main\`** = stable-release branch → publishes to npm's \`latest\` dist-tag
- **\`alpha\`** = prerelease branch → publishes to \`alpha\` dist-tag

Also trigger \`release.yml\` on pushes to either branch, and fix the exec-plugin \`publishCmd\` so \`--tag\` derives from \`nextRelease.channel\` instead of being hardcoded to \`alpha\` — otherwise a future stable release from main would still publish to the \`alpha\` dist-tag.

### Workflow implication (added to CLAUDE.md)

All v2 alpha work must target the **\`alpha\`** branch. Docs / chore / ci / test are safe on main since they don't match \`releaseRules\`, but any \`feat\` / \`fix\` / \`refactor\` / \`perf\` landing directly on main will publish stable v2.0.0 prematurely.

After this merges, I'll create the \`alpha\` branch from post-merge \`main\` and push it so subsequent alpha work has somewhere to go.

## Test plan

- [x] JSON valid (\`jq . .releaserc.json\`)
- [ ] super-linter (slim) green
- [ ] After merge: release.yml on main runs to completion (docs commit → no release, but exits 0 instead of erroring on branches validation)
- [ ] Push \`alpha\` branch → release.yml on alpha runs, either bumps to \`v2.0.0-alpha.1\` (if the ci commits count) or exits cleanly with "no release"