### PR TITLE
ci(release): install npm 11+ so pnpm's publish delegate does OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,15 @@ jobs:
           # own OIDC token request (id-token: write permission above).
           # See https://github.com/actions/setup-node/blob/main/src/authutil.ts
 
+      - name: Ensure npm supports OIDC Trusted Publishing
+        # Node 22 LTS ships with npm 10.x, which does NOT do the OIDC
+        # token exchange with npm's Trusted Publisher endpoint. pnpm's
+        # publish command delegates the actual PUT to npm under the
+        # hood, so `pnpm publish` inherits npm's OIDC support (or lack
+        # thereof). npm 11.5.1+ has native OIDC. Upgrade globally so
+        # `pnpm publish` picks it up.
+        run: npm install -g npm@latest
+
       - name: Install
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

Follow-up to the release-pipeline recovery. After the paused-workflow + git-note fixes, live dispatch (\`dry_run=false\`) produced the correct next version (\`v2.0.0-alpha.1\`) — proving the git-note fix works — but pnpm publish still failed with:

\`\`\`
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
\`\`\`

No OIDC-related output from pnpm 10.33. Root cause: **pnpm's publish delegates the actual PUT to npm's CLI**, and Node 22 LTS ships with npm 10.x which does NOT do the OIDC token exchange with npm's Trusted Publisher endpoint. **npm 11.5.1+ has native OIDC.**

pnpm 10.15's changelog claims automatic OIDC support, but in practice the OIDC dance happens inside npm's CLI when pnpm shells out to it. Installing npm@latest is the missing piece.

### Change

New workflow step between \`Setup Node\` and \`Install\`:

\`\`\`yaml
- name: Ensure npm supports OIDC Trusted Publishing
  run: npm install -g npm@latest
\`\`\`

Everything else unchanged. Workflow trigger is still \`workflow_dispatch\` only (paused).

## Test plan

- [ ] super-linter green on this PR
- [ ] After merge, dispatch: \`gh workflow run Release --ref alpha -f dry_run=false\`
- [ ] Expect: semantic-release computes \`v2.0.0-alpha.1\` → pnpm publish delegates to npm 11+ → OIDC exchange succeeds → 7 packages publish to npm → auto-commit + tag land on alpha
- [ ] Verify \`npm view @theholocron/cli@alpha version\` returns \`2.0.0-alpha.1\`
- [ ] If OIDC still fails: next debug is likely \`--provenance\` flag or explicit \`npm publish\` instead of pnpm's wrapper

## Recovery notes (already done outside this PR)

- Rewound alpha back to \`bc79aae\` after the last failed live run auto-committed
- Deleted \`v2.0.0-alpha.1\` tag and its notes ref (semantic-release created both before publish crashed)