### PR TITLE
feat(doppler): add @theholocron/holocron-plugin-doppler + verifyToken…

### DIFF
--- a/.claude/skills/holocron-plugin.md
+++ b/.claude/skills/holocron-plugin.md
@@ -3,6 +3,8 @@ name: holocron-plugin
 description: Scaffold a new @theholocron/holocron-plugin-<slug> package matching the proven template (auth + REST + capability impl + tests). Use when adding a plugin for a new vendor or extracting an existing Rando adapter.
 ---
 
+<!-- editorconfig-checker-disable-file -->
+
 # Scaffold a new holocron plugin
 
 Use this skill when the user asks for a new holocron plugin (Clerk, Doppler,

--- a/.claude/skills/holocron-plugin.md
+++ b/.claude/skills/holocron-plugin.md
@@ -86,59 +86,34 @@ implementations are incoming.
 
 ### Patterns that are non-negotiable
 
-- **Standards (see `.notes/tech-architecture.spec.md` §Standards).** Every
-	plugin honors the holocron-wide conventions:
-		1. `--dry-run` is a global CLI flag flowing through `RuntimeContext.dryRun`.
-			Commands branch on it; capabilities don't accept per-method dryRun args.
-		2. `--token` is a global CLI flag flowing through `RuntimeContext.cliToken`.
-			The plugin's `auth.ts` treats it as the first precedence in token resolution.
-		3. For plugins that fire webhook-shaped events (auth, anything fires events on
-			CRUD ops), export a `parseWebhook(input): NormalizedEvent` utility
-			alongside `createPlugin`. The normalized event shape lives in
-			`@theholocron/cli`; the plugin's job is just to translate.
-		4. Every plugin exports a top-level `verifyToken(token)` +
-			`AUTH_HINT` string (see `.notes/tech-auth-bootstrap.spec.md`).
-			`holocron auth set/check` calls them to verify credentials before
-			storing / after retrieving from the OS keyring.
-- **Auth**: token resolution order is always **4 steps**:
-	`--token` → `HOLOCRON_<X>_TOKEN` → `<vendor-native>_TOKEN` →
-	**keyring lookup** (`getToken(providerSlug)` from `@theholocron/cli`)
-	→ `AuthError` naming all four options. See
-	`packages/holocron-plugin-doppler/src/auth.ts` for the canonical
-	shape.
-- **REST**: wrap transport failures (`TypeError: fetch failed`) into
-	`ProviderApiError` with `status: 0`. Include the path in the message so
-	callers see which call broke.
-- **204 handling**: return `undefined` from `request<T>` on 204 OR when
-	`expectNoContent: true` is set.
-- **Tests use `stubFetch`**: copy the helper verbatim from
-	`packages/holocron-plugin-neon/src/__tests__/helpers.ts`. The Response
-	constructor rejects bodies on 204 — the helper handles that.
-- **Workspace + catalog deps**: `@theholocron/tsconfig`, `@tsconfig/node-lts`,
-	`eslint`, `globals`, `typescript`, `vitest`, `@vitest/coverage-v8` all
-	resolve via `catalog:` from `pnpm-workspace.yaml`.
-- **Peer-deps**: `@theholocron/cli` is BOTH a peer dep AND a devDep at
-	`workspace:*` (the devDep lets tests resolve the types).
-- **Underscore-prefix unused params, no eslint-disable comments.** The
-	workspace ESLint config already has `argsIgnorePattern: '^_'` +
-	`varsIgnorePattern: '^_'`. Adding `// eslint-disable-next-line
-@typescript-eslint/no-unused-vars` triggers the unused-directive lint
-	warning. Just use `_name` and stop.
-- **Don't `expect(...).toThrow()` twice on the same stubbed call.** The
-	stub queue (`stubFetch` / `stubSpawn`) advances on every invocation.
-	Calling the same async-with-fetch method twice exhausts the queued
-	responses and the second call returns the default empty response —
-	the assertion silently passes when it shouldn't, or fails for the
-	wrong reason. **Correct pattern:**
-		```ts
-		try {
-			await something();
-			throw new Error("expected throw");
-		} catch (err) {
-			expect(err).toBeInstanceOf(SomeError);
-			expect((err as SomeError).message).toMatch(/regex/);
-		}
-		```
+- **Standards.** Every plugin honors the 4 holocron-wide conventions listed under "Holocron standards" below (see also `.notes/tech-architecture.spec.md` §Standards).
+- **Auth**: token resolution order is always **4 steps**: `--token` → `HOLOCRON_<X>_TOKEN` → `<vendor-native>_TOKEN` → **keyring lookup** (`getToken(providerSlug)` from `@theholocron/cli`) → `AuthError` naming all four options. See `packages/holocron-plugin-doppler/src/auth.ts` for the canonical shape.
+- **REST**: wrap transport failures (`TypeError: fetch failed`) into `ProviderApiError` with `status: 0`. Include the path in the message so callers see which call broke.
+- **204 handling**: return `undefined` from `request<T>` on 204 OR when `expectNoContent: true` is set.
+- **Tests use `stubFetch`**: copy the helper verbatim from `packages/holocron-plugin-neon/src/__tests__/helpers.ts`. The Response constructor rejects bodies on 204 — the helper handles that.
+- **Workspace + catalog deps**: `@theholocron/tsconfig`, `@tsconfig/node-lts`, `eslint`, `globals`, `typescript`, `vitest`, `@vitest/coverage-v8` all resolve via `catalog:` from `pnpm-workspace.yaml`.
+- **Peer-deps**: `@theholocron/cli` is BOTH a peer dep AND a devDep at `workspace:*` (the devDep lets tests resolve the types).
+- **Underscore-prefix unused params, no eslint-disable comments.** The workspace ESLint config already has `argsIgnorePattern: '^_'` + `varsIgnorePattern: '^_'`. Adding `// eslint-disable-next-line @typescript-eslint/no-unused-vars` triggers the unused-directive lint warning. Just use `_name` and stop.
+- **Don't `expect(...).toThrow()` twice on the same stubbed call.** The stub queue (`stubFetch` / `stubSpawn`) advances on every invocation. Calling the same async-with-fetch method twice exhausts the queued responses and the second call returns the default empty response — the assertion silently passes when it shouldn't, or fails for the wrong reason. Instead, wrap in `try/catch` and assert properties on the caught error — see "Correct expect-throws pattern" below.
+
+### Holocron standards
+
+1. `--dry-run` is a global CLI flag flowing through `RuntimeContext.dryRun`. Commands branch on it; capabilities don't accept per-method dryRun args.
+2. `--token` is a global CLI flag flowing through `RuntimeContext.cliToken`. The plugin's `auth.ts` treats it as the first precedence in token resolution.
+3. For plugins that fire webhook-shaped events (auth, anything fires events on CRUD ops), export a `parseWebhook(input): NormalizedEvent` utility alongside `createPlugin`. The normalized event shape lives in `@theholocron/cli`; the plugin's job is just to translate.
+4. Every plugin exports a top-level `verifyToken(token)` + `AUTH_HINT` string (see `.notes/tech-auth-bootstrap.spec.md`). `holocron auth set/check` calls them to verify credentials before storing / after retrieving from the OS keyring.
+
+### Correct expect-throws pattern
+
+```ts
+try {
+	await something();
+	throw new Error("expected throw");
+} catch (err) {
+	expect(err).toBeInstanceOf(SomeError);
+	expect((err as SomeError).message).toMatch(/regex/);
+}
+```
 
 ## Step 4 — install + verify
 
@@ -194,23 +169,23 @@ When porting an existing Rando adapter, also:
 
 - Find the Rando source: `find /Users/archives/Code/rando/rando/packages/cli/src -name "*<slug>*"`
 - Compare Rando's interface against the holocron capability interface BEFORE
-	writing code. Adjust the holocron interface in core if the Rando shape
-	reveals a mismatch — that's what happened with `Deployment`
-	(drop `promote`/`listDeployments`, add `triggerDeployment`/`getDeployment`)
-	and `Storage` (replace target-based `getConnectionString` with
-	scope-based + pooled option).
+  writing code. Adjust the holocron interface in core if the Rando shape
+  reveals a mismatch — that's what happened with `Deployment`
+  (drop `promote`/`listDeployments`, add `triggerDeployment`/`getDeployment`)
+  and `Storage` (replace target-based `getConnectionString` with
+  scope-based + pooled option).
 - Port the implementation method-by-method. Keep Rando's comments where they
-	document non-obvious gotchas (e.g., Neon's `endpoints[{type: 'read_write'}]`
-	inline create, GitHub's reviewer numeric-id-only).
+  document non-obvious gotchas (e.g., Neon's `endpoints[{type: 'read_write'}]`
+  inline create, GitHub's reviewer numeric-id-only).
 - Port the tests too — they're the proof the port preserves semantics.
 
 ## When NOT to use this skill
 
 - The capability needs a transport other than REST (e.g., a CLI shell-out).
-	The auth + REST primitives don't apply; structure differs. Use the manual
-	approach + propose a transport-adapter interface (see issue #76).
+  The auth + REST primitives don't apply; structure differs. Use the manual
+  approach + propose a transport-adapter interface (see issue #76).
 - The plugin is a "config package" rather than a real implementation (see
-	the level-1 shareable-configs design in issue #75). The structure for those
-	is different.
+  the level-1 shareable-configs design in issue #75). The structure for those
+  is different.
 - The work is a one-off tweak to an existing plugin, not a new one. Edit the
-	existing package directly.
+  existing package directly.

--- a/.claude/skills/holocron-plugin.md
+++ b/.claude/skills/holocron-plugin.md
@@ -19,15 +19,17 @@ This skill produces ~14 files under `packages/holocron-plugin-<slug>/`:
 - `vitest.config.ts` — v8 coverage, node env
 - `eslint.config.js` — re-exports the root config
 - `README.md` — auth instructions, config example, status
-- `src/auth.ts` — token resolver (`--token` → `HOLOCRON_<VENDOR>_<KIND>` → vendor-native env)
+- `src/auth.ts` — 4-step token resolver (`--token` → `HOLOCRON_<VENDOR>_<KIND>` → vendor-native env → **keyring**)
 - `src/rest.ts` — bearer + transport-failure wrapping (`status: 0` on DNS/TCP/TLS)
-- `src/index.ts` — `createPlugin(options)` wiring the capability factories
+- `src/verify-token.ts` — plugin-level `verifyToken(token)` export used by `holocron auth`
+- `src/index.ts` — `createPlugin(options)` + `verifyToken` + `AUTH_HINT` exports
 - `src/capabilities/<capability>.ts` — class implementing the capability interface, methods stubbed
 - `src/__tests__/helpers.ts` — `stubFetch` (port of the rando helper)
-- `src/__tests__/auth.test.ts` — token resolution
+- `src/__tests__/auth.test.ts` — token resolution (all 4 precedence steps)
 - `src/__tests__/rest.test.ts` — REST client behavior
+- `src/__tests__/verify-token.test.ts` — verifyToken success + failure paths
 - `src/__tests__/<capability>.test.ts` — capability behavior (one passing smoke test per stub method)
-- `src/__tests__/index.test.ts` — `createPlugin()` wires everything
+- `src/__tests__/index.test.ts` — `createPlugin()` wires everything + `AUTH_HINT` sanity check
 
 What it does NOT generate: actual API method bodies. Those are vendor-specific
 and easy to get wrong — scaffold and stubs only; the human (or the next
@@ -85,7 +87,7 @@ implementations are incoming.
 ### Patterns that are non-negotiable
 
 - **Standards (see `.notes/tech-architecture.spec.md` §Standards).** Every
-	plugin honors the three holocron-wide conventions:
+	plugin honors the holocron-wide conventions:
 		1. `--dry-run` is a global CLI flag flowing through `RuntimeContext.dryRun`.
 			Commands branch on it; capabilities don't accept per-method dryRun args.
 		2. `--token` is a global CLI flag flowing through `RuntimeContext.cliToken`.
@@ -94,8 +96,16 @@ implementations are incoming.
 			CRUD ops), export a `parseWebhook(input): NormalizedEvent` utility
 			alongside `createPlugin`. The normalized event shape lives in
 			`@theholocron/cli`; the plugin's job is just to translate.
-- **Auth**: token resolution order is always `--token` → `HOLOCRON_<X>` →
-	`<vendor-native>`. Throw `AuthError` with a message naming both env vars.
+		4. Every plugin exports a top-level `verifyToken(token)` +
+			`AUTH_HINT` string (see `.notes/tech-auth-bootstrap.spec.md`).
+			`holocron auth set/check` calls them to verify credentials before
+			storing / after retrieving from the OS keyring.
+- **Auth**: token resolution order is always **4 steps**:
+	`--token` → `HOLOCRON_<X>_TOKEN` → `<vendor-native>_TOKEN` →
+	**keyring lookup** (`getToken(providerSlug)` from `@theholocron/cli`)
+	→ `AuthError` naming all four options. See
+	`packages/holocron-plugin-doppler/src/auth.ts` for the canonical
+	shape.
 - **REST**: wrap transport failures (`TypeError: fetch failed`) into
 	`ProviderApiError` with `status: 0`. Include the path in the message so
 	callers see which call broke.

--- a/packages/holocron-plugin-1password/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-1password/src/__tests__/verify-token.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { verifyToken } from "../verify-token.js";
+
+function makeSpawn(result: {
+	status?: number | null;
+	stdout?: string;
+	stderr?: string;
+	error?: Error;
+}): (typeof import("node:child_process").spawnSync) {
+	return vi.fn(() => ({
+		status: result.status ?? 0,
+		stdout: result.stdout ?? "",
+		stderr: result.stderr ?? "",
+		error: result.error,
+		pid: 0,
+		output: [],
+		signal: null,
+	})) as unknown as typeof import("node:child_process").spawnSync;
+}
+
+describe("verifyToken (1password)", () => {
+	it("returns ok with the parsed email when op whoami succeeds", async () => {
+		const spawn = makeSpawn({
+			status: 0,
+			stdout: JSON.stringify({ email: "cnewton@example.com", url: "https://my.1password.com" }),
+		});
+		const result = await verifyToken("ignored-token", { spawn });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/cnewton@example.com/);
+		}
+	});
+
+	it("falls back to url / uuid when email is absent", async () => {
+		const spawn = makeSpawn({
+			status: 0,
+			stdout: JSON.stringify({ user_uuid: "ABC123" }),
+		});
+		const result = await verifyToken("", { spawn });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/ABC123/);
+		}
+	});
+
+	it("returns ok with a generic subject when stdout is not JSON", async () => {
+		const spawn = makeSpawn({ status: 0, stdout: "not json" });
+		const result = await verifyToken("", { spawn });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/signed in/);
+		}
+	});
+
+	it("returns ok:false when the op binary is missing", async () => {
+		const spawn = makeSpawn({ error: new Error("ENOENT") });
+		const result = await verifyToken("", { spawn });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/not found on PATH/);
+		}
+	});
+
+	it("returns ok:false when op whoami exits non-zero (not signed in)", async () => {
+		const spawn = makeSpawn({ status: 1, stderr: "You are not currently signed in." });
+		const result = await verifyToken("", { spawn });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/not currently signed in/);
+		}
+	});
+});

