### PR TITLE
feat(cli): `holocron plugin create <slug> <vendor>` (#77 Phase 1a)

### DIFF
--- a/.claude/skills/holocron-plugin.md
+++ b/.claude/skills/holocron-plugin.md
@@ -1,193 +1,55 @@
 ---
 name: holocron-plugin
-description: Scaffold a new @theholocron/holocron-plugin-<slug> package matching the proven template (auth + REST + capability impl + tests). Use when adding a plugin for a new vendor or extracting an existing Rando adapter.
+description: Scaffold a new @theholocron/holocron-plugin-<slug> package. Since v2.0.0-alpha, this is a first-class CLI command — use it directly.
 ---
 
 <!-- editorconfig-checker-disable-file -->
 
 # Scaffold a new holocron plugin
 
-Use this skill when the user asks for a new holocron plugin (Clerk, Doppler,
-Cloudflare, etc.) or when porting one of Rando's existing adapters into a
-plugin package. The output matches the structure that's already been proven
-in `packages/holocron-plugin-{github,vercel,neon}`.
-
-## What you generate
-
-This skill produces ~14 files under `packages/holocron-plugin-<slug>/`:
-
-- `package.json` — workspace package, peer-deps `@theholocron/cli`
-- `tsconfig.json` — extends `@tsconfig/node-lts`
-- `vitest.config.ts` — v8 coverage, node env
-- `eslint.config.js` — re-exports the root config
-- `README.md` — auth instructions, config example, status
-- `src/auth.ts` — 4-step token resolver (`--token` → `HOLOCRON_<VENDOR>_<KIND>` → vendor-native env → **keyring**)
-- `src/rest.ts` — bearer + transport-failure wrapping (`status: 0` on DNS/TCP/TLS)
-- `src/verify-token.ts` — plugin-level `verifyToken(token)` export used by `holocron auth`
-- `src/index.ts` — `createPlugin(options)` + `verifyToken` + `AUTH_HINT` exports
-- `src/capabilities/<capability>.ts` — class implementing the capability interface, methods stubbed
-- `src/__tests__/helpers.ts` — `stubFetch` (port of the rando helper)
-- `src/__tests__/auth.test.ts` — token resolution (all 4 precedence steps)
-- `src/__tests__/rest.test.ts` — REST client behavior
-- `src/__tests__/verify-token.test.ts` — verifyToken success + failure paths
-- `src/__tests__/<capability>.test.ts` — capability behavior (one passing smoke test per stub method)
-- `src/__tests__/index.test.ts` — `createPlugin()` wires everything + `AUTH_HINT` sanity check
-
-What it does NOT generate: actual API method bodies. Those are vendor-specific
-and easy to get wrong — scaffold and stubs only; the human (or the next
-conversation turn) fills in the real implementations.
-
-## Step 1 — gather inputs
-
-Use `AskUserQuestion` to collect the following BEFORE writing any files. Group
-into one or two question batches; don't ask one at a time.
-
-| Input               | Required | Example                                                                           |
-| ------------------- | -------- | --------------------------------------------------------------------------------- |
-| Plugin slug         | yes      | `clerk`, `doppler`, `cloudflare`                                                  |
-| Vendor display name | yes      | `Clerk`, `Doppler`, `Cloudflare`                                                  |
-| Capability key      | yes      | `auth`, `vault`, `dns`, `tooling`, `notifications` (one of the 14 in CARDINALITY) |
-| Holocron token env  | yes      | `HOLOCRON_CLERK_TOKEN`                                                            |
-| Vendor-native env   | yes      | `CLERK_SECRET_KEY`                                                                |
-| Base URL            | yes      | `https://api.clerk.com/v1`                                                        |
-| Rando source path   | no       | `packages/cli/src/adapters/clerk.ts` if porting                                   |
-
-If the capability is `many`-cardinality (per `CARDINALITY` in
-`packages/cli/src/capabilities/index.ts`), warn the operator and confirm —
-those need multiple instances to be active at once and the test patterns are
-slightly different.
-
-## Step 2 — verify the slug isn't taken
+Since v2.0.0-alpha, plugin scaffolding is a first-class CLI command.
+Skip this skill; just run:
 
 ```bash
-ls packages/holocron-plugin-<slug> 2>/dev/null && echo "exists"
+pnpm holocron plugin create <slug> <vendor> \
+    --capability <key> \
+    --vendor-env <VENDOR_NATIVE_ENV_NAME> \
+    --base-url <https://api.vendor.example>
 ```
 
-If the directory exists, error out with a clear "already scaffolded" message —
-do NOT overwrite an existing plugin.
+The command produces 17 files under `packages/holocron-plugin-<slug>/`
+matching the same template this skill used to hand-craft:
 
-## Step 3 — write the files
+- 5 config files (`package.json`, `tsconfig.json`, `vitest.config.ts`,
+  `eslint.config.js`, `tsdown.config.ts`)
+- 1 `README.md`
+- 5 source files (`auth.ts` with 4-step keyring precedence, `rest.ts`,
+  `verify-token.ts`, `index.ts` with `AUTH_HINT` export,
+  `capabilities/<key>.ts` stub)
+- 6 test files (`helpers.ts`, `auth.test.ts`, `rest.test.ts`,
+  `verify-token.test.ts`, `<key>.test.ts` with `it.todo`,
+  `index.test.ts`)
 
-Use the existing plugins as the structural reference. The general rule: copy
-the structure from `packages/holocron-plugin-neon/` (the cleanest of the
-three), then substitute the plugin-specific names. Key substitutions:
+Then follow the "Next" steps printed by the command:
 
-- `Neon` → `<VendorName>` (PascalCase)
-- `neon` → `<slug>` (kebab-case)
-- `NEON` → `<VENDOR>` (UPPER)
-- `HOLOCRON_NEON_API_KEY` → operator's chosen holocron env name
-- `NEON_API_KEY` → operator's chosen vendor-native env name
-- `https://console.neon.tech/api/v2` → base URL
-- `NeonStorage` (capability class) → `<VendorName><CapabilityName>`
-- `storage` (capability key) → operator's chosen capability key
+1. `pnpm install`
+2. `pnpm --filter @theholocron/holocron-plugin-<slug> typecheck lint test`
+3. Fill in the `<VendorName><Capability>` class methods against the
+   capability interface in `packages/cli/src/capabilities/index.ts`.
+4. Replace `it.todo(...)` with real tests.
+5. Commit + push when the capability is functionally complete.
 
-The capability class methods are STUBS — each declared method has a `throw new
-Error('not implemented')` body. The corresponding test cases are skipped via
-`it.todo(...)`. Both the operator and the next conversation turn know
-implementations are incoming.
+## Design context
 
-### Patterns that are non-negotiable
+- `.notes/tool-plugin-create.spec.md` — the CLI's own design spec.
+- `.notes/tech-auth-bootstrap.spec.md` — the 4-step token precedence
+  every plugin's `auth.ts` follows (`--token` → `HOLOCRON_<X>_TOKEN`
+  → `<vendor>-native env` → keyring lookup → `AuthError`).
+- `.notes/tech-vault-choice.spec.md` — the reasoning that made
+  Doppler + Infisical (and the keyring foundation) part of v2.
 
-- **Standards.** Every plugin honors the 4 holocron-wide conventions listed under "Holocron standards" below (see also `.notes/tech-architecture.spec.md` §Standards).
-- **Auth**: token resolution order is always **4 steps**: `--token` → `HOLOCRON_<X>_TOKEN` → `<vendor-native>_TOKEN` → **keyring lookup** (`getToken(providerSlug)` from `@theholocron/cli`) → `AuthError` naming all four options. See `packages/holocron-plugin-doppler/src/auth.ts` for the canonical shape.
-- **REST**: wrap transport failures (`TypeError: fetch failed`) into `ProviderApiError` with `status: 0`. Include the path in the message so callers see which call broke.
-- **204 handling**: return `undefined` from `request<T>` on 204 OR when `expectNoContent: true` is set.
-- **Tests use `stubFetch`**: copy the helper verbatim from `packages/holocron-plugin-neon/src/__tests__/helpers.ts`. The Response constructor rejects bodies on 204 — the helper handles that.
-- **Workspace + catalog deps**: `@theholocron/tsconfig`, `@tsconfig/node-lts`, `eslint`, `globals`, `typescript`, `vitest`, `@vitest/coverage-v8` all resolve via `catalog:` from `pnpm-workspace.yaml`.
-- **Peer-deps**: `@theholocron/cli` is BOTH a peer dep AND a devDep at `workspace:*` (the devDep lets tests resolve the types).
-- **Underscore-prefix unused params, no eslint-disable comments.** The workspace ESLint config already has `argsIgnorePattern: '^_'` + `varsIgnorePattern: '^_'`. Adding `// eslint-disable-next-line @typescript-eslint/no-unused-vars` triggers the unused-directive lint warning. Just use `_name` and stop.
-- **Don't `expect(...).toThrow()` twice on the same stubbed call.** The stub queue (`stubFetch` / `stubSpawn`) advances on every invocation. Calling the same async-with-fetch method twice exhausts the queued responses and the second call returns the default empty response — the assertion silently passes when it shouldn't, or fails for the wrong reason. Instead, wrap in `try/catch` and assert properties on the caught error — see "Correct expect-throws pattern" below.
+## Command source
 
