### PR TITLE
feat(cli): keyring-backed bootstrap credentials + `holocron auth`

### DIFF
--- a/.notes/tech-auth-bootstrap.spec.md
+++ b/.notes/tech-auth-bootstrap.spec.md
@@ -1,0 +1,227 @@
+---
+status: proposed # draft → proposed (issue filed) → approved (milestone attached) → archived
+issue:
+blocked-by: []
+---
+
+<!-- editorconfig-checker-disable-file -->
+
+# Bootstrap credentials — keyring-backed token store
+
+> **Decision.** Every holocron plugin's bootstrap credential
+> (the token needed to talk to the vendor's API before anything else
+> can happen) has a first-class home in the OS keyring, managed by
+> `holocron auth <provider>`. Operators never store tokens in env
+> vars, dotfiles, or shell profiles unless they explicitly want to
+> (CI, per-command overrides). `--token` and env-var precedence
+> remain; the keyring is a **new fourth-precedence layer** the
+> plugin consults after them.
+
+## Context
+
+A vault plugin exists to hold secrets — but the plugin itself needs
+a credential to reach its vendor, and that credential can't live in
+the vault it's authenticating against. Chicken-and-egg.
+
+Prior state (v1 → v2 alpha): 1Password shells out to `op`, which
+handles its own credential lifecycle via the desktop app + biometric
+prompt. Every other plugin resolves its token from env vars, which
+pushes the "where do I store this?" question back onto the operator
+— typically a `.env.local` file, a shell profile export, or the
+same 1Password vault we're deprecating (which reintroduces the
+circular dependency).
+
+Doppler-as-vault surfaces the tension explicitly:
+
+- Doppler's own CLI (`doppler login`) stores the token in the OS
+  keyring under service `doppler-cli`. `.doppler.yaml` contains
+  only a keyring **reference** (`secret-<id>`), not the token
+  itself.
+- Reading Doppler's yaml file gives us the reference but not the
+  bearer. Reading Doppler's keyring entries directly couples us to
+  their undocumented service name + key format.
+- Shelling out to `doppler configure get token --plain` works but
+  reintroduces the CLI-transport pattern we're moving away from
+  (even bounded to auth init, it's still a shell-out).
+
+Rather than solve this per-plugin, we make **holocron owns its own
+bootstrap-credential store**. Every plugin gets the same auth
+precedence layer, every operator gets the same UX, and no plugin
+ever has to know about any other vendor's CLI or storage format.
+
+## Design
+
+### Auth precedence (every plugin)
+
+```
+1. --token          CLI flag (per-command override)
+2. HOLOCRON_<X>     holocron-namespaced env var
+3. <vendor>-native  vendor's own env var (DOPPLER_TOKEN, etc.)
+4. keyring          `com.theholocron.cli` service, key = <provider>
+5. AuthError        with a vendor-specific hint
+```
+
+Steps 1–3 already exist. Step 4 is new. Step 5 gets an upgraded
+message: when no token is found, the error names all four options
++ a vendor-specific hint pointing at the fastest bootstrap path
+(e.g., Doppler: `doppler configure get token --plain | pbcopy;
+holocron auth set doppler <paste>`).
+
+### Keyring service naming
+
+- **Service**: `com.theholocron.cli` (reverse-DNS, matches macOS
+  Keychain convention; portable across platforms via the underlying
+  library).
+- **Account/key**: the provider slug — `doppler`, `infisical`,
+  `github`, `vercel`, etc. One entry per provider. No project or
+  environment scoping at this layer; per-project vault selection
+  happens in `holocron.config.json`, not the keyring.
+
+### Keyring module — `packages/cli/src/keyring.ts`
+
+Thin wrapper over `@napi-rs/keyring` (Rust-based, N-API prebuilt
+binaries, no node-gyp; actively maintained; `keytar` is archived).
+
+```ts
+export async function setToken(provider: string, token: string): Promise<void>;
+export async function getToken(provider: string): Promise<string | null>;
+export async function deleteToken(provider: string): Promise<void>;
+export async function listProviders(): Promise<string[]>;
+```
+
+`listProviders` iterates provider slugs the CLI knows about (from
+loaded config or a static registry) and checks each for a stored
+entry. Keyring APIs typically don't expose "list all keys under a
+service" — we probe.
+
+### `verifyToken` plugin export convention
+
+Every plugin exports a top-level `verifyToken` alongside
+`createPlugin` (mirrors the existing `parseWebhook` pattern for auth
+plugins).
+
+```ts
+export interface VerifyTokenResult {
+    ok: true;
+    /** Human-readable identifier — "workplace: acme" / "user: cnewton@x" */
+    subject: string;
+}
+
+export interface VerifyTokenFailure {
+    ok: false;
+    /** Reason the token was rejected. Surfaces to `holocron auth set` output. */
+    message: string;
+}
+
+export async function verifyToken(token: string): Promise<VerifyTokenResult | VerifyTokenFailure>;
+```
+
+Plugin-level export (not a capability method) so the auth command
+can call it **without** loading the full plugin — plugin
+initialization typically requires an already-resolved token, which
+is exactly what we don't have yet.
+
+### `holocron auth <subcommand>`
+
+```
+holocron auth set <provider> [token]
+    Verify + store a token in the keyring.
+    Token resolution: positional arg → HOLOCRON_<X>_TOKEN → vendor-native.
+    On verify failure, prints a hint (Doppler:
+    "run: doppler configure get token --plain").
+
+holocron auth unset <provider>
+    Delete the stored keyring entry.
+
+holocron auth check <provider>
+    Report stored (yes/no) + valid (yes/no via re-verifyToken).
+
+holocron auth list
+    Table of every known provider + storage/validity status.
+```
+
+All four subcommands soft-skip failures per the standard
+orchestrator pattern (`try/catch`, continue, summary counts).
+
+## Plugin integration
+
+Every existing plugin's `auth.ts` gains one line:
+
+```ts
+import { getToken as getKeyringToken } from "@theholocron/cli";
+
+// after existing --token / HOLOCRON_<X> / <native> checks:
+const keyringToken = await getKeyringToken(providerSlug);
+if (keyringToken) return keyringToken;
+```
+
+Every existing plugin's `index.ts` gains a top-level export:
+
+```ts
+export { verifyToken } from "./verify-token.js";
+```
+
+New plugins get both baked in via the `holocron-plugin` skill
+template (and, later, `holocron plugin create` — see #77).
+
+## CI story
+
+CI never touches the keyring — no login browser flow, no OS
+keychain available in containers. CI runs use step 2 or step 3 of
+the auth precedence:
+
+- `HOLOCRON_DOPPLER_TOKEN` (or vendor-native equivalent) exposed as
+  a GitHub Actions secret.
+- `holocron auth set` is a **laptop** command; it's not invoked in
+  CI.
+
+`@napi-rs/keyring` gracefully returns platform-unsupported errors
+in headless environments; the keyring lookup at precedence step 4
+simply returns `null` when unsupported. No CI code path breaks.
+
+## Migration strategy
+
+For this repo's own vault today:
+
+1. Ship the keyring foundation + Doppler plugin in one PR (#8).
+2. Update `holocron-plugin-1password`'s `auth.ts` to consult the
+   keyring in the same PR — keeps 1P working while we migrate.
+   1P vaults typically don't need this (op handles its own auth)
+   but the consistency is worth the ~10 lines.
+3. Cut over `holocron.config.json` vault from 1password to doppler
+   (task #10).
+4. Deprecate `holocron-plugin-1password` (task #11).
+
+## What we're deliberately NOT building
+
+- **OAuth device flows** per vendor. Real work, requires the vendor
+  to expose OAuth to third-party CLIs, and gets us to the same
+  end state (token in keyring). If a vendor genuinely doesn't
+  offer a Personal Token, we build OAuth for that vendor.
+- **Cross-project vault-of-vaults**. `com.theholocron.cli` is a
+  single service scope. If someone runs multiple holocron projects
+  on the same machine and wants different Doppler tokens per
+  project, they use `--token` or env vars per-project. Not adding
+  project-scoped keyring keys until someone asks.
+- **Encrypted local file fallback** for platforms without keyring.
+  `@napi-rs/keyring` supports macOS Keychain, Linux Secret Service,
+  Windows Credential Manager. Bare Linux servers without
+  Secret Service (some CI images) fall through to env vars —
+  which is what CI uses anyway. No third fallback layer needed.
+
+## Open questions
+
+1. **Auto-detect `doppler configure get token --plain` in the hint
+   text?** If the `doppler` binary is on PATH, the error hint could
+   even be a copy-pasteable one-liner including the actual token
+   fetched. Feels magic and could surprise; leaning toward
+   printing the command as text and letting the operator run it.
+2. **`holocron auth list` — display only providers with stored
+   tokens, or every provider known to the loaded config?** The
+   latter is more informative (shows what's missing) but requires
+   knowing "every provider" — either from loaded config or a
+   static registry. Leaning: from loaded config.
+3. **Do we need `holocron auth rotate <provider>`?** i.e., "here's
+   a new token, replace the old one after verifying." Could just
+   be `holocron auth set <provider> <new-token>` which already
+   overwrites. Skip the rotate subcommand until someone asks.

--- a/.notes/tech-vault-choice.spec.md
+++ b/.notes/tech-vault-choice.spec.md
@@ -1,0 +1,207 @@
+---
+status: proposed # draft → proposed (issue filed) → approved (milestone attached) → archived
+issue:
+blocked-by: []
+---
+
+<!-- editorconfig-checker-disable-file -->
+
+# Vault provider — swap 1Password for Doppler + Infisical (both cloud)
+
+> **Decision.** Build **two** vault plugins:
+> `@theholocron/holocron-plugin-doppler` **first**
+> (hand-written, informs #77 template refinement), then
+> `@theholocron/holocron-plugin-infisical` **using
+> `holocron plugin create` once #77 Phase 1 ships** — proves the
+> new CLI works via real usage. Both target the vendors' **free
+> cloud tiers**; **Infisical self-host is rejected** (numbers in
+> the Options section). Downstream users flip between the two by
+> changing one line in `holocron.config.json` — exactly the swap
+> the capability/provider model was built for.
+
+## Context
+
+- The `vault` capability is the only REQUIRED capability, so this
+  choice touches every downstream flow: `holocron setup`,
+  `holocron secrets sync`, `holocron secret set`, `doctor`.
+- Today `holocron-plugin-1password` is the only CLI-transport
+  plugin in the repo. See `packages/holocron-plugin-1password/src/`.
+  It shells out to `op` with `stdio: ['inherit', ...]` so
+  biometric prompts work locally. In CI the flow degrades to
+  service-account token via env.
+- Swapping vault providers is exactly the swap the
+  capability/provider model was built for — write a new plugin
+  implementing `vault`, flip it in `holocron.config.json`, done.
+  Every other capability (source/ci/secrets/deployment/etc.) keeps
+  working unchanged.
+
+## Requirements
+
+Ranked by what actually matters for this project:
+
+1. **REST-first API.** No desktop-app dependency, no biometric-TTY
+   dance. Should work identically on a laptop and in CI. Removing
+   the only CLI-transport plugin means every plugin is REST, which
+   simplifies `holocron plugin create` templates (see #77 Phase 1).
+2. **Secret grouping** — some notion of project / env / namespace so
+   `secrets sync` can pull "all secrets for `holocron-prod`" in one
+   call rather than N round-trips.
+3. **Free personal tier or open-source.** This is a personal OSS
+   project, not a business.
+4. **Machine tokens** with narrow scope for CI use.
+5. **Existing sync integrations to GitHub / Vercel** are a bonus
+   but NOT required — the whole point of holocron is that our own
+   `secrets sync` flow handles that.
+6. **Webhooks / audit log** — nice-to-have, not required.
+
+## Options
+
+### Doppler (current lean)
+
+- **API**: REST, well-documented, project/config model matches what
+  we need.
+- **Pricing**: free "Developer" tier covers personal use — 5 users,
+  unlimited projects, unlimited secrets.
+- **Auth**: service tokens per project/config, easy to scope for CI.
+- **Downsides**: SaaS-only (no self-host). Company acquisition risk
+  (personal-tier features could get pulled behind a paywall).
+- **Plugin shape**: standard REST plugin. Auth precedence
+  `--token → HOLOCRON_DOPPLER_TOKEN → DOPPLER_TOKEN`. Base URL
+  `https://api.doppler.com/v3`.
+
+### Infisical cloud (also chosen — second plugin)
+
+- **API**: REST, open-source, generous free hosted tier.
+- **Auth**: machine identities with granular scopes.
+- **Plugin shape**: standard REST plugin. Same auth precedence
+  pattern. Base URL configurable so cloud and (theoretical future)
+  self-host use the same plugin binary.
+- **Why also build it**: gives the operator a real choice via
+  `holocron.config.json`. Also exercises `holocron plugin create`
+  end-to-end — building the second vault plugin with the new CLI
+  is the acceptance test for #77 Phase 1.
+
+### Infisical self-host (rejected)
+
+Numbers surfaced by fetching their current self-host docs:
+
+- **Containers**: 3 (backend + Postgres + Redis).
+- **Minimum specs**: 2 CPU / 4 GB RAM.
+- **Setup time**: 5–10 min local, +30–60 min for a real reachable
+  deploy with TLS.
+- **Ongoing cost**: ~$10–15/mo on a VPS (Fly / Railway / DO), or a
+  homelab box with an inbound tunnel so CI can reach it.
+- **Ongoing maintenance**: postgres backups, container upgrades,
+  cert renewal — all become the operator's problem. A broken
+  migration mid-upgrade blocks every downstream flow that depends
+  on `vault`.
+
+For a personal OSS project, paying $120–180/yr and adopting a
+database-you-babysit to avoid a lock-in risk that (a) hasn't
+materialized and (b) is escapable in under an hour via the
+Migration Path section is a bad trade. If Doppler ever squeezes
+its free tier, we already have the Infisical cloud plugin
+built — flip config, done. If Infisical cloud *also* goes bad,
+that's the moment to spin up self-host — not now.
+
+### sops + age (dark horse)
+
+- **API**: none — it's a file format. Encrypted `.env`-style files
+  committed to the repo, decrypted at read time with an `age` key.
+- **Pricing**: free forever, no SaaS, no infra.
+- **Auth**: file-based key. Backup via password manager / hardware
+  token.
+- **Downsides**: no central rotation, no audit log, key management
+  is entirely on the operator. Secrets-sync becomes "read encrypted
+  file → push to GitHub/Vercel," which is fine but different from
+  the API-fetch pattern the other plugins use.
+- **Plugin shape**: unusual — no `rest.ts`; reads local file,
+  shells out to `sops` binary (which is another CLI-transport
+  plugin, ironic given the goal of ditching that pattern).
+- **Verdict**: rejected for now. Solves storage but not the
+  laptop-and-CI-symmetric-access problem cleanly.
+
+### Bitwarden Secrets Manager
+
+- **API**: REST, separate product from Bitwarden Password Manager.
+- **Pricing**: free personal tier exists but is limited.
+- **Auth**: machine access tokens.
+- **Downsides**: newer product, smaller ecosystem, fewer
+  integrations. Docs less polished than Doppler / Infisical.
+- **Verdict**: not compelling relative to Doppler / Infisical
+  unless we're already invested in the Bitwarden ecosystem.
+
+### 1Password (status quo)
+
+- Works today. Fine for personal use. But: CLI-transport, biometric
+  TTY, desktop-app dependency. The `gh` tool talking to 1Password
+  for auth is exactly the friction that motivated this question.
+- **Verdict**: keep working, plan to migrate — but not urgent.
+
+## Migration path
+
+Regardless of which we pick:
+
+1. Build `@theholocron/holocron-plugin-doppler` (or `-infisical`) via
+   `holocron plugin create` (once #77 Phase 1 ships).
+2. Populate the target vault by dumping 1Password → pushing to new
+   vault. One-time script, throw away after.
+3. Update `holocron.config.json` — flip `vault` from `1password` to
+   the new plugin.
+4. Verify with `holocron doctor` + a full `secrets sync` dry-run.
+5. Delete the 1Password plugin package + trusted publisher entry.
+
+The migration is intentionally reversible — the old plugin package
+stays git-available, and secrets are dumped before the cutover.
+
+## Roadmap
+
+Sequenced deliberately — Doppler is hand-written first so its
+shape informs #77's template refinement; Infisical is built via
+the new CLI so #77 gets a real-world acceptance test.
+
+- **Phase 1**: Build `@theholocron/holocron-plugin-doppler`
+  (hand-written, using the `holocron-plugin` skill for guidance).
+  Standard REST plugin, `vault` capability, auth precedence
+  `--token → HOLOCRON_DOPPLER_TOKEN → DOPPLER_TOKEN`, base URL
+  `https://api.doppler.com/v3`. Ship as its own PR.
+- **Phase 2**: Ship #77 Phase 1 (`holocron plugin create` REST-only).
+  See `.notes/tool-plugin-create.spec.md`.
+- **Phase 3**: Build `@theholocron/holocron-plugin-infisical` via
+  `holocron plugin create infisical Infisical`. Same plugin shape,
+  Infisical's REST API. This doubles as the acceptance test for
+  #77 Phase 1 — if the CLI can't produce a green plugin, the CLI
+  isn't done.
+- **Phase 4**: Migrate this repo's own `holocron.config.json`
+  vault from `1password` to `doppler` (or `infisical` — operator
+  choice). Dump secrets from 1Password, push to chosen vault, flip
+  config, verify with `holocron doctor` + a `secrets sync` dry-run.
+- **Phase 5** (later, no rush): Deprecate
+  `@theholocron/holocron-plugin-1password`. Remove the trusted
+  publisher entry once no downstream depends on it.
+
+## Downstream consequences
+
+Deprecating the 1Password plugin removes the **only**
+CLI-transport plugin in the repo. That means:
+
+- **#78** (CLI-transport sibling skill) — no longer motivated. Can
+  be closed unless a future non-vault CLI-transport vendor shows
+  up.
+- **#76** (per-plugin `transport` option) — loses its primary use
+  case. Still has abstract value (future-proofing) but priority
+  drops. Both are already flagged as "don't build speculatively"
+  in `CLAUDE.md`.
+
+Both consequences are net-positive: fewer speculative abstractions
+in the v2 architecture backlog.
+
+## Open questions
+
+1. **Timing relative to v2.0.0 stable.** Options:
+   - **(a)** Ship Phases 1–4 as part of v2.0.0 stable — clean cutover,
+     v2 launches on Doppler, no 1Password baggage.
+   - **(b)** Ship v2.0.0 stable on 1Password (current alpha state),
+     do Phases 1–4 as v2.1.
+   - Leaning **(a)** if Doppler plugin comes together fast; **(b)**
+     if it drags. Decide after Phase 1's PR lands.

--- a/.notes/tool-plugin-create.spec.md
+++ b/.notes/tool-plugin-create.spec.md
@@ -1,20 +1,20 @@
 ---
-status: draft # draft → proposed (issue filed) → approved (milestone attached) → archived
+status: proposed # draft → proposed (issue filed) → approved (milestone attached) → archived
 issue: 77
-blocked-by: [76, 78]
+blocked-by: []
 ---
 
 <!-- editorconfig-checker-disable-file -->
 
 # `holocron plugin create <slug> <vendor>`
 
-> **Blocked.** Design deferred until #76 (per-plugin `transport`
-> option) and #78 (CLI-transport sibling skill) land. Reason: the
-> template shape depends on how transport variants are declared in
-> `holocron.config.json` and what the CLI-transport plugin structure
-> looks like. Designing REST-only templates first would likely bake
-> in the wrong abstractions and force a rewrite once the other two
-> land. Revisit this spec after both are merged.
+> **Phased.** Phase 1 (REST-only) is unblocked and can ship
+> standalone — REST is the only transport that exists today and the
+> skill already covers this shape. Phase 2 (`--transport cli`
+> variant) is gated on #76 (per-plugin `transport` option in
+> `holocron.config.json`) and #78 (CLI-transport sibling skill);
+> adding the flag later is additive and won't reshape Phase 1's
+> template surface. Phase 3 (`--from-rando`) is a nice-to-have.
 
 ## Decision
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@napi-rs/keyring": "^1.3.0",
     "@theholocron/cli-utils": "workspace:*",
     "yargs": "^18.0.0"
   },

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory keyring simulator — same shape as keyring.test.ts.
+const store = new Map<string, string>();
+
+vi.mock("@napi-rs/keyring", () => {
+	class Entry {
+		private readonly key: string;
+		constructor(service: string, username: string) {
+			this.key = `${service}::${username}`;
+		}
+		setPassword(pw: string): void {
+			store.set(this.key, pw);
+		}
+		getPassword(): string | null {
+			return store.get(this.key) ?? null;
+		}
+		deletePassword(): boolean {
+			return store.delete(this.key);
+		}
+	}
+	function findCredentials(service: string): Array<{ account: string; password: string }> {
+		const prefix = `${service}::`;
+		const out: Array<{ account: string; password: string }> = [];
+		for (const [k, v] of store) {
+			if (k.startsWith(prefix)) out.push({ account: k.slice(prefix.length), password: v });
+		}
+		return out;
+	}
+	return { Entry, findCredentials };
+});
+
+const { runAuthCheck, runAuthList, runAuthSet, runAuthUnset, resolveAuthSetToken } = await import(
+	"../commands/auth.js"
+);
+
+function reset() {
+	store.clear();
+}
+
+function collect(): { print: (l: string) => void; lines: string[] } {
+	const lines: string[] = [];
+	return { lines, print: (l: string) => lines.push(l) };
+}
+
+describe("resolveAuthSetToken", () => {
+	it("prefers positional over env vars", () => {
+		expect(
+			resolveAuthSetToken({
+				provider: "doppler",
+				positional: "pos",
+				env: { HOLOCRON_DOPPLER_TOKEN: "hlc", DOPPLER_TOKEN: "vendor" },
+			})
+		).toBe("pos");
+	});
+	it("prefers HOLOCRON_<X>_TOKEN over vendor-native env", () => {
+		expect(
+			resolveAuthSetToken({
+				provider: "doppler",
+				env: { HOLOCRON_DOPPLER_TOKEN: "hlc", DOPPLER_TOKEN: "vendor" },
+			})
+		).toBe("hlc");
+	});
+	it("falls back to vendor-native env", () => {
+		expect(resolveAuthSetToken({ provider: "doppler", env: { DOPPLER_TOKEN: "vendor" } })).toBe("vendor");
+	});
+	it("returns null when nothing is set", () => {
+		expect(resolveAuthSetToken({ provider: "doppler", env: {} })).toBeNull();
+	});
+});
+
+describe("runAuthSet", () => {
+	beforeEach(reset);
+
+	it("stores + reports subject when verifyToken returns ok", async () => {
+		const { print, lines } = collect();
+		const result = await runAuthSet({
+			provider: "doppler",
+			positional: "dp.pt.abc",
+			env: {},
+			importer: async () => ({
+				verifyToken: async () => ({ ok: true as const, subject: "workplace: acme" }),
+			}),
+			print,
+		});
+		expect(result.status).toBe("ok");
+		expect(lines.join("\n")).toMatch(/stored doppler token \(workplace: acme\)/);
+	});
+
+	it("fails + does NOT store when verifyToken rejects", async () => {
+		const { print, lines } = collect();
+		const result = await runAuthSet({
+			provider: "doppler",
+			positional: "bad",
+			env: {},
+			importer: async () => ({
+				verifyToken: async () => ({ ok: false as const, message: "401 unauthorized" }),
+				AUTH_HINT: "run: doppler configure get token --plain",
+			}),
+			print,
+		});
+		expect(result.status).toBe("fail");
+		expect(lines.join("\n")).toMatch(/token rejected/);
+		expect(lines.join("\n")).toMatch(/doppler configure get token --plain/);
+	});
+
+	it("prints hint + fails when no token supplied", async () => {
+		const { print, lines } = collect();
+		const result = await runAuthSet({
+			provider: "doppler",
+			env: {},
+			importer: async () => ({ AUTH_HINT: "run: doppler configure get token --plain" }),
+			print,
+		});
+		expect(result.status).toBe("fail");
+		expect(lines.join("\n")).toMatch(/no token supplied/);
+		expect(lines.join("\n")).toMatch(/doppler configure get token --plain/);
+	});
+
+	it("stores without verification when the plugin exports no verifyToken", async () => {
+		const { print, lines } = collect();
+		const result = await runAuthSet({
+			provider: "custom",
+			positional: "abc",
+			env: {},
+			importer: async () => ({}),
+			print,
+		});
+		expect(result.status).toBe("ok");
+		expect(lines.join("\n")).toMatch(/no verifyToken/);
+	});
+
+	it("stores even when the plugin package can't be loaded", async () => {
+		const { print, lines } = collect();
+		const result = await runAuthSet({
+			provider: "custom",
+			positional: "abc",
+			env: {},
+			importer: async () => {
+				throw new Error("MODULE_NOT_FOUND");
+			},
+			print,
+		});
+		expect(result.status).toBe("ok");
+		expect(lines.join("\n")).toMatch(/failed to load/);
+	});
+
+	it("reads token from HOLOCRON_<X>_TOKEN when no positional supplied", async () => {
+		const result = await runAuthSet({
+			provider: "doppler",
+			env: { HOLOCRON_DOPPLER_TOKEN: "env.abc" },
+			importer: async () => ({ verifyToken: async () => ({ ok: true as const, subject: "test" }) }),
+			print: () => {},
+		});
+		expect(result.status).toBe("ok");
+	});
+});
+
+describe("runAuthUnset", () => {
+	beforeEach(reset);
+
+	it("removes a stored token", () => {
+		store.set("com.theholocron.cli::doppler", "abc");
+		const { print, lines } = collect();
+		const result = runAuthUnset({ provider: "doppler", print });
+		expect(result.status).toBe("ok");
+		expect(lines.join("\n")).toMatch(/removed doppler/);
+	});
+
+	it("is a no-op skip when nothing was stored", () => {
+		const { print, lines } = collect();
+		const result = runAuthUnset({ provider: "doppler", print });
+		expect(result.status).toBe("skip");
+		expect(lines.join("\n")).toMatch(/no stored token/);
+	});
+});
+
+describe("runAuthCheck", () => {
+	beforeEach(reset);
+
+	it("reports skip when no token is stored", async () => {
+		const { print, lines } = collect();
+		const result = await runAuthCheck({
+			provider: "doppler",
+			importer: async () => ({ verifyToken: async () => ({ ok: true as const, subject: "x" }) }),
+			print,
+		});
+		expect(result.status).toBe("skip");
+		expect(lines.join("\n")).toMatch(/no stored token/);
+	});
+
+	it("reports ok + subject when the stored token verifies", async () => {
+		store.set("com.theholocron.cli::doppler", "dp.pt.abc");
+		const { print, lines } = collect();
+		const result = await runAuthCheck({
+			provider: "doppler",
+			importer: async () => ({ verifyToken: async () => ({ ok: true as const, subject: "workplace: acme" }) }),
+			print,
+		});
+		expect(result.status).toBe("ok");
+		expect(lines.join("\n")).toMatch(/doppler: ok — workplace: acme/);
+	});
+
+	it("reports fail + hint when the stored token is rejected", async () => {
+		store.set("com.theholocron.cli::doppler", "stale");
+		const { print, lines } = collect();
+		const result = await runAuthCheck({
+			provider: "doppler",
+			importer: async () => ({
+				verifyToken: async () => ({ ok: false as const, message: "401 unauthorized" }),
+				AUTH_HINT: "run: doppler configure get token --plain",
+			}),
+			print,
+		});
+		expect(result.status).toBe("fail");
+		expect(lines.join("\n")).toMatch(/rejected/);
+		expect(lines.join("\n")).toMatch(/doppler configure get token/);
+	});
+
+	it("reports ok-unverified when the plugin has no verifyToken", async () => {
+		store.set("com.theholocron.cli::custom", "abc");
+		const { print, lines } = collect();
+		const result = await runAuthCheck({
+			provider: "custom",
+			importer: async () => ({}),
+			print,
+		});
+		expect(result.status).toBe("ok");
+		expect(result.message).toBe("stored, unverified");
+		expect(lines.join("\n")).toMatch(/can't confirm validity/);
+	});
+});
+
+describe("runAuthList", () => {
+	beforeEach(reset);
+
+	it("prints a friendly message when nothing is stored", async () => {
+		const { print, lines } = collect();
+		const result = await runAuthList({ print });
+		expect(result.status).toBe("ok");
+		expect(lines.join("\n")).toMatch(/no stored tokens/);
+	});
+
+	it("lists every stored provider with validity status", async () => {
+		store.set("com.theholocron.cli::doppler", "dp.pt.abc");
+		store.set("com.theholocron.cli::infisical", "inf.stale");
+		const { print, lines } = collect();
+		await runAuthList({
+			print,
+			importer: async (pkg: string) => {
+				if (pkg.includes("doppler"))
+					return { verifyToken: async () => ({ ok: true as const, subject: "workplace: acme" }) };
+				return { verifyToken: async () => ({ ok: false as const, message: "expired" }) };
+			},
+		});
+		const joined = lines.join("\n");
+		expect(joined).toMatch(/✓ doppler — workplace: acme/);
+		expect(joined).toMatch(/✗ infisical — expired/);
+	});
+});

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -32,7 +32,6 @@ vi.mock("@napi-rs/keyring", () => {
 
 const { runAuthCheck, runAuthList, runAuthSet, runAuthUnset, resolveAuthSetToken } =
 	await import("../commands/auth.js");
-);
 
 function reset() {
 	store.clear();

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -30,8 +30,8 @@ vi.mock("@napi-rs/keyring", () => {
 	return { Entry, findCredentials };
 });
 
-const { runAuthCheck, runAuthList, runAuthSet, runAuthUnset, resolveAuthSetToken } = await import(
-	"../commands/auth.js"
+const { runAuthCheck, runAuthList, runAuthSet, runAuthUnset, resolveAuthSetToken } =
+	await import("../commands/auth.js");
 );
 
 function reset() {

--- a/packages/cli/src/__tests__/keyring.test.ts
+++ b/packages/cli/src/__tests__/keyring.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory keyring simulator, wired up as a mock of @napi-rs/keyring.
+// A per-test call to `resetKeyring()` clears it between cases.
+const store = new Map<string, string>();
+let entryThrows = false;
+let findThrows = false;
+
+vi.mock("@napi-rs/keyring", () => {
+	class Entry {
+		private readonly key: string;
+		constructor(service: string, username: string) {
+			if (entryThrows) throw new Error("platform unsupported");
+			this.key = `${service}::${username}`;
+		}
+		setPassword(pw: string): void {
+			if (entryThrows) throw new Error("platform unsupported");
+			store.set(this.key, pw);
+		}
+		getPassword(): string | null {
+			if (entryThrows) throw new Error("platform unsupported");
+			return store.get(this.key) ?? null;
+		}
+		deletePassword(): boolean {
+			if (entryThrows) throw new Error("platform unsupported");
+			return store.delete(this.key);
+		}
+	}
+	function findCredentials(service: string): Array<{ account: string; password: string }> {
+		if (findThrows) throw new Error("platform unsupported");
+		const prefix = `${service}::`;
+		const out: Array<{ account: string; password: string }> = [];
+		for (const [k, v] of store) {
+			if (k.startsWith(prefix)) out.push({ account: k.slice(prefix.length), password: v });
+		}
+		return out;
+	}
+	return { Entry, findCredentials };
+});
+
+// Import AFTER the mock so keyring.ts binds to the mocked module.
+const { setToken, getToken, deleteToken, listStoredProviders } = await import("../keyring.js");
+
+function resetKeyring() {
+	store.clear();
+	entryThrows = false;
+	findThrows = false;
+}
+
+describe("keyring", () => {
+	beforeEach(resetKeyring);
+
+	it("setToken then getToken round-trips the value", () => {
+		expect(setToken("doppler", "dp.pt.abc")).toBe(true);
+		expect(getToken("doppler")).toBe("dp.pt.abc");
+	});
+
+	it("getToken returns null when no entry exists", () => {
+		expect(getToken("doppler")).toBeNull();
+	});
+
+	it("setToken overwrites an existing entry", () => {
+		setToken("doppler", "first");
+		setToken("doppler", "second");
+		expect(getToken("doppler")).toBe("second");
+	});
+
+	it("deleteToken removes the entry and returns true", () => {
+		setToken("doppler", "abc");
+		expect(deleteToken("doppler")).toBe(true);
+		expect(getToken("doppler")).toBeNull();
+	});
+
+	it("deleteToken returns false when nothing was stored", () => {
+		expect(deleteToken("doppler")).toBe(false);
+	});
+
+	it("scopes entries per provider", () => {
+		setToken("doppler", "dp.pt.abc");
+		setToken("infisical", "inf.abc");
+		expect(getToken("doppler")).toBe("dp.pt.abc");
+		expect(getToken("infisical")).toBe("inf.abc");
+	});
+
+	it("listStoredProviders returns every account under the holocron service", () => {
+		setToken("doppler", "a");
+		setToken("infisical", "b");
+		expect(listStoredProviders().sort()).toEqual(["doppler", "infisical"]);
+	});
+
+	it("listStoredProviders returns empty when nothing is stored", () => {
+		expect(listStoredProviders()).toEqual([]);
+	});
+
+	describe("platform-unsupported degrade path", () => {
+		it("setToken returns false when the keyring throws", () => {
+			entryThrows = true;
+			expect(setToken("doppler", "abc")).toBe(false);
+		});
+
+		it("getToken returns null when the keyring throws", () => {
+			entryThrows = true;
+			expect(getToken("doppler")).toBeNull();
+		});
+
+		it("deleteToken returns false when the keyring throws", () => {
+			entryThrows = true;
+			expect(deleteToken("doppler")).toBe(false);
+		});
+
+		it("listStoredProviders returns empty when findCredentials throws", () => {
+			findThrows = true;
+			expect(listStoredProviders()).toEqual([]);
+		});
+	});
+});

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -318,6 +318,69 @@ describe("runSetup", () => {
 		expect(synced).toEqual(["postman", "storybook"]);
 	});
 
+	it("calls vault ensureProject + ensureEnvironment when the provider implements them", async () => {
+		const projectCreated: string[] = [];
+		const envsCreated: Array<[string, string]> = [];
+		const loaded = loadedFrom({
+			project: { name: "my-app" },
+			providers: { vault: "doppler" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-doppler": makePlugin("doppler", {
+				vault: {
+					list: async () => [],
+					ensureProject: async (name: string) => {
+						projectCreated.push(name);
+						return { alreadyExists: false };
+					},
+					ensureEnvironment: async (project: string, name: string) => {
+						envsCreated.push([project, name]);
+						return { alreadyExists: false };
+					},
+				},
+			}),
+		});
+
+		const report = await runSetup({
+			loaded,
+			context: { repoRoot: "/tmp/test" },
+			loader,
+			print: () => {},
+		});
+
+		expect(projectCreated).toEqual(["my-app"]);
+		expect(envsCreated).toEqual([
+			["my-app", "dev"],
+			["my-app", "stg"],
+			["my-app", "prd"],
+		]);
+		const vaultSteps = report.steps.filter((s) => s.capability === "vault");
+		expect(vaultSteps.find((s) => s.step.startsWith("ensureProject"))?.message).toContain("created");
+		expect(vaultSteps.filter((s) => s.step.startsWith("ensureEnvironment"))).toHaveLength(3);
+	});
+
+	it("skips vault ensureProject + ensureEnvironment when the provider omits them (1P-shaped vaults)", async () => {
+		const loaded = loadedFrom({
+			project: { name: "demo" },
+			providers: { vault: "1password" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", {
+				vault: { list: async () => ["ONE"] },
+			}),
+		});
+
+		const report = await runSetup({
+			loaded,
+			context: { repoRoot: "/tmp/test" },
+			loader,
+			print: () => {},
+		});
+
+		expect(report.steps.some((s) => s.step.startsWith("ensureProject"))).toBe(false);
+		expect(report.steps.some((s) => s.step.startsWith("ensureEnvironment"))).toBe(false);
+	});
+
 	it("output includes a header + summary line", async () => {
 		const lines: string[] = [];
 		const loaded = loadedFrom({

--- a/packages/cli/src/capabilities/index.ts
+++ b/packages/cli/src/capabilities/index.ts
@@ -532,6 +532,11 @@ export class WebhookVerificationError extends Error {
 // vault — REQUIRED source-of-truth for secrets
 // ───────────────────────────────────────────────────────────────────────
 
+export interface EnsureResult {
+	/** True when the resource already existed (idempotent no-op). */
+	alreadyExists: boolean;
+}
+
 export interface Vault extends ProviderIdentity {
 	readonly key: "vault";
 
@@ -562,6 +567,21 @@ export interface Vault extends ProviderIdentity {
 	 * destinations (CI secrets, deployment env vars, local .env).
 	 */
 	readEnvironment?(environmentId: string): Promise<Record<string, string>>;
+
+	/**
+	 * Optional — create the top-level project container in the vault
+	 * if it does not exist. Idempotent: `alreadyExists: true` when the
+	 * project was already there. Providers whose data model has no
+	 * project notion (or that gate this behind a paid tier) omit this.
+	 */
+	ensureProject?(name: string): Promise<EnsureResult>;
+
+	/**
+	 * Optional — create a named environment/config inside a project
+	 * (e.g., Doppler config `dev` / `stg` / `prd`). Idempotent.
+	 * Providers whose data model has a single flat namespace omit this.
+	 */
+	ensureEnvironment?(project: string, name: string): Promise<EnsureResult>;
 }
 
 // ───────────────────────────────────────────────────────────────────────

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,6 +3,7 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
+import { runAuthCheck, runAuthList, runAuthSet, runAuthUnset } from "./commands/auth.js";
 import { runDeploy } from "./commands/deploy.js";
 import { runDoctor } from "./commands/doctor.js";
 import { runNpmPublishInitial } from "./commands/npm-publish-initial.js";
@@ -249,6 +250,54 @@ await yargs(hideBin(process.argv))
 			const loaded = await loadConfig(argv.cwd);
 			console.log(JSON.stringify(loaded.resolved, null, 2));
 		}
+	)
+	.command(
+		"auth <subcommand>",
+		"Manage bootstrap credentials in the OS keyring",
+		(y) =>
+			y
+				.command(
+					"set <provider> [token]",
+					"Verify + store a bootstrap token for a provider",
+					(yy) =>
+						yy
+							.positional("provider", { type: "string", demandOption: true })
+							.positional("token", { type: "string" }),
+					async (argv) => {
+						const result = await runAuthSet({
+							provider: argv.provider as string,
+							...(argv.token ? { positional: argv.token as string } : {}),
+						});
+						if (result.status === "fail") process.exitCode = 1;
+					}
+				)
+				.command(
+					"unset <provider>",
+					"Remove a stored bootstrap token",
+					(yy) => yy.positional("provider", { type: "string", demandOption: true }),
+					(argv) => {
+						runAuthUnset({ provider: argv.provider as string });
+					}
+				)
+				.command(
+					"check <provider>",
+					"Re-verify a stored bootstrap token",
+					(yy) => yy.positional("provider", { type: "string", demandOption: true }),
+					async (argv) => {
+						const result = await runAuthCheck({ provider: argv.provider as string });
+						if (result.status === "fail") process.exitCode = 1;
+					}
+				)
+				.command(
+					"list",
+					"List every provider with a stored bootstrap token",
+					() => {},
+					async () => {
+						await runAuthList();
+					}
+				)
+				.demandCommand(1, "Run `holocron auth --help` to see available auth subcommands."),
+		() => {}
 	)
 	.demandCommand(1, "Run `holocron --help` to see available commands.")
 	.strict()

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,0 +1,224 @@
+/**
+ * `holocron auth <subcommand>` — manage bootstrap credentials in the
+ * OS keyring.
+ *
+ * Subcommands:
+ *   auth set <provider> [token]   verify + store
+ *   auth unset <provider>         remove
+ *   auth check <provider>         re-verify a stored token
+ *   auth list                     every provider with a stored entry
+ *
+ * See `.notes/tech-auth-bootstrap.spec.md`.
+ *
+ * Verification lives in each plugin as a top-level `verifyToken(token)`
+ * export. The auth command dynamically imports
+ * `@theholocron/holocron-plugin-<provider>` and calls it. Plugins that
+ * don't export `verifyToken` can still store — with a warning — because
+ * "no verify path" shouldn't block credential storage.
+ */
+
+import { resolvePluginPackage } from "../config.js";
+import { deleteToken, getToken, listStoredProviders, setToken } from "../keyring.js";
+
+// ── Plugin-level export shapes (mirrored on every plugin) ────────────
+
+export interface VerifyTokenSuccess {
+	ok: true;
+	/** "workplace: acme" / "user: cnewton@x" — surfaced in success output. */
+	subject: string;
+}
+
+export interface VerifyTokenFailure {
+	ok: false;
+	/** Reason the token was rejected. Surfaces to the operator. */
+	message: string;
+}
+
+export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
+
+interface AuthPluginModule {
+	verifyToken?: (token: string) => Promise<VerifyTokenResult>;
+	/** One-line hint printed when no token was supplied. */
+	AUTH_HINT?: string;
+}
+
+export type AuthImporter = (packageName: string) => Promise<AuthPluginModule>;
+
+const defaultImporter: AuthImporter = async (pkg) => (await import(pkg)) as AuthPluginModule;
+
+// ── Common types ─────────────────────────────────────────────────────
+
+export type AuthPrint = (line: string) => void;
+
+export interface AuthCommandStatus {
+	status: "ok" | "fail" | "skip";
+	message?: string;
+}
+
+// ── Token resolution ─────────────────────────────────────────────────
+
+/**
+ * Resolve a token from (positional → HOLOCRON_<X> → vendor-native env).
+ * Keyring is NOT consulted here — `auth set` writes TO the keyring, so
+ * pulling FROM it would just re-store the same value.
+ */
+export function resolveAuthSetToken(input: {
+	provider: string;
+	positional?: string;
+	env?: NodeJS.ProcessEnv;
+}): string | null {
+	const env = input.env ?? process.env;
+	const upper = input.provider.toUpperCase();
+	const holocronKey = `HOLOCRON_${upper}_TOKEN`;
+	return input.positional || env[holocronKey] || env[upper + "_TOKEN"] || null;
+}
+
+// ── Subcommands ──────────────────────────────────────────────────────
+
+export interface RunAuthSetInput {
+	provider: string;
+	positional?: string;
+	env?: NodeJS.ProcessEnv;
+	importer?: AuthImporter;
+	print?: AuthPrint;
+}
+
+export async function runAuthSet(input: RunAuthSetInput): Promise<AuthCommandStatus> {
+	const print = input.print ?? ((l: string) => console.log(l));
+	const importer = input.importer ?? defaultImporter;
+	const { provider } = input;
+
+	const token = resolveAuthSetToken({ provider, positional: input.positional, env: input.env });
+	const packageName = resolvePluginPackage(provider);
+
+	if (!token) {
+		print(`no token supplied for \`${provider}\`.`);
+		print(`  pass as positional arg: holocron auth set ${provider} <token>`);
+		print(`  or via env: HOLOCRON_${provider.toUpperCase()}_TOKEN / ${provider.toUpperCase()}_TOKEN`);
+		const hint = await tryLoadHint(importer, packageName);
+		if (hint) {
+			print(`  hint: ${hint}`);
+		}
+		return { status: "fail", message: "no token supplied" };
+	}
+
+	// Verify via the plugin if it exports verifyToken.
+	let subject: string | undefined;
+	try {
+		const module = await importer(packageName);
+		if (typeof module.verifyToken === "function") {
+			const verified = await module.verifyToken(token);
+			if (!verified.ok) {
+				print(`token rejected by ${provider}: ${verified.message}`);
+				if (module.AUTH_HINT) print(`  hint: ${module.AUTH_HINT}`);
+				return { status: "fail", message: verified.message };
+			}
+			subject = verified.subject;
+		} else {
+			print(`(${provider} plugin has no verifyToken; storing without verification)`);
+		}
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		print(`cannot verify token — failed to load ${packageName}: ${msg}`);
+		print(`  storing token anyway; run 'holocron auth check ${provider}' once the plugin is installed`);
+	}
+
+	const stored = setToken(provider, token);
+	if (!stored) {
+		print(`keyring unavailable — token not stored. Use env vars instead.`);
+		return { status: "fail", message: "keyring unavailable" };
+	}
+
+	print(`stored ${provider} token${subject ? ` (${subject})` : ""}`);
+	return { status: "ok", ...(subject ? { message: subject } : {}) };
+}
+
+export interface RunAuthUnsetInput {
+	provider: string;
+	print?: AuthPrint;
+}
+
+export function runAuthUnset(input: RunAuthUnsetInput): AuthCommandStatus {
+	const print = input.print ?? ((l: string) => console.log(l));
+	const removed = deleteToken(input.provider);
+	if (removed) {
+		print(`removed ${input.provider} token`);
+		return { status: "ok" };
+	}
+	print(`no stored token for ${input.provider}`);
+	return { status: "skip", message: "nothing to remove" };
+}
+
+export interface RunAuthCheckInput {
+	provider: string;
+	importer?: AuthImporter;
+	print?: AuthPrint;
+}
+
+export async function runAuthCheck(input: RunAuthCheckInput): Promise<AuthCommandStatus> {
+	const print = input.print ?? ((l: string) => console.log(l));
+	const importer = input.importer ?? defaultImporter;
+	const { provider } = input;
+
+	const token = getToken(provider);
+	if (!token) {
+		print(`no stored token for ${provider}`);
+		return { status: "skip", message: "no stored token" };
+	}
+
+	const packageName = resolvePluginPackage(provider);
+	try {
+		const module = await importer(packageName);
+		if (typeof module.verifyToken !== "function") {
+			print(`${provider}: token stored (plugin has no verifyToken; can't confirm validity)`);
+			return { status: "ok", message: "stored, unverified" };
+		}
+		const verified = await module.verifyToken(token);
+		if (verified.ok) {
+			print(`${provider}: ok — ${verified.subject}`);
+			return { status: "ok", message: verified.subject };
+		}
+		print(`${provider}: rejected — ${verified.message}`);
+		if (module.AUTH_HINT) print(`  hint: ${module.AUTH_HINT}`);
+		return { status: "fail", message: verified.message };
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		print(`${provider}: cannot verify — ${msg}`);
+		return { status: "fail", message: msg };
+	}
+}
+
+export interface RunAuthListInput {
+	importer?: AuthImporter;
+	print?: AuthPrint;
+}
+
+export async function runAuthList(input: RunAuthListInput = {}): Promise<AuthCommandStatus> {
+	const print = input.print ?? ((l: string) => console.log(l));
+	const importer = input.importer ?? defaultImporter;
+	const providers = listStoredProviders();
+
+	if (providers.length === 0) {
+		print("no stored tokens.");
+		print("run: holocron auth set <provider> <token>");
+		return { status: "ok", message: "none" };
+	}
+
+	for (const provider of providers.sort()) {
+		const check = await runAuthCheck({ provider, importer, print: () => {} });
+		const icon = check.status === "ok" ? "✓" : check.status === "fail" ? "✗" : "·";
+		print(`  ${icon} ${provider}${check.message ? ` — ${check.message}` : ""}`);
+	}
+	return { status: "ok" };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+async function tryLoadHint(importer: AuthImporter, packageName: string): Promise<string | null> {
+	try {
+		const module = await importer(packageName);
+		return module.AUTH_HINT ?? null;
+	} catch {
+		return null;
+	}
+}

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -127,11 +127,38 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		}
 	}
 
-	// ── vault: read-only probe (no automation) ──────────────────────────
+	// ── vault: bootstrap project + configs, then read-only probe ───────
 	if (loader.has("vault")) {
 		const vault = loader.get("vault") as Vault;
 		print("  → vault");
-		// Always runs even in dry-run — it's read-only.
+
+		// ensureProject — providers that have a top-level container.
+		if (vault.ensureProject) {
+			steps.push(
+				await runStep("vault", `ensureProject ${config.project.name}`, dryRun, async () => {
+					const result = await vault.ensureProject!(config.project.name);
+					return `project ${result.alreadyExists ? "exists" : "created"}`;
+				})
+			);
+			print(formatStep(steps[steps.length - 1]!));
+		}
+
+		// ensureEnvironment — providers with a project/config split
+		// (Doppler configs, Infisical environments, etc.). Canonical
+		// names; per-project overrides live in the plugin's options.
+		if (vault.ensureEnvironment) {
+			for (const envName of ["dev", "stg", "prd"]) {
+				steps.push(
+					await runStep("vault", `ensureEnvironment ${envName}`, dryRun, async () => {
+						const result = await vault.ensureEnvironment!(config.project.name, envName);
+						return `${envName} ${result.alreadyExists ? "exists" : "created"}`;
+					})
+				);
+				print(formatStep(steps[steps.length - 1]!));
+			}
+		}
+
+		// Read-only reachability probe. Runs even under --dry-run.
 		try {
 			const keys = await vault.list();
 			steps.push({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./capabilities/index.js";
 export * from "./config.js";
+export * from "./keyring.js";

--- a/packages/cli/src/keyring.ts
+++ b/packages/cli/src/keyring.ts
@@ -1,0 +1,75 @@
+/**
+ * Keyring-backed bootstrap credential store.
+ *
+ * Every holocron plugin's bootstrap token (the one it needs before it
+ * can talk to its vendor's API) can be stored in the OS keyring under
+ * a single reverse-DNS service scope. Managed via `holocron auth`
+ * subcommands; consulted at position 4 in every plugin's auth
+ * precedence chain (after --token / HOLOCRON_<X>_TOKEN / <native>_TOKEN).
+ *
+ * See `.notes/tech-auth-bootstrap.spec.md` for the design rationale.
+ *
+ * Failure model: keyring access is best-effort. Platforms without a
+ * supported credential store (some Linux CI images, sandboxed
+ * environments) will throw from the underlying library. Every export
+ * here catches and returns a null/empty result rather than propagating
+ * — the plugin's precedence chain then falls through to
+ * env-var-only paths, which is exactly how CI is meant to work.
+ */
+
+import { Entry, findCredentials } from "@napi-rs/keyring";
+
+const SERVICE = "com.theholocron.cli";
+
+/**
+ * Store or overwrite a bootstrap token for a provider. Returns true on
+ * success, false when the underlying keyring is unsupported or errored.
+ */
+export function setToken(provider: string, token: string): boolean {
+	try {
+		new Entry(SERVICE, provider).setPassword(token);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Read the bootstrap token for a provider. Returns `null` for both
+ * "not stored" and "keyring unavailable" — callers can treat them the
+ * same way (fall through to env-var precedence).
+ */
+export function getToken(provider: string): string | null {
+	try {
+		return new Entry(SERVICE, provider).getPassword();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Delete a stored token. Returns true when a token was removed, false
+ * when there was nothing to delete or the keyring is unavailable.
+ * Distinguishing the two cases isn't worth the surface area — the
+ * command output makes the situation clear either way.
+ */
+export function deleteToken(provider: string): boolean {
+	try {
+		return new Entry(SERVICE, provider).deletePassword();
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * List provider slugs with a stored token in this service scope.
+ * Uses the library's `findCredentials(service)` — supported on all
+ * platforms the underlying credential store supports.
+ */
+export function listStoredProviders(): string[] {
+	try {
+		return findCredentials(SERVICE).map((c) => c.account);
+	} catch {
+		return [];
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@napi-rs/keyring':
+        specifier: ^1.3.0
+        version: 1.3.0
       '@theholocron/cli-utils':
         specifier: workspace:*
         version: link:../cli-utils
@@ -941,6 +944,87 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    resolution: {integrity: sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    resolution: {integrity: sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    resolution: {integrity: sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    resolution: {integrity: sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    resolution: {integrity: sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    resolution: {integrity: sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    resolution: {integrity: sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    resolution: {integrity: sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    resolution: {integrity: sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    resolution: {integrity: sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.3.0':
+    resolution: {integrity: sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -6570,6 +6654,57 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@napi-rs/keyring-darwin-arm64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.3.0':
+    optional: true
+
+  '@napi-rs/keyring@1.3.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.3.0
+      '@napi-rs/keyring-darwin-x64': 1.3.0
+      '@napi-rs/keyring-freebsd-x64': 1.3.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.3.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.3.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.3.0
+      '@napi-rs/keyring-linux-x64-musl': 1.3.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.3.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.3.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.3.0
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:


### PR DESCRIPTION
## Description

Give every plugin's bootstrap credential (the token it needs to reach its vendor's API before anything else) a first-class home in the OS keyring, managed via `holocron auth`. Operators no longer store tokens in env vars, dotfiles, or shell profiles unless they explicitly opt in (CI paths + per-command overrides still work).

- `packages/cli/src/keyring.ts` — thin wrapper over @napi-rs/keyring (Rust-based, prebuilt binaries, no node-gyp). Service scope `com.theholocron.cli`, account = provider slug. Degrades to null on platforms without a supported credential store (CI containers).
- `packages/cli/src/commands/auth.ts` — `set / unset / check / list` subcommands. `set` verifies the token via the plugin's exported `verifyToken(token)` before storing; on failure prints the plugin's optional `AUTH_HINT`.
- `Vault` capability gains optional `ensureProject` and `ensureEnvironment` methods so `runSetup` can bootstrap vault containers (Doppler projects/configs, Infisical envs, etc.). `runSetup`'s vault branch calls them when implemented; 1P-shaped vaults with no notion of a project skip cleanly.

Design captured in `.notes/tech-auth-bootstrap.spec.md`. Motivating vault-provider decision in `.notes/tech-vault-choice.spec.md` (Doppler + Infisical cloud, 1Password deprecation path). Minor `tool-plugin-create` spec cleanup: status draft → proposed since Phase 1 is not blocked.