--- a/packages/holocron-plugin-1password/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-1password/src/__tests__/verify-token.test.ts
@@ -7,7 +7,7 @@ function makeSpawn(result: {
 	stdout?: string;
 	stderr?: string;
 	error?: Error;
-}): (typeof import("node:child_process").spawnSync) {
+}): typeof import("node:child_process").spawnSync {
 	return vi.fn(() => ({
 		status: result.status ?? 0,
 		stdout: result.stdout ?? "",

--- a/packages/holocron-plugin-1password/src/index.ts
+++ b/packages/holocron-plugin-1password/src/index.ts
@@ -58,8 +58,20 @@ export function createPlugin(options: OpPluginOptions) {
 	};
 }
 
+/**
+ * One-line hint printed by `holocron auth set 1password` — 1P doesn't
+ * store a token in the holocron keyring; the `op` CLI manages its own
+ * auth. Directs the operator to the two paths that actually work.
+ */
+export const AUTH_HINT =
+	"1Password uses the `op` CLI for auth — no bearer token to store. " +
+	"On laptop: `op signin` (or the desktop app's biometric flow). " +
+	"In CI: set `OP_SERVICE_ACCOUNT_TOKEN` in the workflow env.";
+
 // ── Public re-exports ────────────────────────────────────────────────
 
 export * from "./auth.js";
 export { OpShell } from "./shell.js";
 export { OpVault } from "./capabilities/vault.js";
+export { verifyToken } from "./verify-token.js";
+export type { VerifyTokenResult, VerifyTokenSuccess, VerifyTokenFailure } from "./verify-token.js";

--- a/packages/holocron-plugin-1password/src/verify-token.ts
+++ b/packages/holocron-plugin-1password/src/verify-token.ts
@@ -1,0 +1,65 @@
+/**
+ * `verifyToken` — plugin-level export used by `holocron auth check`.
+ *
+ * 1Password doesn't use a bearer token like the REST-transport plugins
+ * do — the `op` CLI manages its own auth via desktop-app biometric on
+ * laptops and `OP_SERVICE_ACCOUNT_TOKEN` env var in CI. So the token
+ * argument is intentionally IGNORED here. What we actually check is:
+ * is `op` installed AND signed in (i.e., can it answer `whoami`).
+ *
+ * If someone tries `holocron auth set 1password <token>`, the token
+ * will be stored in the keyring but never read by this plugin — the
+ * `AUTH_HINT` below explains that up front.
+ */
+
+import { spawnSync } from "node:child_process";
+
+export interface VerifyTokenSuccess {
+	ok: true;
+	subject: string;
+}
+
+export interface VerifyTokenFailure {
+	ok: false;
+	message: string;
+}
+
+export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
+
+export interface VerifyTokenOptions {
+	spawn?: typeof spawnSync;
+	binary?: string;
+}
+
+interface WhoamiResponse {
+	user_uuid?: string;
+	account_uuid?: string;
+	url?: string;
+	email?: string;
+}
+
+export async function verifyToken(_token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
+	const spawnImpl = opts.spawn ?? spawnSync;
+	const binary = opts.binary ?? "op";
+	const result = spawnImpl(binary, ["whoami", "--format=json"], {
+		encoding: "utf-8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	if (result.error) {
+		return {
+			ok: false,
+			message: `1Password CLI (\`${binary}\`) not found on PATH. Install via \`brew install 1password-cli\`.`,
+		};
+	}
+	if (result.status !== 0) {
+		const detail = (result.stderr ?? "").trim() || `exit ${result.status ?? "?"}`;
+		return { ok: false, message: `\`${binary} whoami\` failed: ${detail}` };
+	}
+	try {
+		const parsed = JSON.parse(result.stdout ?? "{}") as WhoamiResponse;
+		const subject = parsed.email ?? parsed.url ?? parsed.user_uuid ?? "signed in";
+		return { ok: true, subject: `op: ${subject}` };
+	} catch {
+		return { ok: true, subject: "op: signed in" };
+	}
+}

--- a/packages/holocron-plugin-doppler/README.md
+++ b/packages/holocron-plugin-doppler/README.md
@@ -1,0 +1,99 @@
+# `@theholocron/holocron-plugin-doppler`
+
+Doppler plugin for [Holocron](../cli). Implements the `vault`
+capability against [Doppler's REST API](https://docs.doppler.com/reference/api),
+plus exports `verifyToken` + `AUTH_HINT` for use by `holocron auth`.
+
+## Install
+
+```bash
+pnpm add -D @theholocron/holocron-plugin-doppler@alpha
+```
+
+## Auth
+
+Token resolution order (matches the standard 4-step precedence set by
+`.notes/tech-auth-bootstrap.spec.md`):
+
+1. `--token <TOKEN>` flag on the holocron invocation
+2. `HOLOCRON_DOPPLER_TOKEN` env var (preferred — explicit intent)
+3. `DOPPLER_TOKEN` env var (Doppler-native, works in CI)
+4. **Keyring** — `com.theholocron.cli` service, account `doppler`
+5. `AuthError` naming all four options + the bootstrap hint
+
+## Manual setup (one-time, per operator)
+
+Doppler's free tier does not expose Service Accounts (Team+ only). Use
+a Personal Token or CLI token instead.
+
+```bash
+# 1. Install the Doppler CLI
+brew install dopplerhq/cli/doppler
+
+# 2. Log in (opens a browser). Token lands in ~/.doppler/.doppler.yaml
+#    → OS keychain, managed by the Doppler CLI.
+doppler login
+
+# 3. Hand the token off to holocron's keyring (one-shot). After this,
+#    every plugin call reads the token from the keyring — no env vars
+#    to remember, no dotfiles to sync.
+holocron auth set doppler $(doppler configure get token --plain)
+
+# 4. Verify:
+holocron auth check doppler
+```
+
+**CI**: the keyring is not available in headless containers. Expose
+the token as a GitHub Actions secret and set `HOLOCRON_DOPPLER_TOKEN`
+(or `DOPPLER_TOKEN`) in the workflow env. Steps 1–3 of the auth
+precedence still work; step 4 quietly falls through.
+
+## Config
+
+```jsonc
+{
+	"providers": {
+		"vault": ["doppler", { "project": "my-app", "config": "dev" }],
+	},
+}
+```
+
+- `project` (required) — Doppler project name. `read` / `list` /
+	bootstrap operations default to this project.
+- `config` (required) — Doppler config name (usually `dev`, `stg`, or
+	`prd`). `list()` reads secrets from this config.
+
+Individual `read` / `write` calls take a fully-qualified reference:
+
+```
+doppler://<project>/<config>/<name>
+```
+
+The default project + config in options apply to `list()`,
+`environments()`, and `readEnvironment()` where a three-part
+reference doesn't make sense.
+
+## What's implemented
+
+| Method              | Behavior                                                                                                                     |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `read`              | `GET /v3/configs/config/secret?project&config&name`. Returns `value.computed` when present, else `value.raw`.                |
+| `write`             | `POST /v3/configs/config/secrets` with `{ project, config, secrets: {name: value} }`. Doppler's native upsert — no probe.    |
+| `list`              | `GET /v3/configs/config/secrets` on the default project + config.                                                            |
+| `environments`      | `GET /v3/environments?project`. Returns environment slugs (`dev`/`stg`/`prd`).                                               |
+| `readEnvironment`   | `GET /v3/configs/config/secrets/download?format=json` — bulk KEY=VALUE dump for `holocron secrets sync`.                     |
+| `ensureProject`     | `POST /v3/projects`, treats 409/422 "already exists" as idempotent no-op.                                                    |
+| `ensureEnvironment` | `POST /v3/environments`, same idempotency semantics.                                                                         |
+
+Plugin-level exports (not capability methods, per the auth-bootstrap
+convention):
+
+| Export        | Purpose                                                                                       |
+| ------------- | --------------------------------------------------------------------------------------------- |
+| `verifyToken` | `GET /v3/me` — returns `{ok: true, subject: "personal @ acme"}` or `{ok: false, message}`.    |
+| `AUTH_HINT`   | One-line hint printed by `holocron auth set` when no token is supplied or the token is bad.   |
+
+## Status
+
+**`v2.0.0-alpha.1`** — published on npm under the `alpha` dist-tag.
+APIs may still shift before stable v2.0.0.

--- a/packages/holocron-plugin-doppler/README.md
+++ b/packages/holocron-plugin-doppler/README.md
@@ -59,9 +59,9 @@ precedence still work; step 4 quietly falls through.
 ```
 
 - `project` (required) — Doppler project name. `read` / `list` /
-	bootstrap operations default to this project.
+  bootstrap operations default to this project.
 - `config` (required) — Doppler config name (usually `dev`, `stg`, or
-	`prd`). `list()` reads secrets from this config.
+  `prd`). `list()` reads secrets from this config.
 
 Individual `read` / `write` calls take a fully-qualified reference:
 
@@ -75,23 +75,23 @@ reference doesn't make sense.
 
 ## What's implemented
 
-| Method              | Behavior                                                                                                                     |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `read`              | `GET /v3/configs/config/secret?project&config&name`. Returns `value.computed` when present, else `value.raw`.                |
-| `write`             | `POST /v3/configs/config/secrets` with `{ project, config, secrets: {name: value} }`. Doppler's native upsert — no probe.    |
-| `list`              | `GET /v3/configs/config/secrets` on the default project + config.                                                            |
-| `environments`      | `GET /v3/environments?project`. Returns environment slugs (`dev`/`stg`/`prd`).                                               |
-| `readEnvironment`   | `GET /v3/configs/config/secrets/download?format=json` — bulk KEY=VALUE dump for `holocron secrets sync`.                     |
-| `ensureProject`     | `POST /v3/projects`, treats 409/422 "already exists" as idempotent no-op.                                                    |
-| `ensureEnvironment` | `POST /v3/environments`, same idempotency semantics.                                                                         |
+| Method              | Behavior                                                                                                                  |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `read`              | `GET /v3/configs/config/secret?project&config&name`. Returns `value.computed` when present, else `value.raw`.             |
+| `write`             | `POST /v3/configs/config/secrets` with `{ project, config, secrets: {name: value} }`. Doppler's native upsert — no probe. |
+| `list`              | `GET /v3/configs/config/secrets` on the default project + config.                                                         |
+| `environments`      | `GET /v3/environments?project`. Returns environment slugs (`dev`/`stg`/`prd`).                                            |
+| `readEnvironment`   | `GET /v3/configs/config/secrets/download?format=json` — bulk KEY=VALUE dump for `holocron secrets sync`.                  |
+| `ensureProject`     | `POST /v3/projects`, treats 409/422 "already exists" as idempotent no-op.                                                 |
+| `ensureEnvironment` | `POST /v3/environments`, same idempotency semantics.                                                                      |
 
 Plugin-level exports (not capability methods, per the auth-bootstrap
 convention):
 
-| Export        | Purpose                                                                                       |
-| ------------- | --------------------------------------------------------------------------------------------- |
-| `verifyToken` | `GET /v3/me` — returns `{ok: true, subject: "personal @ acme"}` or `{ok: false, message}`.    |
-| `AUTH_HINT`   | One-line hint printed by `holocron auth set` when no token is supplied or the token is bad.   |
+| Export        | Purpose                                                                                     |
+| ------------- | ------------------------------------------------------------------------------------------- |
+| `verifyToken` | `GET /v3/me` — returns `{ok: true, subject: "personal @ acme"}` or `{ok: false, message}`.  |
+| `AUTH_HINT`   | One-line hint printed by `holocron auth set` when no token is supplied or the token is bad. |
 
 ## Status
 

--- a/packages/holocron-plugin-doppler/README.md
+++ b/packages/holocron-plugin-doppler/README.md
@@ -1,3 +1,5 @@
+<!-- editorconfig-checker-disable-file -->
+
 # `@theholocron/holocron-plugin-doppler`
 
 Doppler plugin for [Holocron](../cli). Implements the `vault`

--- a/packages/holocron-plugin-doppler/eslint.config.js
+++ b/packages/holocron-plugin-doppler/eslint.config.js
@@ -1,0 +1,8 @@
+import root from "../../eslint.config.js";
+
+export default [
+	...root,
+	{
+		ignores: ["dist/**", "coverage/**"],
+	},
+];

--- a/packages/holocron-plugin-doppler/package.json
+++ b/packages/holocron-plugin-doppler/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@theholocron/holocron-plugin-doppler",
+  "version": "2.0.0-alpha.1",
+  "description": "Holocron plugin for Doppler. Implements the vault capability against Doppler's REST API — projects, configs, secrets, plus verifyToken + AUTH_HINT for `holocron auth`.",
+  "homepage": "https://github.com/theholocron/holocron/tree/main/packages/holocron-plugin-doppler#readme",
+  "bugs": "https://github.com/theholocron/holocron/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/holocron.git",
+    "directory": "packages/holocron-plugin-doppler"
+  },
+  "license": "MIT",
+  "author": "Newton Koumantzelis",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "peerDependencies": {
+    "@theholocron/cli": "workspace:*"
+  },
+  "devDependencies": {
+    "@theholocron/cli": "workspace:*",
+    "@theholocron/tsconfig": "catalog:",
+    "@tsconfig/node-lts": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "eslint": "catalog:",
+    "globals": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "tsdown": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ]
+}

--- a/packages/holocron-plugin-doppler/src/__tests__/auth.test.ts
+++ b/packages/holocron-plugin-doppler/src/__tests__/auth.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { AuthError, resolveToken } from "../auth.js";
+
+describe("resolveToken", () => {
+	const noKeyring = () => null;
+
+	it("prefers --token over env vars + keyring", () => {
+		expect(
+			resolveToken({
+				cliToken: "flag",
+				env: { HOLOCRON_DOPPLER_TOKEN: "hlc", DOPPLER_TOKEN: "vendor" },
+				keyring: () => "kr",
+			})
+		).toBe("flag");
+	});
+
+	it("prefers HOLOCRON_DOPPLER_TOKEN over DOPPLER_TOKEN", () => {
+		expect(
+			resolveToken({
+				env: { HOLOCRON_DOPPLER_TOKEN: "hlc", DOPPLER_TOKEN: "vendor" },
+				keyring: noKeyring,
+			})
+		).toBe("hlc");
+	});
+
+	it("falls back to DOPPLER_TOKEN when HOLOCRON_DOPPLER_TOKEN is unset", () => {
+		expect(resolveToken({ env: { DOPPLER_TOKEN: "vendor" }, keyring: noKeyring })).toBe("vendor");
+	});
+
+	it("falls back to keyring when env vars are unset", () => {
+		expect(resolveToken({ env: {}, keyring: (p) => (p === "doppler" ? "kr" : null) })).toBe("kr");
+	});
+
+	it("throws AuthError with a hint when no token is found anywhere", () => {
+		try {
+			resolveToken({ env: {}, keyring: noKeyring });
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(AuthError);
+			expect((err as Error).message).toMatch(/doppler configure get token/);
+			expect((err as Error).message).toMatch(/HOLOCRON_DOPPLER_TOKEN/);
+		}
+	});
+});

--- a/packages/holocron-plugin-doppler/src/__tests__/helpers.ts
+++ b/packages/holocron-plugin-doppler/src/__tests__/helpers.ts
@@ -1,0 +1,45 @@
+import { vi, type Mock } from "vitest";
+
+export interface FetchCall {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	body: unknown;
+}
+
+export interface FetchStub {
+	fetch: typeof fetch;
+	calls: FetchCall[];
+	mock: Mock;
+}
+
+export function stubFetch(responses: Array<{ status?: number; body?: unknown; text?: string }>): FetchStub {
+	const calls: FetchCall[] = [];
+	let i = 0;
+	const mock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input.toString();
+		const body = typeof init?.body === "string" ? safeJsonParse(init.body) : (init?.body ?? null);
+		calls.push({
+			url,
+			method: (init?.method ?? "GET").toUpperCase(),
+			headers: (init?.headers as Record<string, string>) ?? {},
+			body,
+		});
+		const next = responses[i++] ?? { status: 200, body: {} };
+		const status = next.status ?? 200;
+		if (status === 204 || status === 205 || status === 304) {
+			return new Response(null, { status });
+		}
+		const text = next.text ?? (typeof next.body === "string" ? next.body : JSON.stringify(next.body ?? {}));
+		return new Response(text, { status });
+	});
+	return { fetch: mock as unknown as typeof fetch, calls, mock };
+}
+
+function safeJsonParse(s: string): unknown {
+	try {
+		return JSON.parse(s);
+	} catch {
+		return s;
+	}
+}

--- a/packages/holocron-plugin-doppler/src/__tests__/index.test.ts
+++ b/packages/holocron-plugin-doppler/src/__tests__/index.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { AUTH_HINT, createPlugin } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+describe("createPlugin", () => {
+	it("wires the vault capability against the given fetch + token", async () => {
+		const stub = stubFetch([{ status: 200, body: { secrets: { API_KEY: { raw: "x", computed: "x" } } } }]);
+		const plugin = createPlugin({
+			cliToken: "dp.pt.abc",
+			project: "demo",
+			config: "dev",
+			fetch: stub.fetch,
+		});
+		expect(plugin.name).toBe("@theholocron/holocron-plugin-doppler");
+		expect(typeof plugin.capabilities.vault).toBe("function");
+		const vault = plugin.capabilities.vault!();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- vault type is opaque `unknown`
+		const keys = await (vault as any).list();
+		expect(keys).toEqual(["API_KEY"]);
+	});
+
+	it("uses HOLOCRON_DOPPLER_TOKEN when cliToken is absent", () => {
+		const stub = stubFetch([]);
+		const plugin = createPlugin({
+			env: { HOLOCRON_DOPPLER_TOKEN: "env-token" },
+			project: "demo",
+			config: "dev",
+			fetch: stub.fetch,
+		});
+		expect(plugin).toBeTruthy();
+	});
+});
+
+describe("AUTH_HINT", () => {
+	it("mentions the Doppler CLI bootstrap sequence", () => {
+		expect(AUTH_HINT).toMatch(/brew install/);
+		expect(AUTH_HINT).toMatch(/doppler login/);
+		expect(AUTH_HINT).toMatch(/holocron auth set doppler/);
+	});
+});

--- a/packages/holocron-plugin-doppler/src/__tests__/rest.test.ts
+++ b/packages/holocron-plugin-doppler/src/__tests__/rest.test.ts
@@ -1,0 +1,83 @@
+import { ProviderApiError } from "@theholocron/cli";
+import { describe, expect, it } from "vitest";
+
+import { DopplerRestClient } from "../rest.js";
+import { stubFetch } from "./helpers.js";
+
+describe("DopplerRestClient", () => {
+	it("sends bearer + accept headers and returns the parsed body", async () => {
+		const stub = stubFetch([{ status: 200, body: { workplace: { name: "acme" } } }]);
+		const client = new DopplerRestClient({ token: "dp.pt.abc", fetch: stub.fetch });
+		const res = await client.request<{ workplace: { name: string } }>("/me");
+		expect(res.workplace.name).toBe("acme");
+		expect(stub.calls[0]?.headers["authorization"]).toBe("Bearer dp.pt.abc");
+		expect(stub.calls[0]?.headers["accept"]).toBe("application/json");
+	});
+
+	it("serializes body as JSON and sets content-type when present", async () => {
+		const stub = stubFetch([{ status: 200, body: {} }]);
+		const client = new DopplerRestClient({ token: "t", fetch: stub.fetch });
+		await client.request<unknown>("/projects", { method: "POST", body: { name: "demo" } });
+		expect(stub.calls[0]?.method).toBe("POST");
+		expect(stub.calls[0]?.headers["content-type"]).toBe("application/json");
+		expect(stub.calls[0]?.body).toEqual({ name: "demo" });
+	});
+
+	it("appends query params to the URL", async () => {
+		const stub = stubFetch([{ status: 200, body: {} }]);
+		const client = new DopplerRestClient({ token: "t", fetch: stub.fetch });
+		await client.request<unknown>("/configs/config/secret", {
+			query: { project: "demo", config: "dev", name: "API_KEY" },
+		});
+		expect(stub.calls[0]?.url).toMatch(/project=demo/);
+		expect(stub.calls[0]?.url).toMatch(/config=dev/);
+		expect(stub.calls[0]?.url).toMatch(/name=API_KEY/);
+	});
+
+	it("returns undefined on 204", async () => {
+		const stub = stubFetch([{ status: 204 }]);
+		const client = new DopplerRestClient({ token: "t", fetch: stub.fetch });
+		const res = await client.request<unknown>("/whatever");
+		expect(res).toBeUndefined();
+	});
+
+	it("returns undefined on expectNoContent even with 200", async () => {
+		const stub = stubFetch([{ status: 200, body: { ignored: true } }]);
+		const client = new DopplerRestClient({ token: "t", fetch: stub.fetch });
+		const res = await client.request<unknown>("/whatever", { expectNoContent: true });
+		expect(res).toBeUndefined();
+	});
+
+	it("throws ProviderApiError with the HTTP status on non-2xx", async () => {
+		const stub = stubFetch([{ status: 401, body: { messages: ["invalid token"] } }]);
+		const client = new DopplerRestClient({ token: "bad", fetch: stub.fetch });
+		try {
+			await client.request<unknown>("/me");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as ProviderApiError).status).toBe(401);
+			expect((err as ProviderApiError).message).toMatch(/→ 401/);
+		}
+	});
+
+	it("wraps transport-level failures with status 0", async () => {
+		const throwing: typeof fetch = async () => {
+			throw new TypeError("fetch failed");
+		};
+		const client = new DopplerRestClient({ token: "t", fetch: throwing });
+		try {
+			await client.request<unknown>("/me");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as ProviderApiError).status).toBe(0);
+			expect((err as ProviderApiError).message).toMatch(/TypeError: fetch failed/);
+		}
+	});
+
+	it("trims trailing slashes from the base URL", () => {
+		const client = new DopplerRestClient({ token: "t", baseUrl: "https://api.doppler.com/v3///" });
+		expect(client.baseUrl).toBe("https://api.doppler.com/v3");
+	});
+});

--- a/packages/holocron-plugin-doppler/src/__tests__/vault.test.ts
+++ b/packages/holocron-plugin-doppler/src/__tests__/vault.test.ts
@@ -1,0 +1,208 @@
+import { ProviderApiError } from "@theholocron/cli";
+import { describe, expect, it } from "vitest";
+
+import { DopplerVault } from "../capabilities/vault.js";
+import { DopplerRestClient } from "../rest.js";
+import { stubFetch } from "./helpers.js";
+
+function makeClient(responses: Array<{ status?: number; body?: unknown }>) {
+	const stub = stubFetch(responses);
+	const client = new DopplerRestClient({ token: "t", fetch: stub.fetch });
+	return { client, stub };
+}
+
+describe("DopplerVault constructor", () => {
+	it("throws when `project` is missing", () => {
+		const { client } = makeClient([]);
+		// @ts-expect-error deliberately missing project
+		expect(() => new DopplerVault(client, { config: "dev" })).toThrow(/project/);
+	});
+	it("throws when `config` is missing", () => {
+		const { client } = makeClient([]);
+		// @ts-expect-error deliberately missing config
+		expect(() => new DopplerVault(client, { project: "demo" })).toThrow(/config/);
+	});
+});
+
+describe("DopplerVault.read", () => {
+	it("hits GET /configs/config/secret with the parsed project/config/name", async () => {
+		const { client, stub } = makeClient([
+			{ status: 200, body: { name: "API_KEY", value: { raw: "raw-val", computed: "computed-val" } } },
+		]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		const value = await vault.read("doppler://demo/dev/API_KEY");
+		expect(value).toBe("computed-val");
+		expect(stub.calls[0]?.url).toMatch(/project=demo/);
+		expect(stub.calls[0]?.url).toMatch(/config=dev/);
+		expect(stub.calls[0]?.url).toMatch(/name=API_KEY/);
+	});
+
+	it("falls back to raw when computed is absent", async () => {
+		const { client } = makeClient([{ status: 200, body: { value: { raw: "raw-only" } } }]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		const value = await vault.read("doppler://demo/dev/API_KEY");
+		expect(value).toBe("raw-only");
+	});
+
+	it("rejects a reference that does not start with doppler://", async () => {
+		const { client } = makeClient([]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		try {
+			await vault.read("op://Vault/Item/field");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as Error).message).toMatch(/doppler:\/\//);
+		}
+	});
+
+	it("rejects a reference missing parts", async () => {
+		const { client } = makeClient([]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		try {
+			await vault.read("doppler://demo/dev");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as Error).message).toMatch(/missing parts/);
+		}
+	});
+});
+
+describe("DopplerVault.write", () => {
+	it("POSTs to /configs/config/secrets with a {name: value} body", async () => {
+		const { client, stub } = makeClient([{ status: 200, body: {} }]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		await vault.write("doppler://demo/dev/API_KEY", "dp.pt.new");
+		expect(stub.calls[0]?.method).toBe("POST");
+		expect(stub.calls[0]?.url).toMatch(/\/configs\/config\/secrets/);
+		expect(stub.calls[0]?.body).toEqual({
+			project: "demo",
+			config: "dev",
+			secrets: { API_KEY: "dp.pt.new" },
+		});
+	});
+});
+
+describe("DopplerVault.list", () => {
+	it("returns secret names from GET /configs/config/secrets", async () => {
+		const { client, stub } = makeClient([
+			{
+				status: 200,
+				body: {
+					secrets: {
+						API_KEY: { raw: "x", computed: "x" },
+						DB_URL: { raw: "y", computed: "y" },
+					},
+				},
+			},
+		]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		const keys = await vault.list();
+		expect(keys.sort()).toEqual(["API_KEY", "DB_URL"]);
+		expect(stub.calls[0]?.url).toMatch(/project=demo/);
+		expect(stub.calls[0]?.url).toMatch(/config=dev/);
+	});
+
+	it("returns [] when the response has no secrets", async () => {
+		const { client } = makeClient([{ status: 200, body: {} }]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		expect(await vault.list()).toEqual([]);
+	});
+});
+
+describe("DopplerVault.environments", () => {
+	it("lists environment slugs from GET /environments", async () => {
+		const { client } = makeClient([
+			{
+				status: 200,
+				body: {
+					environments: [
+						{ id: "dev", name: "Development", slug: "dev" },
+						{ id: "prd", name: "Production", slug: "prd" },
+					],
+				},
+			},
+		]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		expect(await vault.environments()).toEqual(["dev", "prd"]);
+	});
+
+	it("returns [] when the response has no environments", async () => {
+		const { client } = makeClient([{ status: 200, body: {} }]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		expect(await vault.environments()).toEqual([]);
+	});
+});
+
+describe("DopplerVault.readEnvironment", () => {
+	it("returns the KEY=VALUE map from /configs/config/secrets/download", async () => {
+		const { client, stub } = makeClient([{ status: 200, body: { API_KEY: "abc", DB_URL: "postgres://x" } }]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		const env = await vault.readEnvironment("stg");
+		expect(env).toEqual({ API_KEY: "abc", DB_URL: "postgres://x" });
+		expect(stub.calls[0]?.url).toMatch(/format=json/);
+		expect(stub.calls[0]?.url).toMatch(/config=stg/);
+	});
+
+	it("filters non-string values defensively", async () => {
+		const { client } = makeClient([{ status: 200, body: { A: "x", B: 42, C: null } }]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		const env = await vault.readEnvironment("dev");
+		expect(env).toEqual({ A: "x" });
+	});
+});
+
+describe("DopplerVault.ensureProject", () => {
+	it("returns alreadyExists:false when the create succeeds", async () => {
+		const { client, stub } = makeClient([{ status: 200, body: { project: { name: "demo" } } }]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		const result = await vault.ensureProject("demo");
+		expect(result).toEqual({ alreadyExists: false });
+		expect(stub.calls[0]?.method).toBe("POST");
+		expect(stub.calls[0]?.body).toMatchObject({ name: "demo" });
+	});
+
+	it("returns alreadyExists:true on 409", async () => {
+		const { client } = makeClient([{ status: 409, body: { messages: ["project already exists"] } }]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		const result = await vault.ensureProject("demo");
+		expect(result).toEqual({ alreadyExists: true });
+	});
+
+	it("returns alreadyExists:true on 422 with 'already exists' message", async () => {
+		const { client } = makeClient([{ status: 422, body: "project already exists" }]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		const result = await vault.ensureProject("demo");
+		expect(result).toEqual({ alreadyExists: true });
+	});
+
+	it("rethrows unrelated errors", async () => {
+		const { client } = makeClient([{ status: 500, body: "server error" }]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		try {
+			await vault.ensureProject("demo");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as ProviderApiError).status).toBe(500);
+		}
+	});
+});
+
+describe("DopplerVault.ensureEnvironment", () => {
+	it("POSTs to /environments with { project, name, slug } and returns not-existing on success", async () => {
+		const { client, stub } = makeClient([{ status: 200, body: {} }]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		const result = await vault.ensureEnvironment("demo", "dev");
+		expect(result).toEqual({ alreadyExists: false });
+		expect(stub.calls[0]?.method).toBe("POST");
+		expect(stub.calls[0]?.body).toEqual({ project: "demo", name: "dev", slug: "dev" });
+	});
+
+	it("returns alreadyExists:true on 409", async () => {
+		const { client } = makeClient([{ status: 409, body: {} }]);
+		const vault = new DopplerVault(client, { project: "demo", config: "dev" });
+		expect(await vault.ensureEnvironment("demo", "dev")).toEqual({ alreadyExists: true });
+	});
+});

--- a/packages/holocron-plugin-doppler/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-doppler/src/__tests__/verify-token.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { verifyToken } from "../verify-token.js";
+import { stubFetch } from "./helpers.js";
+
+describe("verifyToken", () => {
+	it("returns ok with a subject when /v3/me returns 200", async () => {
+		const stub = stubFetch([{ status: 200, body: { type: "personal", workplace: { name: "acme" } } }]);
+		const result = await verifyToken("dp.pt.abc", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/personal @ acme/);
+		}
+	});
+
+	it("falls back to slug when workplace.name is absent", async () => {
+		const stub = stubFetch([{ status: 200, body: { type: "cli", slug: "cnewton" } }]);
+		const result = await verifyToken("dp.ct.xyz", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/cli @ cnewton/);
+		}
+	});
+
+	it("returns ok:false with the error message on 401", async () => {
+		const stub = stubFetch([{ status: 401, body: { messages: ["Invalid API token"] } }]);
+		const result = await verifyToken("bad", { fetch: stub.fetch });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/→ 401/);
+		}
+	});
+
+	it("returns ok:false when the network layer throws", async () => {
+		const throwing: typeof fetch = async () => {
+			throw new TypeError("network down");
+		};
+		const result = await verifyToken("anything", { fetch: throwing });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/network down/);
+		}
+	});
+
+	it("hits the configured base URL", async () => {
+		const stub = stubFetch([{ status: 200, body: { workplace: { name: "x" } } }]);
+		await verifyToken("t", { fetch: stub.fetch, baseUrl: "https://custom.example.com/v3" });
+		expect(stub.calls[0]?.url).toMatch(/^https:\/\/custom\.example\.com\/v3\/me/);
+	});
+});

--- a/packages/holocron-plugin-doppler/src/auth.ts
+++ b/packages/holocron-plugin-doppler/src/auth.ts
@@ -1,0 +1,39 @@
+/**
+ * Token resolution for the Doppler plugin.
+ *
+ * Resolution order (matches the standard 4-step precedence set by
+ * `.notes/tech-auth-bootstrap.spec.md`):
+ *   1. explicit `cliToken` argument (from `--token` flag)
+ *   2. HOLOCRON_DOPPLER_TOKEN env var (preferred — explicit intent)
+ *   3. DOPPLER_TOKEN env var (Doppler-native, works in CI)
+ *   4. keyring (com.theholocron.cli / "doppler")
+ *   5. AuthError with a hint pointing at `doppler configure`
+ */
+
+import { getToken as getKeyringToken } from "@theholocron/cli";
+
+export class AuthError extends Error {
+	override name = "AuthError";
+}
+
+export interface ResolveTokenInput {
+	/** From `--token` CLI flag. */
+	cliToken?: string;
+	/** Env vars; passed in for testability. Defaults to `process.env`. */
+	env?: NodeJS.ProcessEnv;
+	/** Keyring lookup fn; passed in for testability. Defaults to `getToken(provider)`. */
+	keyring?: (provider: string) => string | null;
+}
+
+export function resolveToken(input: ResolveTokenInput = {}): string {
+	const env = input.env ?? process.env;
+	const keyring = input.keyring ?? getKeyringToken;
+	const token = input.cliToken || env.HOLOCRON_DOPPLER_TOKEN || env.DOPPLER_TOKEN || keyring("doppler");
+	if (!token) {
+		throw new AuthError(
+			"no Doppler token found. Pass --token <TOKEN>, set HOLOCRON_DOPPLER_TOKEN / DOPPLER_TOKEN, " +
+				"or run: holocron auth set doppler $(doppler configure get token --plain)"
+		);
+	}
+	return token;
+}

--- a/packages/holocron-plugin-doppler/src/capabilities/vault.ts
+++ b/packages/holocron-plugin-doppler/src/capabilities/vault.ts
@@ -1,0 +1,200 @@
+/**
+ * `vault` capability for Doppler.
+ *
+ * Reference format: `doppler://<project>/<config>/<name>` — three
+ * parts, mirrors 1P's `op://Vault/Item/field`. The plugin options can
+ * carry a default project + config so `list()` / `environments()` /
+ * `readEnvironment()` don't need a three-part ref.
+ *
+ * Doppler's data model:
+ *   - Projects (top-level)
+ *   - Environments — dev / stg / prd (each has a root config with the
+ *     same name)
+ *   - Configs — the root configs plus optional branch configs (e.g.,
+ *     `dev_local`, `dev_ci`). `holocron secrets sync` reads from
+ *     configs, not environments.
+ *
+ * Write semantics: `POST /v3/configs/config/secrets` accepts a
+ * `{name: value}` map and upserts. No probe-then-act dance needed.
+ *
+ * Bootstrap semantics: `ensureProject` / `ensureEnvironment` treat
+ * "already exists" (409) as success. Doppler returns 409 with a
+ * `messages` array; the plugin's REST client wraps it as
+ * ProviderApiError with `status: 409` which we catch and swallow.
+ */
+
+import { ProviderApiError } from "@theholocron/cli";
+import type { EnsureResult, Vault } from "@theholocron/cli";
+
+import type { DopplerRestClient } from "../rest.js";
+
+export interface DopplerVaultOptions {
+	/** Default project — read/list/etc. operate here unless overridden. */
+	project: string;
+	/** Default config name — dev / stg / prd, etc. */
+	config: string;
+}
+
+interface SecretsListResponse {
+	secrets?: Record<string, { raw?: string; computed?: string } | null>;
+}
+
+interface SecretReadResponse {
+	name?: string;
+	value?: { raw?: string; computed?: string } | null;
+}
+
+interface SecretsDownloadResponse {
+	// `format=json` returns `{NAME: "value", ...}` at the top level.
+	[key: string]: string;
+}
+
+interface EnvironmentsListResponse {
+	environments?: Array<{ id?: string; name?: string; slug?: string }>;
+}
+
+export class DopplerVault implements Vault {
+	readonly key = "vault" as const;
+	readonly providerName = "doppler";
+
+	private readonly project: string;
+	private readonly config: string;
+
+	constructor(
+		private readonly rest: DopplerRestClient,
+		opts: DopplerVaultOptions
+	) {
+		if (!opts.project) {
+			throw new Error("DopplerVault requires `project` in options");
+		}
+		if (!opts.config) {
+			throw new Error("DopplerVault requires `config` in options");
+		}
+		this.project = opts.project;
+		this.config = opts.config;
+	}
+
+	// ── read / write ────────────────────────────────────────────────────
+
+	async read(reference: string): Promise<string> {
+		const parsed = parseReference(reference);
+		const res = await this.rest.request<SecretReadResponse>("/configs/config/secret", {
+			query: { project: parsed.project, config: parsed.config, name: parsed.name },
+		});
+		return res.value?.computed ?? res.value?.raw ?? "";
+	}
+
+	async write(reference: string, value: string): Promise<void> {
+		const parsed = parseReference(reference);
+		await this.rest.request<unknown>("/configs/config/secrets", {
+			method: "POST",
+			body: {
+				project: parsed.project,
+				config: parsed.config,
+				secrets: { [parsed.name]: value },
+			},
+		});
+	}
+
+	async list(): Promise<string[]> {
+		const res = await this.rest.request<SecretsListResponse>("/configs/config/secrets", {
+			query: { project: this.project, config: this.config },
+		});
+		return Object.keys(res.secrets ?? {});
+	}
+
+	// ── environments ────────────────────────────────────────────────────
+
+	async environments(): Promise<string[]> {
+		const res = await this.rest.request<EnvironmentsListResponse>("/environments", {
+			query: { project: this.project },
+		});
+		return (res.environments ?? []).map((e) => e.slug ?? e.name ?? "").filter(Boolean);
+	}
+
+	async readEnvironment(environmentId: string): Promise<Record<string, string>> {
+		const res = await this.rest.request<SecretsDownloadResponse>("/configs/config/secrets/download", {
+			query: { project: this.project, config: environmentId, format: "json" },
+		});
+		// Filter out any non-string entries defensively.
+		const out: Record<string, string> = {};
+		for (const [k, v] of Object.entries(res)) {
+			if (typeof v === "string") out[k] = v;
+		}
+		return out;
+	}
+
+	// ── bootstrap ───────────────────────────────────────────────────────
+
+	async ensureProject(name: string): Promise<EnsureResult> {
+		try {
+			await this.rest.request<unknown>("/projects", {
+				method: "POST",
+				body: { name, description: `Managed by holocron` },
+			});
+			return { alreadyExists: false };
+		} catch (err) {
+			if (isConflict(err)) return { alreadyExists: true };
+			throw err;
+		}
+	}
+
+	async ensureEnvironment(project: string, name: string): Promise<EnsureResult> {
+		try {
+			await this.rest.request<unknown>("/environments", {
+				method: "POST",
+				body: { project, name, slug: name },
+			});
+			return { alreadyExists: false };
+		} catch (err) {
+			if (isConflict(err)) return { alreadyExists: true };
+			throw err;
+		}
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+interface ParsedReference {
+	project: string;
+	config: string;
+	name: string;
+}
+
+/**
+ * Parse `doppler://project/config/name` into its parts. Throws when
+ * the shape doesn't match — surfacing bad inputs at the boundary keeps
+ * downstream REST calls from emitting cryptic errors.
+ */
+function parseReference(reference: string): ParsedReference {
+	if (!reference.startsWith("doppler://")) {
+		throw new ProviderApiError(
+			`Doppler references must start with "doppler://": got "${reference}"`,
+			400,
+			undefined
+		);
+	}
+	const rest = reference.slice("doppler://".length);
+	const parts = rest.split("/");
+	if (parts.length < 3) {
+		throw new ProviderApiError(
+			`Doppler reference "${reference}" missing parts; expected doppler://project/config/name`,
+			400,
+			undefined
+		);
+	}
+	const [project, config, ...nameParts] = parts;
+	return { project: project!, config: config!, name: nameParts.join("/") };
+}
+
+/**
+ * Doppler returns 409 (or 422 with a "already exists" message body)
+ * on duplicate create. The REST client wraps both as ProviderApiError.
+ * We treat either as "already exists" for idempotent ensure* calls.
+ */
+function isConflict(err: unknown): boolean {
+	if (!(err instanceof ProviderApiError)) return false;
+	if (err.status === 409) return true;
+	if (err.status === 422 && typeof err.details === "string" && /already exists/i.test(err.details)) return true;
+	return false;
+}

--- a/packages/holocron-plugin-doppler/src/index.ts
+++ b/packages/holocron-plugin-doppler/src/index.ts
@@ -1,0 +1,66 @@
+/**
+ * `@theholocron/holocron-plugin-doppler` — entrypoint.
+ *
+ * Implements the `vault` capability against Doppler's REST API. Also
+ * exports `verifyToken` + `AUTH_HINT` for `holocron auth`. See README
+ * for auth + config docs.
+ */
+
+import type { Vault } from "@theholocron/cli";
+
+import { resolveToken, type ResolveTokenInput } from "./auth.js";
+import { DopplerVault, type DopplerVaultOptions } from "./capabilities/vault.js";
+import { DopplerRestClient } from "./rest.js";
+
+export interface DopplerPluginOptions extends ResolveTokenInput, DopplerVaultOptions {
+	/** Override base URL for tests. */
+	baseUrl?: string;
+	/** Override `fetch` for tests. */
+	fetch?: typeof fetch;
+}
+
+export interface PluginContext {
+	options: DopplerPluginOptions;
+	rest: DopplerRestClient;
+}
+
+export function createContext(options: DopplerPluginOptions): PluginContext {
+	const token = resolveToken(options);
+	const restOpts: ConstructorParameters<typeof DopplerRestClient>[0] = { token };
+	if (options.baseUrl !== undefined) restOpts.baseUrl = options.baseUrl;
+	if (options.fetch !== undefined) restOpts.fetch = options.fetch;
+	return {
+		options,
+		rest: new DopplerRestClient(restOpts),
+	};
+}
+
+export function vault(ctx: PluginContext): Vault {
+	return new DopplerVault(ctx.rest, { project: ctx.options.project, config: ctx.options.config });
+}
+
+export function createPlugin(options: DopplerPluginOptions) {
+	const ctx = createContext(options);
+	return {
+		name: "@theholocron/holocron-plugin-doppler",
+		capabilities: {
+			vault: () => vault(ctx),
+		},
+	};
+}
+
+/**
+ * One-line hint shown by `holocron auth set doppler` when no token is
+ * supplied or when the supplied token is rejected.
+ */
+export const AUTH_HINT =
+	"install the Doppler CLI (`brew install dopplerhq/cli/doppler`), run `doppler login`, then " +
+	"`holocron auth set doppler $(doppler configure get token --plain)`";
+
+// ── Public re-exports ────────────────────────────────────────────────
+
+export * from "./auth.js";
+export { DopplerRestClient } from "./rest.js";
+export { DopplerVault } from "./capabilities/vault.js";
+export { verifyToken } from "./verify-token.js";
+export type { VerifyTokenResult, VerifyTokenSuccess, VerifyTokenFailure } from "./verify-token.js";

--- a/packages/holocron-plugin-doppler/src/rest.ts
+++ b/packages/holocron-plugin-doppler/src/rest.ts
@@ -1,0 +1,75 @@
+/**
+ * Thin REST wrapper around api.doppler.com/v3.
+ *
+ * Same pattern as the GitHub / Vercel / Neon REST clients — bearer
+ * auth, JSON-only bodies, transport-failure wrapping with `status: 0`
+ * so the orchestrator's soft-skip path sees a clear "Doppler GET /path
+ * failed" message instead of a generic `TypeError: fetch failed`.
+ */
+
+import { ProviderApiError } from "@theholocron/cli";
+
+export interface RestClientOptions {
+	token: string;
+	fetch?: typeof fetch;
+	baseUrl?: string;
+}
+
+export interface RequestOptions {
+	method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+	body?: unknown;
+	query?: Record<string, string>;
+	/** Treat this response as void even if 200 is returned. */
+	expectNoContent?: boolean;
+}
+
+export class DopplerRestClient {
+	private readonly token: string;
+	private readonly fetchImpl: typeof fetch;
+	readonly baseUrl: string;
+
+	constructor(opts: RestClientOptions) {
+		this.token = opts.token;
+		this.fetchImpl = opts.fetch ?? globalThis.fetch;
+		// Manual trailing-slash trim — CodeQL flags regex on library
+		// input as polynomial ReDoS. O(n) loop, no backtracking risk.
+		let url = opts.baseUrl ?? "https://api.doppler.com/v3";
+		while (url.endsWith("/")) url = url.slice(0, -1);
+		this.baseUrl = url;
+	}
+
+	async request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
+		const url = new URL(`${this.baseUrl}${path.startsWith("/") ? path : "/" + path}`);
+		for (const [k, v] of Object.entries(opts.query ?? {})) url.searchParams.set(k, v);
+		const fullUrl = url.toString();
+
+		const headers: Record<string, string> = {
+			authorization: `Bearer ${this.token}`,
+			accept: "application/json",
+		};
+		const init: RequestInit = {
+			method: opts.method ?? "GET",
+			headers,
+		};
+		if (opts.body !== undefined) {
+			headers["content-type"] = "application/json";
+			init.body = JSON.stringify(opts.body);
+		}
+
+		let res: Response;
+		try {
+			res = await this.fetchImpl(fullUrl, init);
+		} catch (err) {
+			const detail = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+			throw new ProviderApiError(`Doppler ${init.method} ${path} failed: ${detail}`, 0, undefined);
+		}
+		if (!res.ok) {
+			const body = await res.text().catch(() => "");
+			throw new ProviderApiError(`Doppler ${init.method} ${path} → ${res.status}`, res.status, body);
+		}
+		if (opts.expectNoContent || res.status === 204) return undefined as T;
+		const text = await res.text();
+		if (!text) return undefined as T;
+		return JSON.parse(text) as T;
+	}
+}

--- a/packages/holocron-plugin-doppler/src/verify-token.ts
+++ b/packages/holocron-plugin-doppler/src/verify-token.ts
@@ -1,0 +1,56 @@
+/**
+ * `verifyToken` — plugin-level export used by `holocron auth set` +
+ * `holocron auth check`. Hits `GET /v3/me` and translates the response
+ * into the normalized `VerifyTokenResult` shape.
+ *
+ * Kept as a standalone function (not a capability method) so the auth
+ * command can call it without initializing the full plugin — plugin
+ * construction requires an already-resolved token, which is exactly
+ * what we don't have yet at bootstrap time.
+ */
+
+import { DopplerRestClient } from "./rest.js";
+
+export interface VerifyTokenSuccess {
+	ok: true;
+	subject: string;
+}
+
+export interface VerifyTokenFailure {
+	ok: false;
+	message: string;
+}
+
+export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
+
+interface MeResponse {
+	/** Token type: "cli", "personal", "service", "service_account". */
+	type?: string;
+	/** Workplace-level identifier. */
+	slug?: string;
+	/** Workplace object (present on account-level tokens). */
+	workplace?: { name?: string; slug?: string };
+	/** Present on user tokens. */
+	name?: string;
+}
+
+export interface VerifyTokenOptions {
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+export async function verifyToken(token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
+	const restOpts: ConstructorParameters<typeof DopplerRestClient>[0] = { token };
+	if (opts.baseUrl !== undefined) restOpts.baseUrl = opts.baseUrl;
+	if (opts.fetch !== undefined) restOpts.fetch = opts.fetch;
+	const rest = new DopplerRestClient(restOpts);
+	try {
+		const me = await rest.request<MeResponse>("/me");
+		const workplace = me.workplace?.name ?? me.slug ?? "unknown";
+		const kind = me.type ?? "token";
+		return { ok: true, subject: `${kind} @ ${workplace}` };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { ok: false, message };
+	}
+}

--- a/packages/holocron-plugin-doppler/tsconfig.json
+++ b/packages/holocron-plugin-doppler/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "display": "Holocron Plugin: Doppler",
+  "extends": "@tsconfig/node-lts/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/holocron-plugin-doppler/tsdown.config.ts
+++ b/packages/holocron-plugin-doppler/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	format: "esm",
+	dts: true,
+	clean: true,
+	deps: { neverBundle: [/^@theholocron\//] },
+});

--- a/packages/holocron-plugin-doppler/vitest.config.ts
+++ b/packages/holocron-plugin-doppler/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+		globals: false,
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "json-summary"],
+			include: ["src/**/*.ts"],
+			exclude: ["src/**/__tests__/**", "src/**/*.test.ts", "src/index.ts"],
+			thresholds: { lines: 0, functions: 0, branches: 0, statements: 0 },
+		},
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,36 @@ importers:
         specifier: 'catalog:'
         version: 3.2.6(@types/debug@4.1.13)(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
 
+  packages/holocron-plugin-doppler:
+    devDependencies:
+      '@theholocron/cli':
+        specifier: workspace:*
+        version: link:../cli
+      '@theholocron/tsconfig':
+        specifier: 'catalog:'
+        version: 4.1.0(tsc@2.0.4)(typescript@5.9.3)
+      '@tsconfig/node-lts':
+        specifier: 'catalog:'
+        version: 24.0.0
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.4(jiti@2.6.1)
+      globals:
+        specifier: 'catalog:'
+        version: 16.5.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+
   packages/holocron-plugin-github:
     dependencies:
       libsodium-wrappers:


### PR DESCRIPTION
… for 1P

First real user of the keyring-backed bootstrap credential foundation (landed in #94). Implements the `vault` capability against Doppler's REST API and exports `verifyToken` + `AUTH_HINT` so `holocron auth` can verify and store tokens.

- **`@theholocron/holocron-plugin-doppler`** — 14-file REST plugin. 4-step auth precedence (`--token` → `HOLOCRON_DOPPLER_TOKEN` → `DOPPLER_TOKEN` → keyring). Reference format `doppler://<project>/<config>/<name>`. Vault methods: `read`, `write`, `list`, `environments`, `readEnvironment`, plus the new `ensureProject` / `ensureEnvironment` bootstrap methods so `holocron setup` provisions the project + `dev`/`stg`/`prd` configs on first run. `verifyToken` hits `GET /v3/me`. `AUTH_HINT` walks operators through `brew install dopplerhq/cli/doppler && doppler login && holocron auth set doppler $(doppler configure get token --plain)`.
- **`@theholocron/holocron-plugin-1password`** — added `verifyToken` and `AUTH_HINT` exports so 1P conforms to the plugin auth convention. Since 1P uses the `op` CLI's own auth (not a bearer token), `verifyToken` ignores its token arg and runs `op whoami`; `AUTH_HINT` directs operators at `op signin` (laptop) or `OP_SERVICE_ACCOUNT_TOKEN` (CI) rather than the keyring.
- **`.claude/skills/holocron-plugin.md`** — updated the plugin scaffolding skill to document the 4-step auth precedence + the `verifyToken` / `AUTH_HINT` plugin-level exports so future plugins are generated with them built in.

Design captured in `.notes/tech-auth-bootstrap.spec.md` and `.notes/tech-vault-choice.spec.md`.

40 new tests for the Doppler plugin (auth/rest/verify-token/vault/ index), 5 new tests for 1P's verifyToken. All packages typecheck + lint + test clean.