### PR TITLE
ci(release): drop setup-node registry-url so pnpm OIDC works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
           cache: pnpm
+          # NOTE: intentionally NO `registry-url` here. When set, setup-node
+          # writes `.npmrc` with `_authToken=XXXXX-XXXXX-XXXXX-XXXXX` (a
+          # literal placeholder, not GitHub's `***` redaction). pnpm publish
+          # then uses that placeholder token instead of doing the OIDC
+          # exchange, and npm returns 404. Without registry-url, no `.npmrc`
+          # is written and pnpm 10.15+ handles Trusted Publishing via its
+          # own OIDC token request (id-token: write permission below).
+          # See https://github.com/actions/setup-node/blob/main/src/authutil.ts
 
       - name: Install
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

Follow-up recovery to #89. After that PR merged, the release pipeline reached the publish step for the first time — and hit \`npm error 404 Not Found - PUT https://registry.npmjs.org/@theholocron/cli\` on every package. Root cause: **setup-node writes a placeholder auth token to \`.npmrc\` that pnpm publish then uses instead of doing the OIDC exchange**.

### What was happening

\`actions/setup-node@v6\` with \`registry-url: 'https://registry.npmjs.org'\` writes:

\`\`\`ini
registry=https://registry.npmjs.org/
always-auth=false
//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}
\`\`\`

When no \`NPM_TOKEN\` secret is provided (the whole point of Trusted Publishing), setup-node's [\`authutil.ts\`](https://github.com/actions/setup-node/blob/main/src/authutil.ts) still exports \`NODE_AUTH_TOKEN\` — set to the literal placeholder \`XXXXX-XXXXX-XXXXX-XXXXX\`. pnpm publish then submits that bogus token to npm instead of doing OIDC, and npm returns 404 (auth failure disguised as not-found).

### Fix

Drop \`registry-url\` from setup-node. No \`.npmrc\` gets written, no placeholder token exists to confuse pnpm. pnpm 10.15+ (this repo pins 10.33.0 via packageManager) has native OIDC support for Trusted Publishing — it detects the GitHub Actions environment, requests an id-token via the workflow's \`id-token: write\` permission, exchanges it with npm, and publishes with provenance attestations attached automatically.

This is the fix that was implied — but not actually landed — by [f300cf3](https://github.com/theholocron/holocron/commit/f300cf3) \"switch to npm Trusted Publishing (OIDC, no stored token)\". Trusted Publisher configs on npmjs.com were correct all along; the workflow just wasn't letting pnpm do its OIDC dance.

### Related cleanup (already done outside this PR)

- Force-rewound \`main\` and \`alpha\` back to \`5891a41\` — the failed runs had auto-committed CHANGELOG bumps for a bogus \`1.1.0\` / \`1.1.0-alpha.1\` (semantic-release didn't know about the manually-tagged \`v2.0.0-alpha.0\`, so it started from \`v1.0.0\`).
- Deleted the stray \`v1.1.0\` and \`v1.1.0-alpha.1\` tags + their notes refs.
- Added a \`refs/notes/semantic-release-v2.0.0-alpha.0\` note with \`{\"channels\":[\"alpha\"]}\` so semantic-release recognizes v2.0.0-alpha.0 as the last alpha release next time it runs.

## Test plan

- [ ] super-linter green
- [ ] After merge: push a releasable commit to \`alpha\` (a real fix or feat, or the next real change). release.yml should:
  - [ ] Recognize \`v2.0.0-alpha.0\` as the last alpha release
  - [ ] Compute a next version (\`v2.0.0-alpha.1\` or similar)
  - [ ] pnpm publish succeeds via OIDC → new alpha version on npm
  - [ ] semantic-release commits back CHANGELOG + package.json bumps
  - [ ] GitHub Release created for the new version
- [ ] If OIDC still fails, the fallback is to keep \`registry-url\` and add a post-setup step that clears \`_authToken\` from \`.npmrc\`