### PR TITLE
ci(release): re-enable push trigger now that OIDC works end-to-end

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,24 @@
 name: Release
 
-# PAUSED (push trigger disabled). Trigger manually via workflow_dispatch
-# until Trusted Publishing (OIDC) is verified end-to-end.
+# main  = stable releases (v2.0.0, v2.0.1, …) → npm `latest` dist-tag
+# alpha = prereleases (v2.0.0-alpha.N)       → npm `alpha` dist-tag
 #
-# Every previous push-triggered run has failed at pnpm publish AFTER
-# @semantic-release/git had already auto-committed a CHANGELOG bump +
-# tagged the next version, leaving main / alpha polluted with runaway
-# state and forcing multiple rewinds.
-#
-# Re-enable the push trigger via a follow-up PR once a dry-run dispatch
-# confirms:
-#   1. semantic-release recognizes v2.0.0-alpha.0 as the last alpha
-#      release (via refs/notes/semantic-release-v2.0.0-alpha.0)
-#   2. pnpm publish successfully exchanges an OIDC id-token with npm
-#      instead of falling back to `npm adduser` prompt (ENEEDAUTH)
+# workflow_dispatch is kept alongside push so alpha/stable releases can
+# also be triggered by hand for recovery / re-runs. The `dry_run` input
+# defaults to true — safe for iterating on release-config changes
+# without accidentally publishing.
 on:
+  push:
+    branches:
+      - main
+      - alpha
   workflow_dispatch:
     inputs:
       dry_run:
         description: |
           Run semantic-release --dry-run. True = analyze + preview only, no
-          git writes, no publish. Set to false ONLY once dry-run reports
-          clean.
+          git writes, no publish. Only meaningful for workflow_dispatch runs;
+          push-triggered runs always run fully.
         required: false
         default: 'true'
         type: choice


### PR DESCRIPTION
## Summary

Trusted Publishing verified end-to-end (see run [28553633375](https://github.com/theholocron/holocron/actions/runs/28553633375) — published v2.0.0-alpha.1 across all 7 packages via OIDC with provenance attestations). Restoring push triggers on \`main\` and \`alpha\`.

Full pipeline now works:

1. semantic-release recognizes \`v2.0.0-alpha.0\` as the last alpha release (via the git note on \`d9211ad\` in \`refs/notes/semantic-release\`)
2. Correct next version computed (\`v2.0.0-alpha.1\`) using tag + commits-since analysis
3. pnpm publish delegates to npm 11+ (installed in a workflow step), which does the OIDC token exchange with npm's Trusted Publisher endpoint — no \`NPM_TOKEN\` needed
4. Provenance attestations attach automatically

### Changes

- \`on: push\` restored with \`main\` and \`alpha\` branches
- \`workflow_dispatch\` kept alongside for recovery / re-runs
- \`dry_run\` input still defaults to \`true\` so hand-dispatched runs don't accidentally publish while iterating on config
- The existing \`if [ \"\${{ inputs.dry_run }}\" = \"true\" ]; then ...\` block handles both: push-triggered runs have empty \`inputs.dry_run\`, so the condition is false and the full run executes as expected

### Workflow going forward (per CLAUDE.md)

- All \`feat\` / \`fix\` / \`refactor\` / \`perf\` PRs → target \`alpha\` branch → auto-publish next alpha version
- Merge \`alpha → main\` only when cutting stable v2.0.0
- Docs / chore / ci / test are safe on either branch (don't match \`releaseRules\`)

## Test plan

- [ ] super-linter green
- [ ] Merge PR: push to main triggers release.yml. Expected result: no releasable commit types in this PR (ci only), so semantic-release runs, prints "no release", exits 0
- [ ] Next \`feat\` or \`fix\` on \`alpha\` should auto-publish \`v2.0.0-alpha.2\`