### PR TITLE
ci(release): pause push trigger + preserve OIDC fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,33 @@
 name: Release
 
+# PAUSED (push trigger disabled). Trigger manually via workflow_dispatch
+# until Trusted Publishing (OIDC) is verified end-to-end.
+#
+# Every previous push-triggered run has failed at pnpm publish AFTER
+# @semantic-release/git had already auto-committed a CHANGELOG bump +
+# tagged the next version, leaving main / alpha polluted with runaway
+# state and forcing multiple rewinds.
+#
+# Re-enable the push trigger via a follow-up PR once a dry-run dispatch
+# confirms:
+#   1. semantic-release recognizes v2.0.0-alpha.0 as the last alpha
+#      release (via refs/notes/semantic-release-v2.0.0-alpha.0)
+#   2. pnpm publish successfully exchanges an OIDC id-token with npm
+#      instead of falling back to `npm adduser` prompt (ENEEDAUTH)
 on:
-  push:
-    branches:
-      - main # stable releases (v2.0.0, v2.0.1, …)
-      - alpha # prereleases (v2.1.0-alpha.N, etc.) — see CLAUDE.md
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: |
+          Run semantic-release --dry-run. True = analyze + preview only, no
+          git writes, no publish. Set to false ONLY once dry-run reports
+          clean.
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
 
 jobs:
   release:
@@ -34,8 +57,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
           cache: pnpm
+          # NOTE: intentionally NO `registry-url` here. When set, setup-node
+          # writes `.npmrc` with `_authToken=XXXXX-XXXXX-XXXXX-XXXXX` (a
+          # literal placeholder, not GitHub's `***` redaction). pnpm publish
+          # then uses that placeholder token instead of doing the OIDC
+          # exchange, and npm returns 404. Without registry-url, no `.npmrc`
+          # is written and pnpm 10.15+ handles Trusted Publishing via its
+          # own OIDC token request (id-token: write permission above).
+          # See https://github.com/actions/setup-node/blob/main/src/authutil.ts
 
       - name: Install
         run: pnpm install --frozen-lockfile
@@ -54,4 +84,9 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm exec semantic-release
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            pnpm exec semantic-release --dry-run
+          else
+            pnpm exec semantic-release
+          fi


### PR DESCRIPTION
## Summary

Stop the bleeding. Every push-trigger run of release.yml since #89 has hit the same failure: \`@semantic-release/git\` auto-commits a CHANGELOG bump and tags the next version, THEN pnpm publish fails, leaving main + alpha polluted. Each attempt requires another force-push rewind. Two runaway cycles have accumulated (both retagged \`v1.1.0\` and \`v1.1.0-alpha.1\` multiple times).

### Changes

- **Replace \`on: push\` with \`on: workflow_dispatch\`** — gated by a \`dry_run\` input that defaults to \`'true'\`. Dispatched runs in dry-run mode analyze commits + preview the next version + preview the release notes, but write nothing to git and publish nothing to npm. Safe iteration on OIDC without polluting branches.
- **Re-apply the OIDC fix from #90** (drop \`registry-url\` from setup-node). That fix landed cleanly in #90's diff but was collateral-damaged by the runaway auto-commits parented on it, so it needs re-applying as part of the rewind.

### Merging this PR does not trigger release.yml

GitHub reads workflow trigger definitions from the workflow file at the merge SHA. This PR's release.yml has no push trigger, so the merge push doesn't fire it.

### Path back to auto-publish

1. Merge this PR.
2. From a fresh clone of main, run \`gh workflow run Release --ref alpha -f dry_run=true\` (dispatch on alpha). Confirm:
   - semantic-release recognizes \`v2.0.0-alpha.0\` as the last alpha release (via the \`refs/notes/semantic-release-v2.0.0-alpha.0\` git note added during cleanup)
   - computed next version is \`v2.0.0-alpha.1\` (or similar sensible bump)
   - the log shows an OIDC id-token exchange (or at least: no ENEEDAUTH / no 404)
3. If dry-run looks right, run \`gh workflow run Release --ref alpha -f dry_run=false\` — actual publish, one alpha version to npm.
4. If pnpm still doesn't do OIDC, follow-up PR: install \`npm@latest\` (11.5.1+) globally in the workflow before publish, since pnpm may delegate the actual PUT to \`npm publish\` under the hood.
5. Once auto-publish is proven, another follow-up PR re-adds the push trigger.

### Cleanup already done outside this PR

- \`origin/main\` and \`origin/alpha\` force-rewound to \`5891a41\` (drops \`e3822df\`, \`83609a3\`, \`a2a261a\`, \`d340f71\`, etc.)
- \`v1.1.0\` and \`v1.1.0-alpha.1\` tags deleted (twice each; they kept coming back with each failed run)
- Stale \`refs/notes/semantic-release-v1.1.0*\` refs deleted
- \`refs/notes/semantic-release-v2.0.0-alpha.0\` note added — tells semantic-release that alpha channel is currently at v2.0.0-alpha.0

## Test plan

- [ ] super-linter green on this PR
- [ ] After merge, no release.yml run in the Actions tab (push trigger removed)
- [ ] \`gh workflow run Release --ref alpha -f dry_run=true\` shows a sensible next version
- [ ] Follow-up PR re-enables push once dry-run + live dispatch both work