-### Holocron standards
-
-1. `--dry-run` is a global CLI flag flowing through `RuntimeContext.dryRun`. Commands branch on it; capabilities don't accept per-method dryRun args.
-2. `--token` is a global CLI flag flowing through `RuntimeContext.cliToken`. The plugin's `auth.ts` treats it as the first precedence in token resolution.
-3. For plugins that fire webhook-shaped events (auth, anything fires events on CRUD ops), export a `parseWebhook(input): NormalizedEvent` utility alongside `createPlugin`. The normalized event shape lives in `@theholocron/cli`; the plugin's job is just to translate.
-4. Every plugin exports a top-level `verifyToken(token)` + `AUTH_HINT` string (see `.notes/tech-auth-bootstrap.spec.md`). `holocron auth set/check` calls them to verify credentials before storing / after retrieving from the OS keyring.
-
-### Correct expect-throws pattern
-
-```ts
-try {
-	await something();
-	throw new Error("expected throw");
-} catch (err) {
-	expect(err).toBeInstanceOf(SomeError);
-	expect((err as SomeError).message).toMatch(/regex/);
-}
-```
-
-## Step 4 — install + verify
-
-ALL commands must run from the holocron repo root (`/path/to/theholocron/holocron`).
-If the active shell is in another directory (e.g., a sibling project), `cd`
-first — pnpm filters silently match nothing when run outside the workspace.
-
-```bash
-cd /path/to/theholocron/holocron
-pnpm install                                                 # picks up the new workspace package
-pnpm --filter @theholocron/holocron-plugin-<slug> typecheck   # green
-pnpm --filter @theholocron/holocron-plugin-<slug> lint        # green
-pnpm --filter @theholocron/holocron-plugin-<slug> test        # green (stubs pass, real tests are it.todo)
-```
-
-If ANY of these fail, surface the failure verbatim to the operator and stop —
-the scaffold is broken and shouldn't be committed.
-
-## Step 5 — print next steps
-
-Show the operator a short summary:
-
-```
-✓ scaffolded packages/holocron-plugin-<slug>/ (14 files)
-✓ typecheck + lint + test green
-
-Next:
-	1. Implement <Capability> methods in src/capabilities/<capability>.ts
-	2. Replace `it.todo(...)` with real tests in src/__tests__/<capability>.test.ts
-	3. Update README "What's implemented" section as you go
-	4. Commit + push when capability is functionally complete
-```
-
-Don't commit. The skill stops at "scaffold + verify"; the human commits when
-the capability is meaningfully implemented.
-
-## Reference: known capability keys
-
-Confirm the chosen capability key is one of these (from
-`packages/cli/src/capabilities/index.ts`):
-
-`source`, `ci`, `secrets`, `environments`, `issues`, `deployment`, `storage`,
-`auth`, `vault`, `dns`, `tooling`, `notifications`, `analytics`,
-`observability`.
-
-If the operator wants a capability not in this list, that's a core change
-first — the capability interface needs to be added to
-`packages/cli/src/capabilities/index.ts` and `CARDINALITY` extended.
-
-## Reference: Rando porting checklist
-
-When porting an existing Rando adapter, also:
-
-- Find the Rando source: `find /Users/archives/Code/rando/rando/packages/cli/src -name "*<slug>*"`
-- Compare Rando's interface against the holocron capability interface BEFORE
-  writing code. Adjust the holocron interface in core if the Rando shape
-  reveals a mismatch — that's what happened with `Deployment`
-  (drop `promote`/`listDeployments`, add `triggerDeployment`/`getDeployment`)
-  and `Storage` (replace target-based `getConnectionString` with
-  scope-based + pooled option).
-- Port the implementation method-by-method. Keep Rando's comments where they
-  document non-obvious gotchas (e.g., Neon's `endpoints[{type: 'read_write'}]`
-  inline create, GitHub's reviewer numeric-id-only).
-- Port the tests too — they're the proof the port preserves semantics.
-
-## When NOT to use this skill
-
-- The capability needs a transport other than REST (e.g., a CLI shell-out).
-  The auth + REST primitives don't apply; structure differs. Use the manual
-  approach + propose a transport-adapter interface (see issue #76).
-- The plugin is a "config package" rather than a real implementation (see
-  the level-1 shareable-configs design in issue #75). The structure for those
-  is different.
-- The work is a one-off tweak to an existing plugin, not a new one. Edit the
-  existing package directly.
+`packages/cli/src/commands/plugin-create/` — 17 templates + orchestrator
++ unit tests. Editing a template ripples to every future plugin
+scaffolded by this command.

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -6,7 +6,11 @@
   "IgnoreDefaults": false,
   "SpacesAfterTabs": false,
   "NoColor": false,
-  "Exclude": ["^LICENSE$", "^public/.*"],
+  "Exclude": [
+    "^LICENSE$",
+    "^public/.*",
+    "^packages/cli/src/commands/plugin-create/templates/.*"
+  ],
   "AllowedContentTypes": [],
   "PassedFiles": [],
   "Disable": {

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -6,11 +6,7 @@
   "IgnoreDefaults": false,
   "SpacesAfterTabs": false,
   "NoColor": false,
-  "Exclude": [
-    "^LICENSE$",
-    "^public/.*",
-    "^packages/cli/src/commands/plugin-create/templates/.*"
-  ],
+  "Exclude": ["^LICENSE$", "^public/.*", "^packages/cli/src/commands/plugin-create/templates/.*"],
   "AllowedContentTypes": [],
   "PassedFiles": [],
   "Disable": {

--- a/.notes/tool-plugin-create.spec.md
+++ b/.notes/tool-plugin-create.spec.md
@@ -8,13 +8,21 @@ blocked-by: []
 
 # `holocron plugin create <slug> <vendor>`
 
-> **Phased.** Phase 1 (REST-only) is unblocked and can ship
-> standalone — REST is the only transport that exists today and the
-> skill already covers this shape. Phase 2 (`--transport cli`
-> variant) is gated on #76 (per-plugin `transport` option in
-> `holocron.config.json`) and #78 (CLI-transport sibling skill);
-> adding the flag later is additive and won't reshape Phase 1's
-> template surface. Phase 3 (`--from-rando`) is a nice-to-have.
+> **Phased.** Phase 1 (REST-only) **shipped** on `alpha` — 17
+> templates, subcommand wired, orchestrator + preflight + slug
+> collision + capability validation + generate + print-next-steps.
+> The skill file is a stub pointing at the CLI.
+>
+> **Prompts + verify are follow-ups** (see §Roadmap). The command
+> currently errors clearly when `--capability` / `--vendor-env` /
+> `--base-url` are missing; interactive prompts + post-scaffold
+> `pnpm install + typecheck + lint + test` are next.
+>
+> Phase 2 (`--transport cli` variant) is gated on #76 (per-plugin
+> `transport` option in `holocron.config.json`) and #78
+> (CLI-transport sibling skill); adding the flag later is additive
+> and won't reshape Phase 1's template surface. Phase 3
+> (`--from-rando`) is a nice-to-have.
 
 ## Decision
 
@@ -69,53 +77,76 @@ which also mix positional + interactive prompts.
 
 ## Behavior — happy path
 
-1. **Preflight**: verify CWD is a holocron workspace root
+Legend: ✅ shipped in Phase 1a · ⏳ Phase 1b follow-up.
+
+1. **Preflight** ✅ — verify CWD is a holocron workspace root
    (`pnpm-workspace.yaml` + `packages/` dir present). If not, error
-   with the same message pnpm gives on out-of-workspace runs.
-2. **Slug collision**: `packages/holocron-plugin-<slug>/` must not
-   exist. If it does, error "already scaffolded, edit in place".
-3. **Prompt for anything missing**: capability key, vendor-native env,
-   base URL — using `@theholocron/cli-utils` prompts.
-4. **Capability sanity**: capability key must be one of the 14; error
-   if not. If capability cardinality is `many` (per `CARDINALITY` in
-   `capabilities/index.ts`), print a warning + confirm — those need
-   different wiring in `holocron.config.json`.
-5. **Generate**: write the 14 template files to
+   with a clear message.
+2. **Slug collision** ✅ — `packages/holocron-plugin-<slug>/` must
+   not exist. If it does, error "already exists — edit in place or
+   pick a different slug".
+3. **Prompt for anything missing** ⏳ — capability key, vendor-native
+   env, base URL — using `@theholocron/cli-utils` prompts. Today the
+   command errors clearly if these flags are absent; interactive
+   prompts land in Phase 1b.
+4. **Capability sanity** ✅ — capability key must be one of the 14
+   in `CARDINALITY`; error if not. Prints a many-cardinality
+   warning (not a hard confirm; a confirmation gate is Phase 1b).
+5. **Generate** ✅ — write the 17 template files to
    `packages/holocron-plugin-<slug>/` (see §Templates below).
-6. **Verify** (unless `--no-verify`): run
-   `pnpm install && pnpm --filter <pkg> typecheck lint test`. If any
-   step fails, surface verbatim and leave the scaffold in place — the
-   operator can inspect + delete if they choose.
-7. **Print next steps**: implement the capability methods, replace
-   `it.todo`, update README, commit.
+6. **Verify** ⏳ — (unless `--no-verify`) run `pnpm install && pnpm
+   --filter <pkg> typecheck lint test`. Flag exists in yargs
+   already; the actual pnpm invocation lands in Phase 1b.
+7. **Print next steps** ✅ — 7-step operator checklist including
+   pnpm install, typecheck/lint/test, implement methods, replace
+   `it.todo`, commit.
 
 `--dry-run` skips steps 5–7 and prints the file list only.
 
 ## Templates
 
 Template content lives **inline as TS string builders** in
-`packages/cli/src/commands/plugin-create/templates/`:
+`packages/cli/src/commands/plugin-create/templates/`. The as-shipped
+list is **17 files** (not 14 as the original spec estimated —
+`verify-token.ts` / `verify-token.test.ts` / `tsdown.config.ts` were
+added post-#94 to reflect the session-derived plugin conventions):
 
-- `package-json.ts` → returns the `package.json` string given inputs
+**Config (5)**
+
+- `package-json.ts` → returns the `package.json` string
 - `tsconfig-json.ts` → returns the `tsconfig.json` string
-- `vitest-config.ts` → `vitest.config.ts` string
-- `eslint-config.ts` → `eslint.config.js` string
-- `readme.ts` → `README.md` string
-- `auth.ts` → `src/auth.ts` string
-- `rest.ts` → `src/rest.ts` string
-- `plugin-index.ts` → `src/index.ts` string
-- `capability.ts` → `src/capabilities/<key>.ts` string (stubbed body)
-- `helpers.ts` → `src/__tests__/helpers.ts` string (stubFetch)
-- `auth-test.ts` → `src/__tests__/auth.test.ts` string
-- `rest-test.ts` → `src/__tests__/rest.test.ts` string
-- `capability-test.ts` → `src/__tests__/<key>.test.ts` string (it.todo)
-- `index-test.ts` → `src/__tests__/index.test.ts` string
+- `vitest-config.ts` → `vitest.config.ts`
+- `eslint-config.ts` → `eslint.config.js`
+- `tsdown-config.ts` → `tsdown.config.ts` (new since draft)
+
+**Docs (1)**
+
+- `readme.ts` → `README.md`
+
+**Source (5)**
+
+- `auth.ts` → `src/auth.ts` (4-step keyring precedence)
+- `rest.ts` → `src/rest.ts`
+- `verify-token.ts` → `src/verify-token.ts` (new since draft)
+- `plugin-index.ts` → `src/index.ts` (includes `AUTH_HINT` +
+  `verifyToken` re-exports)
+- `capability.ts` → `src/capabilities/<key>.ts` (stubbed body — no
+  `implements` at scaffold time; operator adds it once methods land)
+
+**Tests (6)**
+
+- `helpers.ts` → `src/__tests__/helpers.ts` (stubFetch)
+- `auth-test.ts` → `src/__tests__/auth.test.ts`
+- `rest-test.ts` → `src/__tests__/rest.test.ts`
+- `verify-token-test.ts` → `src/__tests__/verify-token.test.ts` (new)
+- `capability-test.ts` → `src/__tests__/<key>.test.ts` (it.todo)
+- `index-test.ts` → `src/__tests__/index.test.ts`
 
 Inline TS over file-based `.tmpl` templates because:
 - No template engine dep
 - Templates get typechecked against a shared `TemplateInputs` type
 - Editor jumps to the string source directly
-- Small enough surface (14 files, ~800 LOC of templates) that it
+- Small enough surface (17 files, ~1000 LOC of templates) that it
   doesn't overwhelm the codebase
 
 Each template exports `(inputs: TemplateInputs) => string` and takes
@@ -176,31 +207,51 @@ throwaway plugin, `.claude/skills/holocron-plugin.md` becomes a
 
 ## Test plan
 
-- **Unit**: each template module gets a golden-file test — input
-  record → expected string. Add a template, add a golden.
-- **Integration**: single vitest scenario that spawns
-  `holocron plugin create test-plugin TestVendor` in a temp workspace
-  fixture (with the minimum viable `pnpm-workspace.yaml` +
-  `holocron.config.json`), asserts:
-  1. The 14 files exist and their content matches golden output
-  2. `pnpm --filter @theholocron/holocron-plugin-test-plugin typecheck`
-     passes on the scaffolded package
-- **Skipped on CI initially**: the integration test runs `pnpm install`
-  which is slow — mark it `describe.skip` behind an env flag, run
-  locally + as a periodic job. Similar to Rando's Postgres opt-in
-  tests.
+**Shipped (Phase 1a)**:
+
+- **Unit** — `packages/cli/src/__tests__/plugin-create.test.ts`
+  covers the orchestrator surface: file count (17), path
+  substitution (`{{capability}}` → real key), dry-run vs write,
+  preflight failure, slug collision, unknown capability rejection,
+  many-cardinality warning, and rendered-content sanity checks on
+  package.json / auth.ts / index.ts.
+- **Manual end-to-end** — during development, scaffolded a
+  `testvendor` plugin with `--capability tooling`, ran
+  `pnpm --filter @theholocron/holocron-plugin-testvendor typecheck
+  lint test` — all green. The command's output matches expectations.
+
+**Follow-up (Phase 1b)**:
+
+- **Golden-file tests per template** — the original spec called for
+  17 individual goldens. Shipped as inline rendered-content
+  assertions instead (fewer files, similar coverage). Full goldens
+  would be additive; not urgent.
+- **Automated integration test** — vitest scenario that spawns
+  `holocron plugin create` against a temp workspace fixture, runs
+  the generated package's `pnpm install && typecheck lint test`,
+  cleans up. Skip on CI initially per the original spec (pnpm
+  install is slow); gate behind `RUN_PLUGIN_CREATE_E2E=1`.
 
 ## Roadmap
 
-- **Phase 1** (this issue): Ship `holocron plugin create <slug> <vendor>`
-  REST-only. Templates + prompts + verify.
-- **Phase 2** (needs #76+#78): Add `--transport cli` variant. Requires
-  the `transport` option in `holocron.config.json` (#76) and the
-  CLI-transport skill/design (#78).
+- **Phase 1a** (shipped): `holocron plugin create <slug> <vendor>`
+  REST-only. 17 templates, subcommand, preflight, slug collision
+  check, capability validation, `--dry-run`, generate loop with
+  `{{capability}}` path substitution, print-next-steps. Skill file
+  reduced to a stub.
+- **Phase 1b** (follow-up — same issue #77): Interactive prompts
+  for missing `--capability` / `--vendor-env` / `--base-url`.
+  Post-scaffold verify step (`pnpm install && pnpm --filter <pkg>
+  typecheck lint test`) gated by `--no-verify`. Full integration
+  test (behind an env flag — spawns pnpm install and typechecks
+  the generated package end-to-end).
+- **Phase 2** (needs #76+#78): Add `--transport cli` variant.
+  Requires the `transport` option in `holocron.config.json` (#76)
+  and the CLI-transport skill/design (#78).
 - **Phase 3** (later): Add `--from-rando <path>` flag that reads an
   existing Rando adapter and pre-fills the template — turns the
-  Rando-porting checklist at the bottom of the skill into a machine
-  step.
+  Rando-porting checklist at the bottom of the (now-stub) skill
+  into a machine step.
 
 ## Open questions
 

--- a/packages/cli/src/__tests__/plugin-create.test.ts
+++ b/packages/cli/src/__tests__/plugin-create.test.ts
@@ -1,3 +1,6 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import { PluginCreateError, runPluginCreate } from "../commands/plugin-create/index.js";
@@ -16,8 +19,11 @@ function makeFakeFs() {
 	};
 }
 
-// Point the CWD at the real workspace root so the preflight passes.
-const WORKSPACE_ROOT = "/Users/archives/Code/theholocron/holocron";
+// Derive the workspace root from this file's location — portable
+// across local dev, CI, and any other check-out path.
+//   packages/cli/src/__tests__/plugin-create.test.ts → up 4 → root
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WORKSPACE_ROOT = path.resolve(HERE, "../../../..");
 
 const BASE_INPUT = {
 	slug: "nonexistent-fake-slug",

--- a/packages/cli/src/__tests__/plugin-create.test.ts
+++ b/packages/cli/src/__tests__/plugin-create.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import { PluginCreateError, runPluginCreate } from "../commands/plugin-create/index.js";
+
+// In-memory fs so tests don't touch the real workspace.
+function makeFakeFs() {
+	const written = new Map<string, string>();
+	return {
+		writeFile: (filepath: string, content: string) => {
+			written.set(filepath, content);
+		},
+		get: (path: string) => written.get(path),
+		has: (path: string) => written.has(path),
+		paths: () => Array.from(written.keys()),
+		size: () => written.size,
+	};
+}
+
+// Point the CWD at the real workspace root so the preflight passes.
+const WORKSPACE_ROOT = "/Users/archives/Code/theholocron/holocron";
+
+const BASE_INPUT = {
+	slug: "nonexistent-fake-slug",
+	vendorName: "FakeVendor",
+	capability: "tooling" as const,
+	vendorEnv: "FAKEVENDOR_KEY",
+	baseUrl: "https://api.fakevendor.example",
+	cwd: WORKSPACE_ROOT,
+};
+
+describe("runPluginCreate — orchestrator", () => {
+	it("emits exactly 17 files (5 config + 1 readme + 5 source + 6 tests)", () => {
+		const fs = makeFakeFs();
+		const report = runPluginCreate({
+			...BASE_INPUT,
+			writeFile: fs.writeFile,
+			print: () => {},
+		});
+		expect(report.status).toBe("ok");
+		expect(report.filesWritten).toHaveLength(17);
+		expect(fs.size()).toBe(17);
+	});
+
+	it("resolves {{capability}} in paths to the chosen capability key", () => {
+		const fs = makeFakeFs();
+		runPluginCreate({
+			...BASE_INPUT,
+			capability: "vault",
+			writeFile: fs.writeFile,
+			print: () => {},
+		});
+		expect(fs.paths().some((p) => p.endsWith("src/capabilities/vault.ts"))).toBe(true);
+		expect(fs.paths().some((p) => p.endsWith("src/__tests__/vault.test.ts"))).toBe(true);
+		expect(fs.paths().every((p) => !p.includes("{{capability}}"))).toBe(true);
+	});
+
+	it("dry-run mode writes no files but reports what would be written", () => {
+		const fs = makeFakeFs();
+		const report = runPluginCreate({
+			...BASE_INPUT,
+			dryRun: true,
+			writeFile: fs.writeFile,
+			print: () => {},
+		});
+		expect(report.status).toBe("ok");
+		expect(fs.size()).toBe(0);
+		expect(report.filesWritten).toHaveLength(17);
+	});
+
+	it("preflight fails when CWD is not a workspace root", () => {
+		expect(() =>
+			runPluginCreate({
+				...BASE_INPUT,
+				cwd: "/tmp",
+				writeFile: () => {},
+				print: () => {},
+			})
+		).toThrow(PluginCreateError);
+	});
+
+	it("slug-collision guard fires when the target directory already exists", () => {
+		expect(() =>
+			runPluginCreate({
+				...BASE_INPUT,
+				slug: "doppler", // real package in the workspace
+				writeFile: () => {},
+				print: () => {},
+			})
+		).toThrow(/already exists/);
+	});
+
+	it("rejects an unknown capability key", () => {
+		expect(() =>
+			runPluginCreate({
+				...BASE_INPUT,
+				// @ts-expect-error deliberately invalid
+				capability: "not-a-real-capability",
+				writeFile: () => {},
+				print: () => {},
+			})
+		).toThrow(/not a known capability/);
+	});
+
+	it("warns on many-cardinality capabilities without erroring", () => {
+		const messages: string[] = [];
+		const report = runPluginCreate({
+			...BASE_INPUT,
+			capability: "tooling", // 'many' cardinality
+			dryRun: true,
+			writeFile: () => {},
+			print: (l) => messages.push(l),
+		});
+		expect(report.status).toBe("ok");
+		expect(messages.some((m) => m.includes("many-cardinality"))).toBe(true);
+	});
+});
+
+describe("Rendered content sanity", () => {
+	it("package.json contains the plugin name, tsdown build, workspace peer dep", () => {
+		const fs = makeFakeFs();
+		runPluginCreate({
+			...BASE_INPUT,
+			slug: "acme",
+			vendorName: "Acme",
+			writeFile: fs.writeFile,
+			print: () => {},
+		});
+		const pkg = fs.paths().find((p) => p.endsWith("package.json"));
+		expect(pkg).toBeTruthy();
+		const content = fs.get(pkg!)!;
+		expect(content).toMatch(/@theholocron\/holocron-plugin-acme/);
+		expect(content).toMatch(/"peerDependencies":\s*{\s*"@theholocron\/cli":/);
+		expect(content).toMatch(/"build":\s*"tsdown"/);
+	});
+
+	it("auth.ts uses the 4-step precedence with keyring + custom env vars", () => {
+		const fs = makeFakeFs();
+		runPluginCreate({
+			...BASE_INPUT,
+			slug: "acme",
+			vendorName: "Acme",
+			vendorEnv: "ACME_KEY",
+			writeFile: fs.writeFile,
+			print: () => {},
+		});
+		const content = fs.get(fs.paths().find((p) => p.endsWith("src/auth.ts"))!)!;
+		expect(content).toMatch(/HOLOCRON_ACME_TOKEN/);
+		expect(content).toMatch(/ACME_KEY/);
+		expect(content).toMatch(/getKeyringToken/);
+		expect(content).toMatch(/keyring\("acme"\)/);
+	});
+
+	it("index.ts exports AUTH_HINT and verifyToken", () => {
+		const fs = makeFakeFs();
+		runPluginCreate({
+			...BASE_INPUT,
+			slug: "acme",
+			vendorName: "Acme",
+			writeFile: fs.writeFile,
+			print: () => {},
+		});
+		const content = fs.get(fs.paths().find((p) => p.endsWith("src/index.ts"))!)!;
+		expect(content).toMatch(/export const AUTH_HINT/);
+		expect(content).toMatch(/export \{ verifyToken \}/);
+		expect(content).toMatch(/holocron auth set acme/);
+	});
+});

--- a/packages/cli/src/__tests__/plugin-create.test.ts
+++ b/packages/cli/src/__tests__/plugin-create.test.ts
@@ -107,6 +107,39 @@ describe("runPluginCreate — orchestrator", () => {
 		).toThrow(/not a known capability/);
 	});
 
+	it("rejects a slug that isn't kebab-case", () => {
+		expect(() =>
+			runPluginCreate({
+				...BASE_INPUT,
+				slug: "MyPlugin", // PascalCase — invalid
+				writeFile: () => {},
+				print: () => {},
+			})
+		).toThrow(/invalid slug/);
+	});
+
+	it("rejects a slug that starts with a digit", () => {
+		expect(() =>
+			runPluginCreate({
+				...BASE_INPUT,
+				slug: "1password", // catches the env.HOLOCRON_1PASSWORD_TOKEN identifier trap
+				writeFile: () => {},
+				print: () => {},
+			})
+		).toThrow(/invalid slug/);
+	});
+
+	it("rejects a vendor name that isn't PascalCase", () => {
+		expect(() =>
+			runPluginCreate({
+				...BASE_INPUT,
+				vendorName: "myVendor", // starts lowercase
+				writeFile: () => {},
+				print: () => {},
+			})
+		).toThrow(/invalid vendor name/);
+	});
+
 	it("warns on many-cardinality capabilities without erroring", () => {
 		const messages: string[] = [];
 		const report = runPluginCreate({
@@ -154,6 +187,24 @@ describe("Rendered content sanity", () => {
 		expect(content).toMatch(/ACME_KEY/);
 		expect(content).toMatch(/getKeyringToken/);
 		expect(content).toMatch(/keyring\("acme"\)/);
+	});
+
+	it("normalizes trailing slashes in baseUrl so the rest-test's assertion matches", () => {
+		const fs = makeFakeFs();
+		runPluginCreate({
+			...BASE_INPUT,
+			slug: "acme",
+			vendorName: "Acme",
+			baseUrl: "https://api.acme.example/v1///", // trailing slashes
+			writeFile: fs.writeFile,
+			print: () => {},
+		});
+		const restTest = fs.get(fs.paths().find((p) => p.endsWith("src/__tests__/rest.test.ts"))!)!;
+		// The trimming test expects `client.baseUrl` to equal the normalized
+		// URL. If baseUrl had leaked in with a trailing slash, the assertion
+		// would embed it and fail against the client's own trim.
+		expect(restTest).toContain('expect(client.baseUrl).toBe("https://api.acme.example/v1")');
+		expect(restTest).not.toMatch(/toBe\("https:\/\/api\.acme\.example\/v1\/+/);
 	});
 
 	it("index.ts exports AUTH_HINT and verifyToken", () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -277,10 +277,11 @@ await yargs(hideBin(process.argv))
 					type: "string",
 					describe: "REST base URL",
 				})
-				.option("no-verify", {
+				.option("verify", {
 					type: "boolean",
-					default: false,
-					describe: "Skip the post-scaffold pnpm install + typecheck + lint + test",
+					default: true,
+					describe:
+						"Run post-scaffold pnpm install + typecheck + lint + test (default true; --no-verify skips)",
 				}),
 		(argv) => {
 			try {
@@ -298,7 +299,9 @@ await yargs(hideBin(process.argv))
 					baseUrl: argv.baseUrl as string,
 					...(argv.tokenEnv ? { tokenEnv: argv.tokenEnv as string } : {}),
 					dryRun: argv.dryRun,
-					noVerify: argv.noVerify as boolean,
+					// Yargs: `--no-verify` flips `argv.verify` to false. We pass
+					// the inverse to preserve the internal `noVerify` naming.
+					noVerify: !argv.verify,
 					cwd: argv.cwd,
 				});
 				if (report.status === "fail") process.exitCode = 1;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -259,7 +259,11 @@ await yargs(hideBin(process.argv))
 		(y) =>
 			y
 				.positional("slug", { type: "string", demandOption: true, describe: "Package slug (kebab-case)" })
-				.positional("vendor", { type: "string", demandOption: true, describe: "Vendor display name (PascalCase)" })
+				.positional("vendor", {
+					type: "string",
+					demandOption: true,
+					describe: "Vendor display name (PascalCase)",
+				})
 				.option("capability", {
 					type: "string",
 					describe:

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,10 +3,12 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
+import type { CapabilityKey } from "./capabilities/index.js";
 import { runAuthCheck, runAuthList, runAuthSet, runAuthUnset } from "./commands/auth.js";
 import { runDeploy } from "./commands/deploy.js";
 import { runDoctor } from "./commands/doctor.js";
 import { runNpmPublishInitial } from "./commands/npm-publish-initial.js";
+import { PluginCreateError, runPluginCreate } from "./commands/plugin-create/index.js";
 import { runSecretSet } from "./commands/secret-set.js";
 import { runSecretsSync } from "./commands/secrets-sync.js";
 import { runSetup } from "./commands/setup.js";
@@ -249,6 +251,65 @@ await yargs(hideBin(process.argv))
 		async (argv) => {
 			const loaded = await loadConfig(argv.cwd);
 			console.log(JSON.stringify(loaded.resolved, null, 2));
+		}
+	)
+	.command(
+		"plugin create <slug> <vendor>",
+		"Scaffold a new @theholocron/holocron-plugin-<slug> package",
+		(y) =>
+			y
+				.positional("slug", { type: "string", demandOption: true, describe: "Package slug (kebab-case)" })
+				.positional("vendor", { type: "string", demandOption: true, describe: "Vendor display name (PascalCase)" })
+				.option("capability", {
+					type: "string",
+					describe:
+						"Capability key: source|ci|secrets|environments|issues|deployment|storage|auth|vault|dns|tooling|notifications|analytics|observability",
+				})
+				.option("token-env", {
+					type: "string",
+					describe: "Holocron env var name (defaults to HOLOCRON_<VENDOR>_TOKEN)",
+				})
+				.option("vendor-env", {
+					type: "string",
+					describe: "Vendor-native env var name",
+				})
+				.option("base-url", {
+					type: "string",
+					describe: "REST base URL",
+				})
+				.option("no-verify", {
+					type: "boolean",
+					default: false,
+					describe: "Skip the post-scaffold pnpm install + typecheck + lint + test",
+				}),
+		(argv) => {
+			try {
+				if (!argv.capability || !argv.vendorEnv || !argv.baseUrl) {
+					throw new PluginCreateError(
+						"Phase A: --capability, --vendor-env, and --base-url are required. " +
+							"Interactive prompts land in Phase B."
+					);
+				}
+				const report = runPluginCreate({
+					slug: argv.slug as string,
+					vendorName: argv.vendor as string,
+					capability: argv.capability as CapabilityKey,
+					vendorEnv: argv.vendorEnv as string,
+					baseUrl: argv.baseUrl as string,
+					...(argv.tokenEnv ? { tokenEnv: argv.tokenEnv as string } : {}),
+					dryRun: argv.dryRun,
+					noVerify: argv.noVerify as boolean,
+					cwd: argv.cwd,
+				});
+				if (report.status === "fail") process.exitCode = 1;
+			} catch (err) {
+				if (err instanceof PluginCreateError) {
+					console.error(`plugin create: ${err.message}`);
+					process.exitCode = 1;
+					return;
+				}
+				throw err;
+			}
 		}
 	)
 	.command(

--- a/packages/cli/src/commands/plugin-create/index.ts
+++ b/packages/cli/src/commands/plugin-create/index.ts
@@ -126,6 +126,8 @@ export function runPluginCreate(input: RunPluginCreateInput): PluginCreateReport
 	const write = input.writeFile ?? defaultWrite;
 
 	preflight(cwd);
+	validateSlug(input.slug);
+	validateVendorName(input.vendorName);
 
 	const packageDir = path.join(cwd, "packages", `holocron-plugin-${input.slug}`);
 	if (existsSync(packageDir)) {
@@ -147,7 +149,9 @@ export function runPluginCreate(input: RunPluginCreateInput): PluginCreateReport
 		capabilityClass: derived.capabilityClass,
 		tokenEnv: input.tokenEnv ?? derived.tokenEnv,
 		vendorEnv: input.vendorEnv,
-		baseUrl: input.baseUrl,
+		// Normalize: strip trailing slashes so the embedded value in the
+		// generated rest-test.ts matches what the client trims at runtime.
+		baseUrl: trimTrailingSlashes(input.baseUrl),
 		transport: derived.transport,
 	};
 
@@ -185,6 +189,45 @@ function preflight(cwd: string): void {
 	if (!existsSync(path.join(cwd, "packages"))) {
 		throw new PluginCreateError(`\`packages/\` directory not found in \`${cwd}\`.`);
 	}
+}
+
+/**
+ * npm-package-name conventions: kebab-case, starts with lowercase
+ * letter. Rejecting numeric-prefixed slugs also sidesteps the
+ * `env.HOLOCRON_1FOO_TOKEN` invalid-identifier trap in the auth
+ * template.
+ */
+const SLUG_RE = /^[a-z][a-z0-9-]*$/;
+
+function validateSlug(slug: string): void {
+	if (!SLUG_RE.test(slug)) {
+		throw new PluginCreateError(
+			`invalid slug "${slug}" — must be kebab-case: lowercase letter followed by lowercase letters, digits, or hyphens. ` +
+				`Examples: "clerk", "cloud-flare", "doppler".`
+		);
+	}
+}
+
+/** PascalCase — starts with uppercase, alphanumeric only. */
+const VENDOR_NAME_RE = /^[A-Z][a-zA-Z0-9]*$/;
+
+function validateVendorName(name: string): void {
+	if (!VENDOR_NAME_RE.test(name)) {
+		throw new PluginCreateError(
+			`invalid vendor name "${name}" — must be PascalCase: starts with uppercase, alphanumeric only. ` +
+				`Examples: "Clerk", "CloudFlare", "Doppler".`
+		);
+	}
+}
+
+/**
+ * Trim trailing slashes with a plain loop (no regex — matches the
+ * rest.ts template's own trimming to stay ReDoS-safe under CodeQL).
+ */
+function trimTrailingSlashes(url: string): string {
+	let out = url;
+	while (out.endsWith("/")) out = out.slice(0, -1);
+	return out;
 }
 
 function validateCapability(capability: CapabilityKey, print: (line: string) => void): void {

--- a/packages/cli/src/commands/plugin-create/index.ts
+++ b/packages/cli/src/commands/plugin-create/index.ts
@@ -1,0 +1,223 @@
+/**
+ * `holocron plugin create <slug> <vendor>` — scaffold a new plugin
+ * package matching the proven template.
+ *
+ * Design: see `.notes/tool-plugin-create.spec.md`.
+ *
+ * Flow:
+ *   1. Preflight — verify CWD is a workspace root (pnpm-workspace.yaml
+ *      + packages/ dir present).
+ *   2. Slug collision — packages/holocron-plugin-<slug>/ must not exist.
+ *   3. Capability sanity — must be one of the 14 known keys; warn for
+ *      many-cardinality caps.
+ *   4. Prompt — fill in any missing flags via cli-utils / inquirer
+ *      (Phase B; Phase A takes fully-populated input).
+ *   5. Generate — for each template, write to
+ *      packages/holocron-plugin-<slug>/<path>.
+ *   6. Verify (unless --no-verify) — Phase B; runs pnpm install +
+ *      pnpm --filter <pkg> typecheck lint test.
+ *   7. Print next steps.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import type { CapabilityKey } from "../../capabilities/index.js";
+import { CARDINALITY } from "../../capabilities/index.js";
+import { deriveDefaults, type TemplateInputs } from "./template-inputs.js";
+import { render as renderAuth } from "./templates/auth.js";
+import { render as renderAuthTest } from "./templates/auth-test.js";
+import { render as renderCapability } from "./templates/capability.js";
+import { render as renderCapabilityTest } from "./templates/capability-test.js";
+import { render as renderEslintConfig } from "./templates/eslint-config.js";
+import { render as renderHelpers } from "./templates/helpers.js";
+import { render as renderIndexTest } from "./templates/index-test.js";
+import { render as renderPackageJson } from "./templates/package-json.js";
+import { render as renderPluginIndex } from "./templates/plugin-index.js";
+import { render as renderReadme } from "./templates/readme.js";
+import { render as renderRest } from "./templates/rest.js";
+import { render as renderRestTest } from "./templates/rest-test.js";
+import { render as renderTsconfigJson } from "./templates/tsconfig-json.js";
+import { render as renderTsdownConfig } from "./templates/tsdown-config.js";
+import { render as renderVerifyToken } from "./templates/verify-token.js";
+import { render as renderVerifyTokenTest } from "./templates/verify-token-test.js";
+import { render as renderVitestConfig } from "./templates/vitest-config.js";
+
+// ── Public API ──────────────────────────────────────────────────────
+
+export interface RunPluginCreateInput {
+	/** Package slug, e.g., "clerk". Kebab-case. */
+	slug: string;
+	/** Vendor display name, e.g., "Clerk". PascalCase. */
+	vendorName: string;
+	/** Capability the plugin implements — one of the 14 known keys. */
+	capability: CapabilityKey;
+	/** Vendor-native env var, e.g., "CLERK_SECRET_KEY". */
+	vendorEnv: string;
+	/** REST base URL, e.g., "https://api.clerk.com/v1". */
+	baseUrl: string;
+	/** Optional token env override. Defaults to `HOLOCRON_<VENDOR>_TOKEN`. */
+	tokenEnv?: string;
+	/** Print steps without writing files. */
+	dryRun?: boolean;
+	/** Skip the post-scaffold pnpm install/typecheck/lint/test. */
+	noVerify?: boolean;
+	/** Working directory (workspace root). Defaults to `process.cwd()`. */
+	cwd?: string;
+	/** Injection point for tests / dry-run wiring. Defaults to fs write. */
+	writeFile?: (filepath: string, content: string) => void;
+	/** Print fn — captures orchestrator output. Defaults to console.log. */
+	print?: (line: string) => void;
+}
+
+export interface PluginCreateReport {
+	status: "ok" | "fail";
+	packagePath: string;
+	filesWritten: string[];
+	message?: string;
+}
+
+export class PluginCreateError extends Error {
+	override name = "PluginCreateError";
+}
+
+// ── Templates registry ──────────────────────────────────────────────
+
+interface TemplateEntry {
+	/** Path relative to the plugin package root. */
+	path: string;
+	render: (inputs: TemplateInputs) => string;
+}
+
+const TEMPLATES: TemplateEntry[] = [
+	// Config (5)
+	{ path: "package.json", render: renderPackageJson },
+	{ path: "tsconfig.json", render: renderTsconfigJson },
+	{ path: "vitest.config.ts", render: renderVitestConfig },
+	{ path: "eslint.config.js", render: renderEslintConfig },
+	{ path: "tsdown.config.ts", render: renderTsdownConfig },
+	// Docs (1)
+	{ path: "README.md", render: renderReadme },
+	// Source (5) — capability path uses the dynamic capability slug.
+	{ path: "src/auth.ts", render: renderAuth },
+	{ path: "src/rest.ts", render: renderRest },
+	{ path: "src/verify-token.ts", render: renderVerifyToken },
+	{ path: "src/index.ts", render: renderPluginIndex },
+	{ path: "src/capabilities/{{capability}}.ts", render: renderCapability },
+	// Tests (6)
+	{ path: "src/__tests__/helpers.ts", render: renderHelpers },
+	{ path: "src/__tests__/auth.test.ts", render: renderAuthTest },
+	{ path: "src/__tests__/rest.test.ts", render: renderRestTest },
+	{ path: "src/__tests__/verify-token.test.ts", render: renderVerifyTokenTest },
+	{ path: "src/__tests__/{{capability}}.test.ts", render: renderCapabilityTest },
+	{ path: "src/__tests__/index.test.ts", render: renderIndexTest },
+];
+
+/** Replace `{{capability}}` in a template path with the actual capability key. */
+function resolvePath(template: string, inputs: TemplateInputs): string {
+	return template.replace(/\{\{capability\}\}/g, inputs.capability);
+}
+
+// ── Orchestrator ────────────────────────────────────────────────────
+
+export function runPluginCreate(input: RunPluginCreateInput): PluginCreateReport {
+	const cwd = input.cwd ?? process.cwd();
+	const print = input.print ?? ((line: string) => console.log(line));
+	const write = input.writeFile ?? defaultWrite;
+
+	preflight(cwd);
+
+	const packageDir = path.join(cwd, "packages", `holocron-plugin-${input.slug}`);
+	if (existsSync(packageDir)) {
+		throw new PluginCreateError(
+			`\`${packageDir}\` already exists — edit in place or pick a different slug.`
+		);
+	}
+
+	validateCapability(input.capability, print);
+
+	const derived = deriveDefaults({
+		slug: input.slug,
+		vendorName: input.vendorName,
+		capability: input.capability,
+	});
+	const inputs: TemplateInputs = {
+		slug: input.slug,
+		vendorName: input.vendorName,
+		vendorUpper: derived.vendorUpper,
+		capability: input.capability,
+		capabilityClass: derived.capabilityClass,
+		tokenEnv: input.tokenEnv ?? derived.tokenEnv,
+		vendorEnv: input.vendorEnv,
+		baseUrl: input.baseUrl,
+		transport: derived.transport,
+	};
+
+	const filesWritten: string[] = [];
+	print(`Scaffolding @theholocron/holocron-plugin-${inputs.slug}${input.dryRun ? " (dry-run)" : ""}`);
+	print(`  → ${packageDir}`);
+	for (const template of TEMPLATES) {
+		const resolvedPath = resolvePath(template.path, inputs);
+		const filepath = path.join(packageDir, resolvedPath);
+		const content = template.render(inputs);
+		if (input.dryRun) {
+			print(`  … would write ${resolvedPath} (${content.length} bytes)`);
+		} else {
+			write(filepath, content);
+			print(`  ✓ ${resolvedPath}`);
+		}
+		filesWritten.push(resolvedPath);
+	}
+
+	if (!input.dryRun) {
+		printNextSteps(print, inputs);
+	}
+
+	return { status: "ok", packagePath: packageDir, filesWritten };
+}
+
+// ── Internals ───────────────────────────────────────────────────────
+
+function preflight(cwd: string): void {
+	if (!existsSync(path.join(cwd, "pnpm-workspace.yaml"))) {
+		throw new PluginCreateError(
+			`\`pnpm-workspace.yaml\` not found in \`${cwd}\`. Run \`holocron plugin create\` from the monorepo root.`
+		);
+	}
+	if (!existsSync(path.join(cwd, "packages"))) {
+		throw new PluginCreateError(`\`packages/\` directory not found in \`${cwd}\`.`);
+	}
+}
+
+function validateCapability(capability: CapabilityKey, print: (line: string) => void): void {
+	if (!(capability in CARDINALITY)) {
+		throw new PluginCreateError(
+			`\`${capability}\` is not a known capability. See \`packages/cli/src/capabilities/index.ts\`.`
+		);
+	}
+	if (CARDINALITY[capability] === "many") {
+		print(
+			`  ! ${capability} is a many-cardinality capability — multiple providers can be active at once. ` +
+				"Confirm your config wiring accordingly."
+		);
+	}
+}
+
+function defaultWrite(filepath: string, content: string): void {
+	mkdirSync(path.dirname(filepath), { recursive: true });
+	writeFileSync(filepath, content, "utf8");
+}
+
+function printNextSteps(print: (line: string) => void, inputs: TemplateInputs): void {
+	print("");
+	print(`  Scaffolded @theholocron/holocron-plugin-${inputs.slug} (17 files).`);
+	print("");
+	print("  Next:");
+	print(`    1. pnpm install                                                        # picks up the workspace package`);
+	print(`    2. pnpm --filter @theholocron/holocron-plugin-${inputs.slug} typecheck   # green`);
+	print(`    3. pnpm --filter @theholocron/holocron-plugin-${inputs.slug} lint        # green`);
+	print(`    4. pnpm --filter @theholocron/holocron-plugin-${inputs.slug} test        # green (stubs pass, real tests are it.todo)`);
+	print(`    5. Implement ${inputs.capabilityClass} methods in src/capabilities/${inputs.capability}.ts`);
+	print(`    6. Replace it.todo(...) with real tests in src/__tests__/${inputs.capability}.test.ts`);
+	print("    7. Commit + push when capability is functionally complete.");
+}

--- a/packages/cli/src/commands/plugin-create/index.ts
+++ b/packages/cli/src/commands/plugin-create/index.ts
@@ -129,9 +129,7 @@ export function runPluginCreate(input: RunPluginCreateInput): PluginCreateReport
 
 	const packageDir = path.join(cwd, "packages", `holocron-plugin-${input.slug}`);
 	if (existsSync(packageDir)) {
-		throw new PluginCreateError(
-			`\`${packageDir}\` already exists — edit in place or pick a different slug.`
-		);
+		throw new PluginCreateError(`\`${packageDir}\` already exists — edit in place or pick a different slug.`);
 	}
 
 	validateCapability(input.capability, print);
@@ -213,10 +211,14 @@ function printNextSteps(print: (line: string) => void, inputs: TemplateInputs): 
 	print(`  Scaffolded @theholocron/holocron-plugin-${inputs.slug} (17 files).`);
 	print("");
 	print("  Next:");
-	print(`    1. pnpm install                                                        # picks up the workspace package`);
+	print(
+		`    1. pnpm install                                                        # picks up the workspace package`
+	);
 	print(`    2. pnpm --filter @theholocron/holocron-plugin-${inputs.slug} typecheck   # green`);
 	print(`    3. pnpm --filter @theholocron/holocron-plugin-${inputs.slug} lint        # green`);
-	print(`    4. pnpm --filter @theholocron/holocron-plugin-${inputs.slug} test        # green (stubs pass, real tests are it.todo)`);
+	print(
+		`    4. pnpm --filter @theholocron/holocron-plugin-${inputs.slug} test        # green (stubs pass, real tests are it.todo)`
+	);
 	print(`    5. Implement ${inputs.capabilityClass} methods in src/capabilities/${inputs.capability}.ts`);
 	print(`    6. Replace it.todo(...) with real tests in src/__tests__/${inputs.capability}.test.ts`);
 	print("    7. Commit + push when capability is functionally complete.");

--- a/packages/cli/src/commands/plugin-create/template-inputs.ts
+++ b/packages/cli/src/commands/plugin-create/template-inputs.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared input record for every template module.
+ *
+ * Every template exports `(inputs: TemplateInputs) => string` and reads
+ * from this record. Keeping the surface small + typechecked lets the
+ * templates stay dumb string builders while the command layer handles
+ * normalization + defaulting from user input.
+ */
+
+import type { CapabilityKey } from "../../capabilities/index.js";
+
+export interface TemplateInputs {
+	/** Package slug — e.g., "clerk". Lowercase, kebab-case. */
+	slug: string;
+	/** Vendor display name — e.g., "Clerk". PascalCase. */
+	vendorName: string;
+	/** Vendor slug UPPERCASED — e.g., "CLERK". Used for env var names + class prefixes. */
+	vendorUpper: string;
+	/** Capability the plugin implements — one of the 14 known keys. */
+	capability: CapabilityKey;
+	/** Capability implementation class name — e.g., "ClerkAuth". PascalCase. */
+	capabilityClass: string;
+	/** Holocron-namespaced env var — defaults to `HOLOCRON_<VENDOR_UPPER>_TOKEN`. */
+	tokenEnv: string;
+	/** Vendor-native env var — e.g., "CLERK_SECRET_KEY". */
+	vendorEnv: string;
+	/** REST base URL — e.g., "https://api.clerk.com/v1". */
+	baseUrl: string;
+	/** Transport. Only "rest" is supported in Phase 1 (spec: #77). */
+	transport: "rest";
+}
+
+/** Derive the standard defaults from a slug + vendor name. */
+export function deriveDefaults(input: {
+	slug: string;
+	vendorName: string;
+	capability: CapabilityKey;
+}): Pick<TemplateInputs, "vendorUpper" | "capabilityClass" | "tokenEnv" | "transport"> {
+	const vendorUpper = input.slug.toUpperCase().replace(/-/g, "_");
+	const capability = input.capability;
+	const capabilityClass = `${input.vendorName}${capability.charAt(0).toUpperCase() + capability.slice(1)}`;
+	return {
+		vendorUpper,
+		capabilityClass,
+		tokenEnv: `HOLOCRON_${vendorUpper}_TOKEN`,
+		transport: "rest",
+	};
+}

--- a/packages/cli/src/commands/plugin-create/templates/auth-test.ts
+++ b/packages/cli/src/commands/plugin-create/templates/auth-test.ts
@@ -1,0 +1,50 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(inputs: TemplateInputs): string {
+	return `import { describe, expect, it } from "vitest";
+
+import { AuthError, resolveToken } from "../auth.js";
+
+const noKeyring = () => null;
+
+describe("resolveToken", () => {
+	it("prefers --token over env vars + keyring", () => {
+		expect(
+			resolveToken({
+				cliToken: "flag",
+				env: { ${inputs.tokenEnv}: "hlc", ${inputs.vendorEnv}: "vendor" },
+				keyring: () => "kr",
+			})
+		).toBe("flag");
+	});
+
+	it("prefers ${inputs.tokenEnv} over ${inputs.vendorEnv}", () => {
+		expect(
+			resolveToken({
+				env: { ${inputs.tokenEnv}: "hlc", ${inputs.vendorEnv}: "vendor" },
+				keyring: noKeyring,
+			})
+		).toBe("hlc");
+	});
+
+	it("falls back to ${inputs.vendorEnv} when ${inputs.tokenEnv} is unset", () => {
+		expect(resolveToken({ env: { ${inputs.vendorEnv}: "vendor" }, keyring: noKeyring })).toBe("vendor");
+	});
+
+	it("falls back to keyring when env vars are unset", () => {
+		expect(resolveToken({ env: {}, keyring: (p) => (p === "${inputs.slug}" ? "kr" : null) })).toBe("kr");
+	});
+
+	it("throws AuthError with a helpful message when nothing is set", () => {
+		try {
+			resolveToken({ env: {}, keyring: noKeyring });
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(AuthError);
+			expect((err as Error).message).toMatch(/${inputs.tokenEnv}/);
+			expect((err as Error).message).toMatch(/holocron auth set ${inputs.slug}/);
+		}
+	});
+});
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/auth.ts
+++ b/packages/cli/src/commands/plugin-create/templates/auth.ts
@@ -31,7 +31,10 @@ export interface ResolveTokenInput {
 export function resolveToken(input: ResolveTokenInput = {}): string {
 	const env = input.env ?? process.env;
 	const keyring = input.keyring ?? getKeyringToken;
-	const token = input.cliToken || env.${inputs.tokenEnv} || env.${inputs.vendorEnv} || keyring("${inputs.slug}");
+	// Bracket access so numeric-prefixed slugs (e.g., env.HOLOCRON_1PASSWORD_TOKEN
+	// which is invalid JS) still produce syntactically valid code.
+	const token =
+		input.cliToken || env["${inputs.tokenEnv}"] || env["${inputs.vendorEnv}"] || keyring("${inputs.slug}");
 	if (!token) {
 		throw new AuthError(
 			"no ${inputs.vendorName} token found. Pass --token <TOKEN>, set ${inputs.tokenEnv} / ${inputs.vendorEnv}, " +

--- a/packages/cli/src/commands/plugin-create/templates/auth.ts
+++ b/packages/cli/src/commands/plugin-create/templates/auth.ts
@@ -1,0 +1,44 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(inputs: TemplateInputs): string {
+	return `/**
+ * Token resolution for the ${inputs.vendorName} plugin.
+ *
+ * Resolution order (matches the standard 4-step precedence set by
+ * \`.notes/tech-auth-bootstrap.spec.md\`):
+ *   1. explicit \`cliToken\` argument (from \`--token\` flag)
+ *   2. ${inputs.tokenEnv} env var (preferred — explicit intent)
+ *   3. ${inputs.vendorEnv} env var (vendor-native)
+ *   4. keyring (com.theholocron.cli / "${inputs.slug}")
+ *   5. AuthError naming all four options + the bootstrap hint
+ */
+
+import { getToken as getKeyringToken } from "@theholocron/cli";
+
+export class AuthError extends Error {
+	override name = "AuthError";
+}
+
+export interface ResolveTokenInput {
+	/** From \`--token\` CLI flag. */
+	cliToken?: string;
+	/** Env vars; passed in for testability. Defaults to \`process.env\`. */
+	env?: NodeJS.ProcessEnv;
+	/** Keyring lookup fn; passed in for testability. Defaults to \`getToken(provider)\`. */
+	keyring?: (provider: string) => string | null;
+}
+
+export function resolveToken(input: ResolveTokenInput = {}): string {
+	const env = input.env ?? process.env;
+	const keyring = input.keyring ?? getKeyringToken;
+	const token = input.cliToken || env.${inputs.tokenEnv} || env.${inputs.vendorEnv} || keyring("${inputs.slug}");
+	if (!token) {
+		throw new AuthError(
+			"no ${inputs.vendorName} token found. Pass --token <TOKEN>, set ${inputs.tokenEnv} / ${inputs.vendorEnv}, " +
+				"or run: holocron auth set ${inputs.slug} <TOKEN>"
+		);
+	}
+	return token;
+}
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/capability-test.ts
+++ b/packages/cli/src/commands/plugin-create/templates/capability-test.ts
@@ -1,0 +1,33 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(inputs: TemplateInputs): string {
+	const clientClass = `${inputs.vendorName}RestClient`;
+	return `import { describe, it } from "vitest";
+
+import { ${inputs.capabilityClass} } from "../capabilities/${inputs.capability}.js";
+import { ${clientClass} } from "../rest.js";
+import { stubFetch } from "./helpers.js";
+
+// Stub client used by the constructor smoke test. Real capability
+// tests replace this with per-method stubs once implementations land.
+function makeCapability() {
+	const stub = stubFetch([]);
+	const rest = new ${clientClass}({ token: "t", fetch: stub.fetch });
+	return new ${inputs.capabilityClass}(rest);
+}
+
+describe("${inputs.capabilityClass}", () => {
+	it("constructs with a REST client", () => {
+		makeCapability();
+	});
+
+	// TODO: implement one test per ${inputs.capability} capability method
+	// as you fill in the class stubs. See other plugins for reference
+	// patterns:
+	//   - REST behaviors (URL / method / body / query) via \`stub.calls\`
+	//   - Error paths via \`stubFetch([{ status: 4xx, body: {...} }])\`
+	//   - Idempotency (409 handling for ensure* methods, if applicable)
+	it.todo("implement per-method tests");
+});
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/capability.ts
+++ b/packages/cli/src/commands/plugin-create/templates/capability.ts
@@ -1,0 +1,35 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(inputs: TemplateInputs): string {
+	const clientClass = `${inputs.vendorName}RestClient`;
+	const capabilityInterface = inputs.capability.charAt(0).toUpperCase() + inputs.capability.slice(1);
+	return `/**
+ * \`${inputs.capability}\` capability for ${inputs.vendorName}.
+ *
+ * Methods are STUBS — implement them against ${inputs.vendorName}'s
+ * REST API per the \`${capabilityInterface}\` interface contract in
+ * \`@theholocron/cli\`.
+ *
+ * TODO once you've stubbed the interface methods, restore the type
+ * import + \`implements\` clause:
+ *   import type { ${capabilityInterface} } from "@theholocron/cli";
+ *   export class ${inputs.capabilityClass} implements ${capabilityInterface} { ... }
+ */
+
+import type { ${clientClass} } from "../rest.js";
+
+export class ${inputs.capabilityClass} {
+	readonly key = "${inputs.capability}" as const;
+	readonly providerName = "${inputs.slug}";
+
+	constructor(private readonly rest: ${clientClass}) {}
+
+	// TODO: implement the ${capabilityInterface} interface methods
+	// (see \`packages/cli/src/capabilities/index.ts\`). Each method
+	// should hit a specific ${inputs.vendorName} REST endpoint via
+	// \`this.rest.request(...)\`. Once methods are stubbed, add
+	// \`implements ${capabilityInterface}\` to the class declaration
+	// above and remove the \`as unknown as\` cast in src/index.ts.
+}
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/eslint-config.ts
+++ b/packages/cli/src/commands/plugin-create/templates/eslint-config.ts
@@ -1,0 +1,13 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(_inputs: TemplateInputs): string {
+	return `import root from "../../eslint.config.js";
+
+export default [
+	...root,
+	{
+		ignores: ["dist/**", "coverage/**"],
+	},
+];
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/helpers.ts
+++ b/packages/cli/src/commands/plugin-create/templates/helpers.ts
@@ -1,0 +1,50 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(_inputs: TemplateInputs): string {
+	return `import { vi, type Mock } from "vitest";
+
+export interface FetchCall {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	body: unknown;
+}
+
+export interface FetchStub {
+	fetch: typeof fetch;
+	calls: FetchCall[];
+	mock: Mock;
+}
+
+export function stubFetch(responses: Array<{ status?: number; body?: unknown; text?: string }>): FetchStub {
+	const calls: FetchCall[] = [];
+	let i = 0;
+	const mock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input.toString();
+		const body = typeof init?.body === "string" ? safeJsonParse(init.body) : (init?.body ?? null);
+		calls.push({
+			url,
+			method: (init?.method ?? "GET").toUpperCase(),
+			headers: (init?.headers as Record<string, string>) ?? {},
+			body,
+		});
+		const next = responses[i++] ?? { status: 200, body: {} };
+		const status = next.status ?? 200;
+		if (status === 204 || status === 205 || status === 304) {
+			return new Response(null, { status });
+		}
+		const text = next.text ?? (typeof next.body === "string" ? next.body : JSON.stringify(next.body ?? {}));
+		return new Response(text, { status });
+	});
+	return { fetch: mock as unknown as typeof fetch, calls, mock };
+}
+
+function safeJsonParse(s: string): unknown {
+	try {
+		return JSON.parse(s);
+	} catch {
+		return s;
+	}
+}
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/index-test.ts
+++ b/packages/cli/src/commands/plugin-create/templates/index-test.ts
@@ -1,0 +1,27 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(inputs: TemplateInputs): string {
+	return `import { describe, expect, it } from "vitest";
+
+import { AUTH_HINT, createPlugin } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+describe("createPlugin", () => {
+	it("wires the ${inputs.capability} capability against the given fetch + token", () => {
+		const stub = stubFetch([]);
+		const plugin = createPlugin({
+			cliToken: "test-token",
+			fetch: stub.fetch,
+		});
+		expect(plugin.name).toBe("@theholocron/holocron-plugin-${inputs.slug}");
+		expect(typeof plugin.capabilities.${inputs.capability}).toBe("function");
+	});
+});
+
+describe("AUTH_HINT", () => {
+	it("mentions the holocron auth set command", () => {
+		expect(AUTH_HINT).toMatch(/holocron auth set ${inputs.slug}/);
+	});
+});
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/package-json.ts
+++ b/packages/cli/src/commands/plugin-create/templates/package-json.ts
@@ -1,0 +1,62 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(inputs: TemplateInputs): string {
+	return `{
+  "name": "@theholocron/holocron-plugin-${inputs.slug}",
+  "version": "2.0.0-alpha.1",
+  "description": "Holocron plugin for ${inputs.vendorName}. Implements the ${inputs.capability} capability against ${inputs.vendorName}'s REST API, plus exports verifyToken + AUTH_HINT for \`holocron auth\`.",
+  "homepage": "https://github.com/theholocron/holocron/tree/main/packages/holocron-plugin-${inputs.slug}#readme",
+  "bugs": "https://github.com/theholocron/holocron/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/holocron.git",
+    "directory": "packages/holocron-plugin-${inputs.slug}"
+  },
+  "license": "MIT",
+  "author": "Newton Koumantzelis",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "peerDependencies": {
+    "@theholocron/cli": "workspace:*"
+  },
+  "devDependencies": {
+    "@theholocron/cli": "workspace:*",
+    "@theholocron/tsconfig": "catalog:",
+    "@tsconfig/node-lts": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "eslint": "catalog:",
+    "globals": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "tsdown": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ]
+}
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/plugin-index.ts
+++ b/packages/cli/src/commands/plugin-create/templates/plugin-index.ts
@@ -1,0 +1,81 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(inputs: TemplateInputs): string {
+	const clientClass = `${inputs.vendorName}RestClient`;
+	// Camel-case capability name is used as the factory function name.
+	const capabilityInterface = inputs.capability.charAt(0).toUpperCase() + inputs.capability.slice(1);
+	return `/**
+ * \`@theholocron/holocron-plugin-${inputs.slug}\` — entrypoint.
+ *
+ * Implements the \`${inputs.capability}\` capability against ${inputs.vendorName}'s
+ * REST API. Also exports \`verifyToken\` + \`AUTH_HINT\` for
+ * \`holocron auth\`. See README for auth + config docs.
+ *
+ * TODO: once you fill in the ${inputs.capabilityClass} methods and add
+ * \`implements ${capabilityInterface}\` to the class, add the type import:
+ *   import type { ${capabilityInterface} } from "@theholocron/cli";
+ * and set \`: ${capabilityInterface}\` as the factory return type below.
+ */
+
+import { resolveToken, type ResolveTokenInput } from "./auth.js";
+import { ${inputs.capabilityClass} } from "./capabilities/${inputs.capability}.js";
+import { ${clientClass} } from "./rest.js";
+
+export interface ${inputs.vendorName}PluginOptions extends ResolveTokenInput {
+	/** Override base URL for tests. */
+	baseUrl?: string;
+	/** Override \`fetch\` for tests. */
+	fetch?: typeof fetch;
+}
+
+export interface PluginContext {
+	options: ${inputs.vendorName}PluginOptions;
+	rest: ${clientClass};
+}
+
+export function createContext(options: ${inputs.vendorName}PluginOptions): PluginContext {
+	const token = resolveToken(options);
+	const restOpts: ConstructorParameters<typeof ${clientClass}>[0] = { token };
+	if (options.baseUrl !== undefined) restOpts.baseUrl = options.baseUrl;
+	if (options.fetch !== undefined) restOpts.fetch = options.fetch;
+	return {
+		options,
+		rest: new ${clientClass}(restOpts),
+	};
+}
+
+export function ${inputs.capability}(ctx: PluginContext) {
+	// Return type inferred at scaffold time — the class doesn't yet
+	// \`implements ${capabilityInterface}\`. Add the type import + the
+	// \`: ${capabilityInterface}\` annotation once methods are stubbed.
+	return new ${inputs.capabilityClass}(ctx.rest);
+}
+
+export function createPlugin(options: ${inputs.vendorName}PluginOptions) {
+	const ctx = createContext(options);
+	return {
+		name: "@theholocron/holocron-plugin-${inputs.slug}",
+		capabilities: {
+			${inputs.capability}: () => ${inputs.capability}(ctx),
+		},
+	};
+}
+
+/**
+ * One-line hint printed by \`holocron auth set ${inputs.slug}\` when no
+ * token is supplied or the supplied token is rejected. Edit this to
+ * point operators at the specific ${inputs.vendorName} docs path for
+ * generating a token.
+ */
+export const AUTH_HINT =
+	"generate a ${inputs.vendorName} API token, then run: holocron auth set ${inputs.slug} <TOKEN>";
+
+// ── Public re-exports ────────────────────────────────────────────────
+
+export * from "./auth.js";
+export { ${clientClass} } from "./rest.js";
+export { ${inputs.capabilityClass} } from "./capabilities/${inputs.capability}.js";
+export { verifyToken } from "./verify-token.js";
+export type { VerifyTokenResult, VerifyTokenSuccess, VerifyTokenFailure } from "./verify-token.js";
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/readme.ts
+++ b/packages/cli/src/commands/plugin-create/templates/readme.ts
@@ -1,0 +1,68 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(inputs: TemplateInputs): string {
+	return `<!-- editorconfig-checker-disable-file -->
+
+# \`@theholocron/holocron-plugin-${inputs.slug}\`
+
+${inputs.vendorName} plugin for [Holocron](../cli). Implements the
+\`${inputs.capability}\` capability against [${inputs.vendorName}'s REST API](${inputs.baseUrl}),
+plus exports \`verifyToken\` + \`AUTH_HINT\` for use by \`holocron auth\`.
+
+## Install
+
+\`\`\`bash
+pnpm add -D @theholocron/holocron-plugin-${inputs.slug}@alpha
+\`\`\`
+
+## Auth
+
+Token resolution order (matches the standard 4-step precedence set by
+\`.notes/tech-auth-bootstrap.spec.md\`):
+
+1. \`--token <TOKEN>\` flag on the holocron invocation
+2. \`${inputs.tokenEnv}\` env var (preferred — explicit intent)
+3. \`${inputs.vendorEnv}\` env var (${inputs.vendorName}-native)
+4. **Keyring** — \`com.theholocron.cli\` service, account \`${inputs.slug}\`
+5. \`AuthError\` naming all four options + the bootstrap hint
+
+## Setup
+
+\`\`\`bash
+# Generate a ${inputs.vendorName} API token (see vendor docs), then:
+holocron auth set ${inputs.slug} <TOKEN>
+holocron auth check ${inputs.slug}    # verify
+\`\`\`
+
+## Config
+
+\`\`\`jsonc
+{
+	"providers": {
+		"${inputs.capability}": "${inputs.slug}",
+	},
+}
+\`\`\`
+
+Plugin options extend \`ResolveTokenInput\` — add whatever ${inputs.vendorName}-
+specific options you need here (project id, workspace slug, etc.) via
+the tuple form:
+
+\`\`\`jsonc
+{
+	"providers": {
+		"${inputs.capability}": ["${inputs.slug}", { "baseUrl": "${inputs.baseUrl}" }],
+	},
+}
+\`\`\`
+
+## What's implemented
+
+TODO: fill in as capability methods land.
+
+## Status
+
+**\`v2.0.0-alpha.1\`** — scaffolded via \`holocron plugin create\`.
+Not yet published; capability methods are stubs.
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/rest-test.ts
+++ b/packages/cli/src/commands/plugin-create/templates/rest-test.ts
@@ -1,0 +1,68 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(inputs: TemplateInputs): string {
+	const clientClass = `${inputs.vendorName}RestClient`;
+	return `import { ProviderApiError } from "@theholocron/cli";
+import { describe, expect, it } from "vitest";
+
+import { ${clientClass} } from "../rest.js";
+import { stubFetch } from "./helpers.js";
+
+describe("${clientClass}", () => {
+	it("sends bearer + accept headers and returns the parsed body", async () => {
+		const stub = stubFetch([{ status: 200, body: { ok: true } }]);
+		const client = new ${clientClass}({ token: "t", fetch: stub.fetch });
+		const res = await client.request<{ ok: boolean }>("/me");
+		expect(res.ok).toBe(true);
+		expect(stub.calls[0]?.headers["authorization"]).toBe("Bearer t");
+		expect(stub.calls[0]?.headers["accept"]).toBe("application/json");
+	});
+
+	it("serializes body as JSON and sets content-type when present", async () => {
+		const stub = stubFetch([{ status: 200, body: {} }]);
+		const client = new ${clientClass}({ token: "t", fetch: stub.fetch });
+		await client.request<unknown>("/resource", { method: "POST", body: { name: "demo" } });
+		expect(stub.calls[0]?.method).toBe("POST");
+		expect(stub.calls[0]?.headers["content-type"]).toBe("application/json");
+		expect(stub.calls[0]?.body).toEqual({ name: "demo" });
+	});
+
+	it("returns undefined on 204", async () => {
+		const stub = stubFetch([{ status: 204 }]);
+		const client = new ${clientClass}({ token: "t", fetch: stub.fetch });
+		expect(await client.request<unknown>("/whatever")).toBeUndefined();
+	});
+
+	it("throws ProviderApiError with the HTTP status on non-2xx", async () => {
+		const stub = stubFetch([{ status: 401, body: { messages: ["invalid"] } }]);
+		const client = new ${clientClass}({ token: "bad", fetch: stub.fetch });
+		try {
+			await client.request<unknown>("/me");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as ProviderApiError).status).toBe(401);
+		}
+	});
+
+	it("wraps transport-level failures with status 0", async () => {
+		const throwing: typeof fetch = async () => {
+			throw new TypeError("fetch failed");
+		};
+		const client = new ${clientClass}({ token: "t", fetch: throwing });
+		try {
+			await client.request<unknown>("/me");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as ProviderApiError).status).toBe(0);
+		}
+	});
+
+	it("trims trailing slashes from the base URL", () => {
+		const client = new ${clientClass}({ token: "t", baseUrl: "${inputs.baseUrl}//" });
+		expect(client.baseUrl).toBe("${inputs.baseUrl}");
+	});
+});
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/rest.ts
+++ b/packages/cli/src/commands/plugin-create/templates/rest.ts
@@ -1,0 +1,80 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(inputs: TemplateInputs): string {
+	const clientClass = `${inputs.vendorName}RestClient`;
+	return `/**
+ * Thin REST wrapper around ${inputs.baseUrl}.
+ *
+ * Bearer auth, JSON-only bodies, transport-failure wrapping with
+ * \`status: 0\` so orchestrator soft-skip paths see a clear message
+ * instead of a generic \`TypeError: fetch failed\`.
+ */
+
+import { ProviderApiError } from "@theholocron/cli";
+
+export interface RestClientOptions {
+	token: string;
+	fetch?: typeof fetch;
+	baseUrl?: string;
+}
+
+export interface RequestOptions {
+	method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+	body?: unknown;
+	query?: Record<string, string>;
+	/** Treat this response as void even if 200 is returned. */
+	expectNoContent?: boolean;
+}
+
+export class ${clientClass} {
+	private readonly token: string;
+	private readonly fetchImpl: typeof fetch;
+	readonly baseUrl: string;
+
+	constructor(opts: RestClientOptions) {
+		this.token = opts.token;
+		this.fetchImpl = opts.fetch ?? globalThis.fetch;
+		// Manual trailing-slash trim — CodeQL flags regex on library
+		// input as polynomial ReDoS. O(n) loop, no backtracking risk.
+		let url = opts.baseUrl ?? "${inputs.baseUrl}";
+		while (url.endsWith("/")) url = url.slice(0, -1);
+		this.baseUrl = url;
+	}
+
+	async request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
+		const url = new URL(\`\${this.baseUrl}\${path.startsWith("/") ? path : "/" + path}\`);
+		for (const [k, v] of Object.entries(opts.query ?? {})) url.searchParams.set(k, v);
+		const fullUrl = url.toString();
+
+		const headers: Record<string, string> = {
+			authorization: \`Bearer \${this.token}\`,
+			accept: "application/json",
+		};
+		const init: RequestInit = {
+			method: opts.method ?? "GET",
+			headers,
+		};
+		if (opts.body !== undefined) {
+			headers["content-type"] = "application/json";
+			init.body = JSON.stringify(opts.body);
+		}
+
+		let res: Response;
+		try {
+			res = await this.fetchImpl(fullUrl, init);
+		} catch (err) {
+			const detail = err instanceof Error ? \`\${err.name}: \${err.message}\` : String(err);
+			throw new ProviderApiError(\`${inputs.vendorName} \${init.method} \${path} failed: \${detail}\`, 0, undefined);
+		}
+		if (!res.ok) {
+			const body = await res.text().catch(() => "");
+			throw new ProviderApiError(\`${inputs.vendorName} \${init.method} \${path} → \${res.status}\`, res.status, body);
+		}
+		if (opts.expectNoContent || res.status === 204) return undefined as T;
+		const text = await res.text();
+		if (!text) return undefined as T;
+		return JSON.parse(text) as T;
+	}
+}
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/tsconfig-json.ts
+++ b/packages/cli/src/commands/plugin-create/templates/tsconfig-json.ts
@@ -1,0 +1,18 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(inputs: TemplateInputs): string {
+	return `{
+  "display": "Holocron Plugin: ${inputs.vendorName}",
+  "extends": "@tsconfig/node-lts/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/tsdown-config.ts
+++ b/packages/cli/src/commands/plugin-create/templates/tsdown-config.ts
@@ -1,0 +1,14 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(_inputs: TemplateInputs): string {
+	return `import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	format: "esm",
+	dts: true,
+	clean: true,
+	deps: { neverBundle: [/^@theholocron\\//] },
+});
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/verify-token-test.ts
+++ b/packages/cli/src/commands/plugin-create/templates/verify-token-test.ts
@@ -1,0 +1,40 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(_inputs: TemplateInputs): string {
+	return `import { describe, expect, it } from "vitest";
+
+import { verifyToken } from "../verify-token.js";
+import { stubFetch } from "./helpers.js";
+
+describe("verifyToken", () => {
+	it("returns ok with a subject when /me returns 200", async () => {
+		const stub = stubFetch([{ status: 200, body: { email: "user@example.com" } }]);
+		const result = await verifyToken("token", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/user@example.com/);
+		}
+	});
+
+	it("returns ok:false with the error message on 401", async () => {
+		const stub = stubFetch([{ status: 401, body: { messages: ["Invalid token"] } }]);
+		const result = await verifyToken("bad", { fetch: stub.fetch });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/→ 401/);
+		}
+	});
+
+	it("returns ok:false when the network layer throws", async () => {
+		const throwing: typeof fetch = async () => {
+			throw new TypeError("network down");
+		};
+		const result = await verifyToken("t", { fetch: throwing });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/network down/);
+		}
+	});
+});
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/verify-token.ts
+++ b/packages/cli/src/commands/plugin-create/templates/verify-token.ts
@@ -51,7 +51,8 @@ export async function verifyToken(token: string, opts: VerifyTokenOptions = {}):
 	const rest = new ${clientClass}(restOpts);
 	try {
 		const me = await rest.request<MeResponse>("/me");
-		const subject = me.email ?? me.name ?? me.id ?? "unknown";
+		// Optional chaining because \`me\` is \`undefined\` on 204 / empty body.
+		const subject = me?.email ?? me?.name ?? me?.id ?? "unknown";
 		return { ok: true, subject: \`user @ \${subject}\` };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/commands/plugin-create/templates/verify-token.ts
+++ b/packages/cli/src/commands/plugin-create/templates/verify-token.ts
@@ -1,0 +1,62 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(inputs: TemplateInputs): string {
+	const clientClass = `${inputs.vendorName}RestClient`;
+	return `/**
+ * \`verifyToken\` — plugin-level export used by \`holocron auth set\` +
+ * \`holocron auth check\`. Hits a lightweight whoami-style endpoint
+ * and translates the response into the normalized \`VerifyTokenResult\`
+ * shape.
+ *
+ * Kept as a standalone function (not a capability method) so the auth
+ * command can call it without initializing the full plugin — plugin
+ * construction requires an already-resolved token, which is exactly
+ * what we don't have yet at bootstrap time.
+ *
+ * TODO: replace \`/me\` with the ${inputs.vendorName} equivalent of a
+ * "check my token" endpoint. Common shapes: \`/user\`, \`/whoami\`,
+ * \`/me\`, \`/account\`.
+ */
+
+import { ${clientClass} } from "./rest.js";
+
+export interface VerifyTokenSuccess {
+	ok: true;
+	subject: string;
+}
+
+export interface VerifyTokenFailure {
+	ok: false;
+	message: string;
+}
+
+export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
+
+interface MeResponse {
+	/** Adjust to whatever ${inputs.vendorName}'s whoami endpoint returns. */
+	name?: string;
+	email?: string;
+	id?: string;
+}
+
+export interface VerifyTokenOptions {
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+export async function verifyToken(token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
+	const restOpts: ConstructorParameters<typeof ${clientClass}>[0] = { token };
+	if (opts.baseUrl !== undefined) restOpts.baseUrl = opts.baseUrl;
+	if (opts.fetch !== undefined) restOpts.fetch = opts.fetch;
+	const rest = new ${clientClass}(restOpts);
+	try {
+		const me = await rest.request<MeResponse>("/me");
+		const subject = me.email ?? me.name ?? me.id ?? "unknown";
+		return { ok: true, subject: \`user @ \${subject}\` };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { ok: false, message };
+	}
+}
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/vitest-config.ts
+++ b/packages/cli/src/commands/plugin-create/templates/vitest-config.ts
@@ -1,0 +1,20 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+export function render(_inputs: TemplateInputs): string {
+	return `import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+		globals: false,
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "json-summary"],
+			include: ["src/**/*.ts"],
+			exclude: ["src/**/__tests__/**", "src/**/*.test.ts", "src/index.ts"],
+			thresholds: { lines: 0, functions: 0, branches: 0, statements: 0 },
+		},
+	},
+});
+`;
+}

--- a/packages/holocron-plugin-github/src/__tests__/auth.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/auth.test.ts
@@ -45,8 +45,6 @@ describe("resolveToken", () => {
 	});
 
 	it("ignores empty-string cliToken (treats as absent)", () => {
-		expect(
-			resolveToken({ cliToken: "", env: { GITHUB_TOKEN: "gha-pat" }, keyring: noKeyring })
-		).toBe("gha-pat");
+		expect(resolveToken({ cliToken: "", env: { GITHUB_TOKEN: "gha-pat" }, keyring: noKeyring })).toBe("gha-pat");
 	});
 });

--- a/packages/holocron-plugin-github/src/__tests__/index.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/index.test.ts
@@ -19,9 +19,7 @@ const LABELS = { inProgress: "status:in-progress", inReview: "status:in-review" 
 
 describe("createPlugin", () => {
 	it("throws AuthError when no token is found", () => {
-		expect(() =>
-			createPlugin({ repo: "theholocron/holocron", env: {}, keyring: () => null })
-		).toThrow(AuthError);
+		expect(() => createPlugin({ repo: "theholocron/holocron", env: {}, keyring: () => null })).toThrow(AuthError);
 	});
 
 	it("wires every capability with the right concrete implementation", () => {


### PR DESCRIPTION
## Summary

First-class CLI command replacing the manual scaffolding skill. Produces 17 files under `packages/holocron-plugin-<slug>/` matching the proven plugin template, including the session-derived keyring + `verifyToken` + `AUTH_HINT` conventions established in #94 / #95.

Design spec: [`.notes/tool-plugin-create.spec.md`](.notes/tool-plugin-create.spec.md).

## Usage

```bash
pnpm holocron plugin create clerk Clerk \
    --capability auth \
    --vendor-env CLERK_SECRET_KEY \
    --base-url https://api.clerk.com/v1
```

Produces:

```
packages/holocron-plugin-clerk/
├── package.json / tsconfig.json / vitest.config.ts / eslint.config.js / tsdown.config.ts
├── README.md
└── src/
    ├── auth.ts               # 4-step keyring precedence
    ├── rest.ts               # bearer + status-0 transport-failure wrapping
    ├── verify-token.ts       # plugin-level export
    ├── index.ts              # createPlugin + verifyToken + AUTH_HINT
    ├── capabilities/auth.ts  # class stub
    └── __tests__/
        ├── helpers.ts        # stubFetch
        ├── auth.test.ts
        ├── rest.test.ts
        ├── verify-token.test.ts
        ├── auth.test.ts      # capability tests (constructor + it.todo)
        └── index.test.ts
```

## Command flow

- **Preflight** — checks `pnpm-workspace.yaml` + `packages/` presence
- **Slug collision** — refuses to overwrite existing packages
- **Capability validation** — must be one of the 14 known keys; prints many-cardinality warning
- **Generate** — writes 17 templates with `{{capability}}` path substitution
- **`--dry-run`** — enumerates files with byte counts, writes nothing
- **7-step "next steps"** — printed after generation to guide operator through pnpm install / typecheck / lint / test / implement methods

## Test plan

- [x] `pnpm typecheck` clean workspace-wide
- [x] `pnpm lint` clean workspace-wide
- [x] `pnpm test` — 10 new unit tests for the orchestrator (file count, path substitution, dry-run, preflight, slug collision, capability validation, many-cardinality warning, rendered-content sanity)
- [x] Manual integration test — scaffolded a throwaway `testvendor` plugin with `--capability tooling`, ran `pnpm --filter @theholocron/holocron-plugin-testvendor typecheck lint test` → all 3 gates green
- [ ] Phase 1b — automated integration test behind an env flag (spawns pnpm install + typechecks the generated package)

## Design choices worth calling out

- **Capability class stubs don't declare `implements`** at scaffold time (both typecheck AND lint stay clean; operator adds `implements <Interface>` once methods land). Explained in the generated capability file's TODO comment.
- **`{{capability}}` path substitution** in template registry means `src/capabilities/{{capability}}.ts` → `src/capabilities/auth.ts` etc. at generation time.
- **Templates as inline TS string builders** (not `.tmpl` files) per the spec — no template engine dep, typechecked against a shared `TemplateInputs`, editor jumps to source directly.

## What's Phase 1b (not this PR)

Tracked in the spec's Roadmap:

- Interactive prompts for missing `--capability` / `--vendor-env` / `--base-url` (today errors clearly with all-flags-required message)
- Post-scaffold verify step — the `--no-verify` flag already exists in yargs; wiring the actual `pnpm install && pnpm --filter <pkg> typecheck lint test` invocation is next
- Automated end-to-end integration test behind `RUN_PLUGIN_CREATE_E2E=1`

## Skill deprecation

`.claude/skills/holocron-plugin.md` reduced from ~200 lines of manual scaffolding instructions to a ~30-line stub pointing operators at the new CLI + linking the design specs.

## Follow-ups after this merges

- Use `holocron plugin create` to scaffold `@theholocron/holocron-plugin-infisical` (issue #97) as the first real acceptance test of this command in production.

Refs #77.
