### PR TITLE
feat(infisical): add @theholocron/holocron-plugin-infisical (#97)

### DIFF
--- a/.claude/skills/holocron-plugin.md
+++ b/.claude/skills/holocron-plugin.md
@@ -53,7 +53,6 @@ Then follow the "Next" steps printed by the command:
 
 ## Command source
 
-`packages/cli/src/commands/plugin-create/` — 18 templates + orchestrator
-
-- unit tests. Editing a template ripples to every future plugin
-  scaffolded by this command.
+`packages/cli/src/commands/plugin-create/` — 18 templates,
+orchestrator, and unit tests. Editing a template ripples to every
+future plugin scaffolded by this command.

--- a/.claude/skills/holocron-plugin.md
+++ b/.claude/skills/holocron-plugin.md
@@ -17,7 +17,7 @@ pnpm holocron plugin create <slug> <vendor> \
     --base-url <https://api.vendor.example>
 ```
 
-The command produces 17 files under `packages/holocron-plugin-<slug>/`
+The command produces 18 files under `packages/holocron-plugin-<slug>/`
 matching the same template this skill used to hand-craft:
 
 - 5 config files (`package.json`, `tsconfig.json`, `vitest.config.ts`,
@@ -29,6 +29,9 @@ matching the same template this skill used to hand-craft:
 - 6 test files (`helpers.ts`, `auth.test.ts`, `rest.test.ts`,
   `verify-token.test.ts`, `<key>.test.ts` with `it.todo`,
   `index.test.ts`)
+- 1 validation script (`scripts/validate.mjs`) — read-only smoke
+  test against a live vendor account; invoked via
+  `pnpm --filter @theholocron/holocron-plugin-<slug> validate`
 
 Then follow the "Next" steps printed by the command:
 
@@ -50,6 +53,7 @@ Then follow the "Next" steps printed by the command:
 
 ## Command source
 
-`packages/cli/src/commands/plugin-create/` — 17 templates + orchestrator
-+ unit tests. Editing a template ripples to every future plugin
-scaffolded by this command.
+`packages/cli/src/commands/plugin-create/` — 18 templates + orchestrator
+
+- unit tests. Editing a template ripples to every future plugin
+  scaffolded by this command.

--- a/.notes/tech-setup-and-config.spec.md
+++ b/.notes/tech-setup-and-config.spec.md
@@ -39,7 +39,7 @@ migration) exposed gaps in setup ergonomics:
    from loading.** `holocron-plugin-github`'s `issues` factory used
    to throw at construction if `labels` was missing. Even for
    commands that never touch the issues capability (e.g., `holocron
-   setup`), the load-time error aborted the whole run.
+setup`), the load-time error aborted the whole run.
 
 Plus the ORIGINAL #82 scope — `holocron setup` doesn't yet touch
 repo-level policy or branch protection, both of which belong in the
@@ -120,6 +120,28 @@ Open question: does the policy shape live in the top-level config
 (`providers.source: ["github", { policy: {...} }]`)? Leaning
 top-level since it's provider-agnostic (GitLab et al. will need the
 same concept).
+
+### Environment slug convention (discovered during Infisical validation)
+
+`runSetup` currently hardcodes `["dev", "stg", "prd"]` when calling
+`vault.ensureEnvironment`. That matches Doppler's short-slug
+convention, but Infisical ships `dev` / `staging` / `prod` as its
+default environment slugs — running setup against Infisical would
+create additional `stg` and `prd` envs alongside the existing
+`staging` and `prod` (idempotent, not destructive, but noisy).
+
+Fix options:
+
+- **`project.environments`** top-level config field with the operator's
+  chosen env slugs (`["dev", "staging", "prod"]` or whatever)
+- **Per-vault-provider env name mapping** in plugin options (more
+  scoped but pushes the concern into every vault plugin)
+
+Leaning **`project.environments`** — same rationale as `project.repo`:
+it's a project-wide concept, not a vault-specific one. The other
+capabilities that iterate over environments (`environments.upsertEnvironment`
+in the github plugin, currently hardcoded to `["staging", "production"]`)
+should read the same field for consistency.
 
 ## Roadmap
 

--- a/.notes/tech-vault-choice.spec.md
+++ b/.notes/tech-vault-choice.spec.md
@@ -169,11 +169,13 @@ the new CLI so #77 gets a real-world acceptance test.
   `https://api.doppler.com/v3`. Ship as its own PR.
 - **Phase 2**: Ship #77 Phase 1 (`holocron plugin create` REST-only).
   See `.notes/tool-plugin-create.spec.md`.
-- **Phase 3**: Build `@theholocron/holocron-plugin-infisical` via
-  `holocron plugin create infisical Infisical`. Same plugin shape,
-  Infisical's REST API. This doubles as the acceptance test for
-  #77 Phase 1 — if the CLI can't produce a green plugin, the CLI
-  isn't done.
+- **Phase 3** (shipped): Built `@theholocron/holocron-plugin-infisical`
+  via `holocron plugin create infisical Infisical --capability vault
+  --vendor-env INFISICAL_TOKEN --base-url https://app.infisical.com/api`.
+  Same plugin shape, Infisical's REST API. Doubled as the first
+  real production use of #77's CLI — 17 files scaffolded, gate
+  green from the get-go, only the vault capability methods needed
+  filling in. Filed as #97.
 - **Phase 4**: Migrate this repo's own `holocron.config.json`
   vault from `1password` to `doppler` (or `infisical` — operator
   choice). Dump secrets from 1Password, push to chosen vault, flip

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@theholocron/holocron-plugin-clerk": "workspace:*",
     "@theholocron/holocron-plugin-doppler": "workspace:*",
     "@theholocron/holocron-plugin-github": "workspace:*",
+    "@theholocron/holocron-plugin-infisical": "workspace:*",
     "@theholocron/holocron-plugin-neon": "workspace:*",
     "@theholocron/holocron-plugin-postman": "workspace:*",
     "@theholocron/holocron-plugin-vercel": "workspace:*",

--- a/packages/cli/src/__tests__/plugin-create.test.ts
+++ b/packages/cli/src/__tests__/plugin-create.test.ts
@@ -35,7 +35,7 @@ const BASE_INPUT = {
 };
 
 describe("runPluginCreate — orchestrator", () => {
-	it("emits exactly 17 files (5 config + 1 readme + 5 source + 6 tests)", () => {
+	it("emits exactly 18 files (5 config + 1 readme + 5 source + 6 tests + 1 script)", () => {
 		const fs = makeFakeFs();
 		const report = runPluginCreate({
 			...BASE_INPUT,

--- a/packages/cli/src/__tests__/plugin-create.test.ts
+++ b/packages/cli/src/__tests__/plugin-create.test.ts
@@ -43,8 +43,8 @@ describe("runPluginCreate — orchestrator", () => {
 			print: () => {},
 		});
 		expect(report.status).toBe("ok");
-		expect(report.filesWritten).toHaveLength(17);
-		expect(fs.size()).toBe(17);
+		expect(report.filesWritten).toHaveLength(18);
+		expect(fs.size()).toBe(18);
 	});
 
 	it("resolves {{capability}} in paths to the chosen capability key", () => {
@@ -70,7 +70,7 @@ describe("runPluginCreate — orchestrator", () => {
 		});
 		expect(report.status).toBe("ok");
 		expect(fs.size()).toBe(0);
-		expect(report.filesWritten).toHaveLength(17);
+		expect(report.filesWritten).toHaveLength(18);
 	});
 
 	it("preflight fails when CWD is not a workspace root", () => {

--- a/packages/cli/src/commands/plugin-create/index.ts
+++ b/packages/cli/src/commands/plugin-create/index.ts
@@ -39,6 +39,7 @@ import { render as renderRest } from "./templates/rest.js";
 import { render as renderRestTest } from "./templates/rest-test.js";
 import { render as renderTsconfigJson } from "./templates/tsconfig-json.js";
 import { render as renderTsdownConfig } from "./templates/tsdown-config.js";
+import { render as renderValidateScript } from "./templates/validate-script.js";
 import { render as renderVerifyToken } from "./templates/verify-token.js";
 import { render as renderVerifyTokenTest } from "./templates/verify-token-test.js";
 import { render as renderVitestConfig } from "./templates/vitest-config.js";
@@ -111,6 +112,8 @@ const TEMPLATES: TemplateEntry[] = [
 	{ path: "src/__tests__/verify-token.test.ts", render: renderVerifyTokenTest },
 	{ path: "src/__tests__/{{capability}}.test.ts", render: renderCapabilityTest },
 	{ path: "src/__tests__/index.test.ts", render: renderIndexTest },
+	// Live-account validation script (1) — read-only smoke test.
+	{ path: "scripts/validate.mjs", render: renderValidateScript },
 ];
 
 /** Replace `{{capability}}` in a template path with the actual capability key. */
@@ -251,7 +254,7 @@ function defaultWrite(filepath: string, content: string): void {
 
 function printNextSteps(print: (line: string) => void, inputs: TemplateInputs): void {
 	print("");
-	print(`  Scaffolded @theholocron/holocron-plugin-${inputs.slug} (17 files).`);
+	print(`  Scaffolded @theholocron/holocron-plugin-${inputs.slug} (18 files).`);
 	print("");
 	print("  Next:");
 	print(

--- a/packages/cli/src/commands/plugin-create/templates/package-json.ts
+++ b/packages/cli/src/commands/plugin-create/templates/package-json.ts
@@ -25,7 +25,8 @@ export function render(inputs: TemplateInputs): string {
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
     "@theholocron/cli": "workspace:*"
@@ -39,7 +40,8 @@ export function render(inputs: TemplateInputs): string {
     "globals": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "tsdown": "catalog:"
+    "tsdown": "catalog:",
+    "tsx": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/cli/src/commands/plugin-create/templates/validate-script.ts
+++ b/packages/cli/src/commands/plugin-create/templates/validate-script.ts
@@ -1,0 +1,74 @@
+import type { TemplateInputs } from "../template-inputs.js";
+
+/**
+ * Scaffolds `scripts/validate.mjs` — a smoke-test the operator runs
+ * against a live vendor account to verify the plugin's REST endpoints,
+ * auth, and response parsing all work in reality (the unit tests only
+ * exercise stubbed HTTP responses). READ-ONLY BY DESIGN.
+ *
+ * Convention: every plugin ships this script + a matching `validate`
+ * entry in `package.json`'s scripts block, so operators run
+ * `pnpm --filter @theholocron/holocron-plugin-<slug> validate`.
+ * Capability-specific args (project id, workspace, etc.) come from
+ * positional command-line arguments; the plugin author fills in the
+ * exact shape per their vendor.
+ */
+export function render(inputs: TemplateInputs): string {
+	return `#!/usr/bin/env node
+/**
+ * Read-only smoke test for @theholocron/holocron-plugin-${inputs.slug} against
+ * a live ${inputs.vendorName} account.
+ *
+ * READ-ONLY BY DESIGN. Never calls write(), or bootstrap methods
+ * (\`ensureProject\`, \`ensureEnvironment\`, etc.). Any ERROR line means
+ * the plugin needs adjusting.
+ *
+ * Auth: reads the ${inputs.vendorName} token from holocron's keyring —
+ * you must have run \`pnpm holocron auth set ${inputs.slug} <TOKEN>\` first.
+ *
+ * Usage:
+ *   pnpm --filter @theholocron/holocron-plugin-${inputs.slug} validate <arg1> [arg2] ...
+ *
+ * TODO: replace the positional args below with whatever your
+ * capability's methods need (e.g., project id, environment slug,
+ * secret name). Adapt the test steps to your capability's method
+ * surface. Model on \`packages/holocron-plugin-infisical/scripts/validate.mjs\`
+ * or \`packages/holocron-plugin-doppler/scripts/validate.mjs\` (if it
+ * exists).
+ */
+
+import { getToken } from "@theholocron/cli";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- filled in by operator
+import { createPlugin, verifyToken } from "../src/index.ts";
+
+const args = process.argv.slice(2);
+
+if (args.length === 0) {
+	console.error("usage: pnpm --filter @theholocron/holocron-plugin-${inputs.slug} validate <args>");
+	process.exit(2);
+}
+
+const token = getToken("${inputs.slug}");
+if (!token) {
+	console.error("no ${inputs.vendorName} token in keyring. Run: pnpm holocron auth set ${inputs.slug} <TOKEN>");
+	process.exit(2);
+}
+
+console.log("Validating @theholocron/holocron-plugin-${inputs.slug} (READ-ONLY)");
+console.log("");
+
+// ── 1. verifyToken ─────────────────────────────────────────────────
+console.log("[1/N] verifyToken");
+const verifyResult = await verifyToken(token);
+console.log(\`      \${verifyResult.ok ? "✓" : "✗"} \${JSON.stringify(verifyResult)}\`);
+console.log("");
+
+// ── 2..N. capability method calls ──────────────────────────────────
+// TODO: implement one console.log-wrapped call per meaningful
+// read-side capability method. Model on the infisical / doppler
+// validate.mjs. Never call write / ensure* / other mutating paths.
+
+console.log("Done. Fill in capability method calls above before shipping.");
+`;
+}

--- a/packages/cli/src/commands/plugin-create/templates/validate-script.ts
+++ b/packages/cli/src/commands/plugin-create/templates/validate-script.ts
@@ -12,6 +12,11 @@ import type { TemplateInputs } from "../template-inputs.js";
  * Capability-specific args (project id, workspace, etc.) come from
  * positional command-line arguments; the plugin author fills in the
  * exact shape per their vendor.
+ *
+ * Includes a `hintFor(message)` helper the operator customizes with
+ * vendor-specific "here's the likely fix" guidance for common error
+ * shapes (401 / 403 / 404 / network / 5xx). Points users at docs and
+ * setup steps rather than leaving them staring at a raw stack trace.
  */
 export function render(inputs: TemplateInputs): string {
 	return `#!/usr/bin/env node
@@ -21,7 +26,8 @@ export function render(inputs: TemplateInputs): string {
  *
  * READ-ONLY BY DESIGN. Never calls write(), or bootstrap methods
  * (\`ensureProject\`, \`ensureEnvironment\`, etc.). Any ERROR line means
- * the plugin needs adjusting.
+ * the plugin needs adjusting — the \`hintFor\` helper below points at
+ * the most likely fix per error shape.
  *
  * Auth: reads the ${inputs.vendorName} token from holocron's keyring —
  * you must have run \`pnpm holocron auth set ${inputs.slug} <TOKEN>\` first.
@@ -32,9 +38,7 @@ export function render(inputs: TemplateInputs): string {
  * TODO: replace the positional args below with whatever your
  * capability's methods need (e.g., project id, environment slug,
  * secret name). Adapt the test steps to your capability's method
- * surface. Model on \`packages/holocron-plugin-infisical/scripts/validate.mjs\`
- * or \`packages/holocron-plugin-doppler/scripts/validate.mjs\` (if it
- * exists).
+ * surface. Model on \`packages/holocron-plugin-infisical/scripts/validate.mjs\`.
  */
 
 import { getToken } from "@theholocron/cli";
@@ -52,6 +56,7 @@ if (args.length === 0) {
 const token = getToken("${inputs.slug}");
 if (!token) {
 	console.error("no ${inputs.vendorName} token in keyring. Run: pnpm holocron auth set ${inputs.slug} <TOKEN>");
+	console.error("  see: packages/holocron-plugin-${inputs.slug}/README.md#setup");
 	process.exit(2);
 }
 
@@ -62,13 +67,62 @@ console.log("");
 console.log("[1/N] verifyToken");
 const verifyResult = await verifyToken(token);
 console.log(\`      \${verifyResult.ok ? "✓" : "✗"} \${JSON.stringify(verifyResult)}\`);
+if (!verifyResult.ok) {
+	const hint = hintFor(verifyResult.message);
+	if (hint) console.log(\`         hint: \${hint}\`);
+}
 console.log("");
 
 // ── 2..N. capability method calls ──────────────────────────────────
-// TODO: implement one console.log-wrapped call per meaningful
-// read-side capability method. Model on the infisical / doppler
-// validate.mjs. Never call write / ensure* / other mutating paths.
+// TODO: implement one \`runStep\`-wrapped call per meaningful read-side
+// capability method. Model on the infisical validate.mjs. Never call
+// write / ensure* / other mutating paths.
+//
+// Example:
+//   console.log("[2/N] vault.list()");
+//   await runStep(async () => {
+//       const keys = await vault.list();
+//       console.log(\`      ✓ \${keys.length} secrets\`);
+//   });
 
 console.log("Done. Fill in capability method calls above before shipping.");
+
+// ── helpers ────────────────────────────────────────────────────────
+
+/** Wrap a capability call, print ERROR + hint on failure. */
+async function runStep(body) {
+	try {
+		await body();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.log(\`      ✗ ERROR: \${message}\`);
+		const hint = hintFor(message);
+		if (hint) console.log(\`         hint: \${hint}\`);
+	}
+}
+
+/**
+ * Point the operator at the most likely fix based on the error shape.
+ * Generic defaults below — CUSTOMIZE per your vendor's docs URLs and
+ * common permission/config gotchas.
+ */
+function hintFor(message) {
+	if (/→ 401/.test(message)) {
+		return "token invalid — regenerate per ${inputs.vendorName}'s docs (see README §Setup)";
+	}
+	if (/→ 403/.test(message)) {
+		return "token authenticates but lacks scope — check the token/identity has permissions on the resource";
+	}
+	if (/→ 404/.test(message)) {
+		return "endpoint or resource not found — verify your positional args match a real resource";
+	}
+	if (/fetch failed|status: 0|network/i.test(message)) {
+		return "network error — check the base URL (${inputs.baseUrl}) and connectivity";
+	}
+	if (/→ 5\\d\\d/.test(message)) {
+		return "server error — vendor-side. Retry, and check the vendor's status page if persistent";
+	}
+	return null;
+}
 `;
 }

--- a/packages/cli/src/commands/plugin-create/templates/validate-script.ts
+++ b/packages/cli/src/commands/plugin-create/templates/validate-script.ts
@@ -41,10 +41,8 @@ export function render(inputs: TemplateInputs): string {
  * surface. Model on \`packages/holocron-plugin-infisical/scripts/validate.mjs\`.
  */
 
-import { getToken } from "@theholocron/cli";
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- filled in by operator
-import { createPlugin, verifyToken } from "../src/index.ts";
+import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
 
 const args = process.argv.slice(2);
 
@@ -53,11 +51,21 @@ if (args.length === 0) {
 	process.exit(2);
 }
 
-const token = getToken("${inputs.slug}");
-if (!token) {
-	console.error("no ${inputs.vendorName} token in keyring. Run: pnpm holocron auth set ${inputs.slug} <TOKEN>");
-	console.error("  see: packages/holocron-plugin-${inputs.slug}/README.md#setup");
-	process.exit(2);
+// Use the plugin's own auth resolution so the validate script honors
+// the same 4-step precedence as the plugin's runtime:
+//   --token → ${inputs.tokenEnv} → ${inputs.vendorEnv} → keyring
+// (--token isn't available here since this is a bare Node script;
+// the other three all work.)
+let token;
+try {
+	token = resolveToken();
+} catch (err) {
+	if (err instanceof AuthError) {
+		console.error(err.message);
+		console.error("  see: packages/holocron-plugin-${inputs.slug}/README.md#setup");
+		process.exit(2);
+	}
+	throw err;
 }
 
 console.log("Validating @theholocron/holocron-plugin-${inputs.slug} (READ-ONLY)");

--- a/packages/holocron-plugin-infisical/README.md
+++ b/packages/holocron-plugin-infisical/README.md
@@ -48,18 +48,35 @@ by `.notes/tech-auth-bootstrap.spec.md`):
 
 ## Setup
 
+**Important**: this plugin sends the stored value as
+`Authorization: Bearer <token>` directly. That means you need a token
+that IS a bearer, not a credential-pair that needs an exchange.
+
+Two token types work out of the box:
+
+- **Personal API Token** — inherits your user permissions, simplest
+  path.
+- **Token Auth** on a machine identity — long-lived, single-string
+  token. In Infisical: **organization access control → identities →
+  your identity → add auth method → Token Auth → create token**.
+
+**Universal Auth's Client Secret does NOT work directly** —
+Universal Auth is a two-step flow (client id + client secret → login
+endpoint → short-lived access token). Support for that exchange is
+tracked as a follow-up; for now, use one of the two above.
+
 ```bash
-# 1. Generate an Infisical token. Either token type works — see
-#    https://infisical.com/docs for the current click path since
-#    Infisical's dashboard reshuffles occasionally:
-#      - Personal API Token — dashboard user profile → API tokens
-#      - Universal Auth (machine identity, recommended for CI)
-#        — organization access control → identities → create
+# 1. Generate the token per the note above.
 # 2. Hand it off to holocron's keyring (one-shot):
 holocron auth set infisical <TOKEN>
 # 3. Verify (calls GET /v1/workspace and reports accessible workspaces):
 holocron auth check infisical
 ```
+
+**If you have a machine identity that's Universal-Auth-only**: add a
+Token Auth authentication method to the SAME identity — you don't
+have to create a new identity. Machine identities can have multiple
+auth methods attached.
 
 **CI**: the keyring is not available in headless containers. Expose
 the token as a GitHub Actions secret and set `HOLOCRON_INFISICAL_TOKEN`

--- a/packages/holocron-plugin-infisical/README.md
+++ b/packages/holocron-plugin-infisical/README.md
@@ -49,12 +49,15 @@ by `.notes/tech-auth-bootstrap.spec.md`):
 ## Setup
 
 ```bash
-# 1. Generate a Universal Auth token in the Infisical dashboard:
-#    Access Control → Machine Identities → Create → Universal Auth
-#    Copy the token (starts with `st.`).
+# 1. Generate an Infisical token. Either token type works — see
+#    https://infisical.com/docs for the current click path since
+#    Infisical's dashboard reshuffles occasionally:
+#      - Personal API Token — dashboard user profile → API tokens
+#      - Universal Auth (machine identity, recommended for CI)
+#        — organization access control → identities → create
 # 2. Hand it off to holocron's keyring (one-shot):
 holocron auth set infisical <TOKEN>
-# 3. Verify:
+# 3. Verify (calls GET /v1/workspace and reports accessible workspaces):
 holocron auth check infisical
 ```
 
@@ -104,10 +107,10 @@ doesn't make sense.
 Plugin-level exports (not capability methods, per the auth-bootstrap
 convention):
 
-| Export        | Purpose                                                                                   |
-| ------------- | ----------------------------------------------------------------------------------------- |
-| `verifyToken` | `GET /v1/users/me` — returns `{ok: true, subject: "user @ …"}` or `{ok: false, message}`. |
-| `AUTH_HINT`   | Directs operators at the Universal Auth flow in the Infisical dashboard.                  |
+| Export        | Purpose                                                                                                                                                                           |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `verifyToken` | `GET /v1/workspace` — returns `{ok: true, subject: "<n> workspaces · first: …"}` or `{ok: false, message}`. Works for both Personal Tokens and Universal Auth machine identities. |
+| `AUTH_HINT`   | Points at Infisical's docs for token generation (rather than a specific click path — dashboard UI shifts).                                                                        |
 
 ## Self-hosted Infisical
 

--- a/packages/holocron-plugin-infisical/README.md
+++ b/packages/holocron-plugin-infisical/README.md
@@ -1,0 +1,138 @@
+<!-- editorconfig-checker-disable-file -->
+
+# `@theholocron/holocron-plugin-infisical`
+
+Infisical plugin for [Holocron](../cli). Implements the `vault`
+capability against [Infisical's REST API](https://infisical.com/docs/api-reference/overview/introduction),
+plus exports `verifyToken` + `AUTH_HINT` for use by `holocron auth`.
+
+## One of several vault providers
+
+`vault` is a REQUIRED capability but Infisical is one of several
+providers you can pick. Peer plugins:
+
+- **[`@theholocron/holocron-plugin-doppler`](../holocron-plugin-doppler)**
+  — this repo's own default vault since `2.0.0-alpha.4`.
+- **[`@theholocron/holocron-plugin-1password`](../holocron-plugin-1password)**
+  — for teams already invested in 1Password's biometric UX.
+- **This plugin** — for teams that want an open-source vault they
+  can self-host later if desired.
+
+Switch by editing `holocron.config.json`.
+
+### When to choose Infisical
+
+- You want an open-source vault with a clear path to self-hosting
+  (the plugin's `baseUrl` option points at cloud today; swap it for
+  your self-hosted URL later, no code changes).
+- Machine-identity + Universal Auth token model matches your
+  security posture better than dashboard-generated Personal Tokens.
+- Your team already uses Infisical for other projects.
+
+## Install
+
+```bash
+pnpm add -D @theholocron/holocron-plugin-infisical@alpha
+```
+
+## Auth
+
+Token resolution order (matches the standard 4-step precedence set
+by `.notes/tech-auth-bootstrap.spec.md`):
+
+1. `--token <TOKEN>` flag on the holocron invocation
+2. `HOLOCRON_INFISICAL_TOKEN` env var (preferred — explicit intent)
+3. `INFISICAL_TOKEN` env var (Infisical-native, works in CI)
+4. **Keyring** — `com.theholocron.cli` service, account `infisical`
+5. `AuthError` naming all four options + the bootstrap hint
+
+## Setup
+
+```bash
+# 1. Generate a Universal Auth token in the Infisical dashboard:
+#    Access Control → Machine Identities → Create → Universal Auth
+#    Copy the token (starts with `st.`).
+# 2. Hand it off to holocron's keyring (one-shot):
+holocron auth set infisical <TOKEN>
+# 3. Verify:
+holocron auth check infisical
+```
+
+**CI**: the keyring is not available in headless containers. Expose
+the token as a GitHub Actions secret and set `HOLOCRON_INFISICAL_TOKEN`
+(or `INFISICAL_TOKEN`) in the workflow env. Steps 1–3 of the auth
+precedence still work; step 4 quietly falls through.
+
+## Config
+
+```jsonc
+{
+	"providers": {
+		"vault": ["infisical", { "workspace": "<workspace-id>", "environment": "dev" }],
+	},
+}
+```
+
+- `workspace` (required) — Infisical workspace (project) id. Find via
+  the workspace URL or the API. **Not the workspace slug** — Infisical's
+  API rejects slug in this position ([Infisical#1894](https://github.com/Infisical/infisical/issues/1894)).
+- `environment` (required) — Environment slug (usually `dev`, `stg`,
+  or `prd`). `list()` reads secrets from this environment.
+
+Individual `read` / `write` calls take a fully-qualified reference:
+
+```
+infisical://<workspaceId>/<environment>/<name>
+```
+
+The default `workspace` + `environment` in options apply to `list()`,
+`environments()`, and `readEnvironment()` where a three-part reference
+doesn't make sense.
+
+## What's implemented
+
+| Method              | Behavior                                                                                                             |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `read`              | `GET /v3/secrets/raw/{name}?workspaceId&environment&secretPath=/`.                                                   |
+| `write`             | `POST /v3/secrets/raw/{name}` (create); falls back to `PATCH` on "already exists" body for upsert semantics.         |
+| `list`              | `GET /v3/secrets/raw` at the default `workspace + environment + secretPath=/`.                                       |
+| `environments`      | `GET /v1/workspace/{workspaceId}`, returns each environment's `slug`.                                                |
+| `readEnvironment`   | `GET /v3/secrets/raw?workspaceId&environment=<id>` — bulk KEY=VALUE dump for `holocron secrets sync`.                |
+| `ensureProject`     | `POST /v2/workspace` with `{ projectName, slug }`. Treats 400/409/422 "already exists" as idempotent no-op.          |
+| `ensureEnvironment` | `POST /v1/workspace/{project}/environments` with `{ environmentName, environmentSlug }`. Same idempotency semantics. |
+
+Plugin-level exports (not capability methods, per the auth-bootstrap
+convention):
+
+| Export        | Purpose                                                                                   |
+| ------------- | ----------------------------------------------------------------------------------------- |
+| `verifyToken` | `GET /v1/users/me` — returns `{ok: true, subject: "user @ …"}` or `{ok: false, message}`. |
+| `AUTH_HINT`   | Directs operators at the Universal Auth flow in the Infisical dashboard.                  |
+
+## Self-hosted Infisical
+
+Set the `baseUrl` option in `holocron.config.json`:
+
+```jsonc
+{
+	"providers": {
+		"vault": [
+			"infisical",
+			{
+				"workspace": "<id>",
+				"environment": "dev",
+				"baseUrl": "https://infisical.internal.example.com/api",
+			},
+		],
+	},
+}
+```
+
+## Status
+
+**`v2.0.0-alpha.1`** — scaffolded via `holocron plugin create` (see
+`.notes/tool-plugin-create.spec.md` — this is the first real
+production use of that command, doubling as its acceptance test in
+a live scenario). Not yet published on npm; capability methods are
+implemented but not yet validated against a live Infisical account.
+APIs may still shift before stable v2.0.0.

--- a/packages/holocron-plugin-infisical/eslint.config.js
+++ b/packages/holocron-plugin-infisical/eslint.config.js
@@ -1,0 +1,8 @@
+import root from "../../eslint.config.js";
+
+export default [
+	...root,
+	{
+		ignores: ["dist/**", "coverage/**"],
+	},
+];

--- a/packages/holocron-plugin-infisical/package.json
+++ b/packages/holocron-plugin-infisical/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@theholocron/holocron-plugin-infisical",
+  "version": "2.0.0-alpha.1",
+  "description": "Holocron plugin for Infisical. Implements the vault capability against Infisical's REST API, plus exports verifyToken + AUTH_HINT for `holocron auth`.",
+  "homepage": "https://github.com/theholocron/holocron/tree/main/packages/holocron-plugin-infisical#readme",
+  "bugs": "https://github.com/theholocron/holocron/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/holocron.git",
+    "directory": "packages/holocron-plugin-infisical"
+  },
+  "license": "MIT",
+  "author": "Newton Koumantzelis",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "peerDependencies": {
+    "@theholocron/cli": "workspace:*"
+  },
+  "devDependencies": {
+    "@theholocron/cli": "workspace:*",
+    "@theholocron/tsconfig": "catalog:",
+    "@tsconfig/node-lts": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "eslint": "catalog:",
+    "globals": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "tsdown": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ]
+}

--- a/packages/holocron-plugin-infisical/package.json
+++ b/packages/holocron-plugin-infisical/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
     "@theholocron/cli": "workspace:*"
@@ -34,9 +35,10 @@
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
     "globals": "catalog:",
+    "tsdown": "catalog:",
+    "tsx": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:",
-    "tsdown": "catalog:"
+    "vitest": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/holocron-plugin-infisical/scripts/validate.mjs
+++ b/packages/holocron-plugin-infisical/scripts/validate.mjs
@@ -30,9 +30,7 @@
  * Standardized by the plugin-create scaffold.
  */
 
-import { getToken } from "@theholocron/cli";
-
-import { createPlugin, verifyToken } from "../src/index.ts";
+import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
 
 const [workspace, environment, secretName] = process.argv.slice(2);
 
@@ -43,11 +41,21 @@ if (!workspace || !environment) {
 	process.exit(2);
 }
 
-const token = getToken("infisical");
-if (!token) {
-	console.error("no Infisical token in keyring. Run: pnpm holocron auth set infisical <TOKEN>");
-	console.error("  see: packages/holocron-plugin-infisical/README.md#setup");
-	process.exit(2);
+// Use the plugin's own auth resolution so the validate script honors
+// the same 4-step precedence as the plugin's runtime:
+//   --token → HOLOCRON_INFISICAL_TOKEN → INFISICAL_TOKEN → keyring
+// (--token isn't available here since this is a bare Node script;
+// the other three all work.)
+let token;
+try {
+	token = resolveToken();
+} catch (err) {
+	if (err instanceof AuthError) {
+		console.error(err.message);
+		console.error("  see: packages/holocron-plugin-infisical/README.md#setup");
+		process.exit(2);
+	}
+	throw err;
 }
 
 console.log("Validating @theholocron/holocron-plugin-infisical (READ-ONLY)");

--- a/packages/holocron-plugin-infisical/scripts/validate.mjs
+++ b/packages/holocron-plugin-infisical/scripts/validate.mjs
@@ -8,7 +8,8 @@
  *
  * READ-ONLY BY DESIGN. Never calls write(), ensureProject, or
  * ensureEnvironment. If any method here shows an ERROR, the plugin
- * needs adjusting.
+ * needs adjusting — the `hintFor` helper below points at the most
+ * likely cause per error shape.
  *
  * Auth: reads the Infisical token from holocron's keyring — you
  * must have run `pnpm holocron auth set infisical <TOKEN>` first.
@@ -24,9 +25,9 @@
  *   pnpm --filter @theholocron/holocron-plugin-infisical validate \
  *     abc-123 dev TEST_KEY
  *
- * Convention: every holocron plugin ships a \`scripts/validate.mjs\`
+ * Convention: every holocron plugin ships a `scripts/validate.mjs`
  * that smoke-tests its capability methods against a live account.
- * Standardized by the plugin-create scaffold since v2.0.0-alpha.<n>.
+ * Standardized by the plugin-create scaffold.
  */
 
 import { getToken } from "@theholocron/cli";
@@ -37,8 +38,7 @@ const [workspace, environment, secretName] = process.argv.slice(2);
 
 if (!workspace || !environment) {
 	console.error(
-		"usage: pnpm exec tsx packages/holocron-plugin-infisical/scripts/validate-plugin-infisical.mjs " +
-			"<workspaceId> <env> [secretName]"
+		"usage: pnpm --filter @theholocron/holocron-plugin-infisical validate <workspaceId> <env> [secretName]"
 	);
 	process.exit(2);
 }
@@ -46,6 +46,7 @@ if (!workspace || !environment) {
 const token = getToken("infisical");
 if (!token) {
 	console.error("no Infisical token in keyring. Run: pnpm holocron auth set infisical <TOKEN>");
+	console.error("  see: packages/holocron-plugin-infisical/README.md#setup");
 	process.exit(2);
 }
 
@@ -59,23 +60,25 @@ console.log("");
 console.log("[1/4] verifyToken");
 const verifyResult = await verifyToken(token);
 console.log(`      ${verifyResult.ok ? "✓" : "✗"} ${JSON.stringify(verifyResult)}`);
+if (!verifyResult.ok) {
+	const hint = hintFor(verifyResult.message);
+	if (hint) console.log(`         hint: ${hint}`);
+}
 console.log("");
 
 // ── 2. environments() ──────────────────────────────────────────────
 console.log("[2/4] vault.environments()");
 const plugin = createPlugin({ cliToken: token, workspace, environment });
 const vault = plugin.capabilities.vault();
-try {
+await runStep(async () => {
 	const envs = await vault.environments();
 	console.log(`      ✓ ${envs.length} environment${envs.length === 1 ? "" : "s"}: ${envs.join(", ") || "(none)"}`);
-} catch (err) {
-	console.log(`      ✗ ERROR: ${err instanceof Error ? err.message : String(err)}`);
-}
+});
 console.log("");
 
 // ── 3. list() ──────────────────────────────────────────────────────
 console.log(`[3/4] vault.list()  (workspace: ${workspace}, environment: ${environment}, path: /)`);
-try {
+await runStep(async () => {
 	const keys = await vault.list();
 	console.log(`      ✓ ${keys.length} secret${keys.length === 1 ? "" : "s"} at root path`);
 	if (keys.length > 0 && keys.length <= 25) {
@@ -84,9 +87,7 @@ try {
 		console.log(`         (${keys.length} total — showing first 25)`);
 		keys.slice(0, 25).forEach((k) => console.log(`         · ${k}`));
 	}
-} catch (err) {
-	console.log(`      ✗ ERROR: ${err instanceof Error ? err.message : String(err)}`);
-}
+});
 console.log("");
 
 // ── 4. read() ──────────────────────────────────────────────────────
@@ -96,15 +97,53 @@ if (!secretName) {
 } else {
 	const reference = `infisical://${workspace}/${environment}/${secretName}`;
 	console.log(`      · reference: ${reference}`);
-	try {
+	await runStep(async () => {
 		const value = await vault.read(reference);
 		// Report length only — never print the actual secret value.
 		console.log(`      ✓ read succeeded — value is ${value.length} chars long`);
-	} catch (err) {
-		console.log(`      ✗ ERROR: ${err instanceof Error ? err.message : String(err)}`);
-	}
+	});
 }
 console.log("");
 console.log(
 	"Done. No writes, no bootstrap operations. Nothing in your Infisical account was created, modified, or deleted."
 );
+
+// ── helpers ────────────────────────────────────────────────────────
+
+/**
+ * Wrap a capability call, print ERROR + hint on failure. Keeps the
+ * per-step block small at each call site.
+ */
+async function runStep(body) {
+	try {
+		await body();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.log(`      ✗ ERROR: ${message}`);
+		const hint = hintFor(message);
+		if (hint) console.log(`         hint: ${hint}`);
+	}
+}
+
+/**
+ * Point the operator at the most likely fix based on the error shape.
+ * Add cases here as new failure modes surface.
+ */
+function hintFor(message) {
+	if (/→ 401/.test(message)) {
+		return "token invalid — regenerate a Personal Token or Token Auth token (see README §Setup)";
+	}
+	if (/→ 403/.test(message)) {
+		return "token authenticates but lacks scope — grant your machine identity access to the workspace/project in the Infisical dashboard, OR use a Personal API Token";
+	}
+	if (/→ 404/.test(message)) {
+		return "endpoint or resource not found — verify the workspace id from your dashboard URL, and confirm the environment slug + secret name exist";
+	}
+	if (/fetch failed|status: 0|network/i.test(message)) {
+		return "network error — check the base URL (defaults to https://app.infisical.com/api) and connectivity";
+	}
+	if (/→ 5\d\d/.test(message)) {
+		return "server error — Infisical-side. Retry, and if persistent check https://status.infisical.com";
+	}
+	return null;
+}

--- a/packages/holocron-plugin-infisical/scripts/validate.mjs
+++ b/packages/holocron-plugin-infisical/scripts/validate.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Read-only smoke test for @theholocron/holocron-plugin-infisical
+ * against a live Infisical account. Handy for validating that the
+ * plugin's REST endpoints, auth handling, and response parsing all
+ * work against the real API — the unit tests only exercise stubbed
+ * HTTP responses.
+ *
+ * READ-ONLY BY DESIGN. Never calls write(), ensureProject, or
+ * ensureEnvironment. If any method here shows an ERROR, the plugin
+ * needs adjusting.
+ *
+ * Auth: reads the Infisical token from holocron's keyring — you
+ * must have run `pnpm holocron auth set infisical <TOKEN>` first.
+ * Use a **Personal API Token** or a **Token Auth** token — Universal
+ * Auth's Client Secret doesn't work (needs a login exchange the
+ * plugin doesn't yet do — tracked in #100).
+ *
+ * Usage:
+ *   pnpm --filter @theholocron/holocron-plugin-infisical validate \
+ *     <workspaceId> <env> [secretName]
+ *
+ * Example:
+ *   pnpm --filter @theholocron/holocron-plugin-infisical validate \
+ *     abc-123 dev TEST_KEY
+ *
+ * Convention: every holocron plugin ships a \`scripts/validate.mjs\`
+ * that smoke-tests its capability methods against a live account.
+ * Standardized by the plugin-create scaffold since v2.0.0-alpha.<n>.
+ */
+
+import { getToken } from "@theholocron/cli";
+
+import { createPlugin, verifyToken } from "../src/index.ts";
+
+const [workspace, environment, secretName] = process.argv.slice(2);
+
+if (!workspace || !environment) {
+	console.error(
+		"usage: pnpm exec tsx packages/holocron-plugin-infisical/scripts/validate-plugin-infisical.mjs " +
+			"<workspaceId> <env> [secretName]"
+	);
+	process.exit(2);
+}
+
+const token = getToken("infisical");
+if (!token) {
+	console.error("no Infisical token in keyring. Run: pnpm holocron auth set infisical <TOKEN>");
+	process.exit(2);
+}
+
+console.log("Validating @theholocron/holocron-plugin-infisical (READ-ONLY)");
+console.log(`  workspace:   ${workspace}`);
+console.log(`  environment: ${environment}`);
+if (secretName) console.log(`  secretName:  ${secretName}`);
+console.log("");
+
+// ── 1. verifyToken ─────────────────────────────────────────────────
+console.log("[1/4] verifyToken");
+const verifyResult = await verifyToken(token);
+console.log(`      ${verifyResult.ok ? "✓" : "✗"} ${JSON.stringify(verifyResult)}`);
+console.log("");
+
+// ── 2. environments() ──────────────────────────────────────────────
+console.log("[2/4] vault.environments()");
+const plugin = createPlugin({ cliToken: token, workspace, environment });
+const vault = plugin.capabilities.vault();
+try {
+	const envs = await vault.environments();
+	console.log(`      ✓ ${envs.length} environment${envs.length === 1 ? "" : "s"}: ${envs.join(", ") || "(none)"}`);
+} catch (err) {
+	console.log(`      ✗ ERROR: ${err instanceof Error ? err.message : String(err)}`);
+}
+console.log("");
+
+// ── 3. list() ──────────────────────────────────────────────────────
+console.log(`[3/4] vault.list()  (workspace: ${workspace}, environment: ${environment}, path: /)`);
+try {
+	const keys = await vault.list();
+	console.log(`      ✓ ${keys.length} secret${keys.length === 1 ? "" : "s"} at root path`);
+	if (keys.length > 0 && keys.length <= 25) {
+		keys.forEach((k) => console.log(`         · ${k}`));
+	} else if (keys.length > 25) {
+		console.log(`         (${keys.length} total — showing first 25)`);
+		keys.slice(0, 25).forEach((k) => console.log(`         · ${k}`));
+	}
+} catch (err) {
+	console.log(`      ✗ ERROR: ${err instanceof Error ? err.message : String(err)}`);
+}
+console.log("");
+
+// ── 4. read() ──────────────────────────────────────────────────────
+console.log("[4/4] vault.read()");
+if (!secretName) {
+	console.log("      · skipped (no secret name provided)");
+} else {
+	const reference = `infisical://${workspace}/${environment}/${secretName}`;
+	console.log(`      · reference: ${reference}`);
+	try {
+		const value = await vault.read(reference);
+		// Report length only — never print the actual secret value.
+		console.log(`      ✓ read succeeded — value is ${value.length} chars long`);
+	} catch (err) {
+		console.log(`      ✗ ERROR: ${err instanceof Error ? err.message : String(err)}`);
+	}
+}
+console.log("");
+console.log(
+	"Done. No writes, no bootstrap operations. Nothing in your Infisical account was created, modified, or deleted."
+);

--- a/packages/holocron-plugin-infisical/src/__tests__/auth.test.ts
+++ b/packages/holocron-plugin-infisical/src/__tests__/auth.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { AuthError, resolveToken } from "../auth.js";
+
+const noKeyring = () => null;
+
+describe("resolveToken", () => {
+	it("prefers --token over env vars + keyring", () => {
+		expect(
+			resolveToken({
+				cliToken: "flag",
+				env: { HOLOCRON_INFISICAL_TOKEN: "hlc", INFISICAL_TOKEN: "vendor" },
+				keyring: () => "kr",
+			})
+		).toBe("flag");
+	});
+
+	it("prefers HOLOCRON_INFISICAL_TOKEN over INFISICAL_TOKEN", () => {
+		expect(
+			resolveToken({
+				env: { HOLOCRON_INFISICAL_TOKEN: "hlc", INFISICAL_TOKEN: "vendor" },
+				keyring: noKeyring,
+			})
+		).toBe("hlc");
+	});
+
+	it("falls back to INFISICAL_TOKEN when HOLOCRON_INFISICAL_TOKEN is unset", () => {
+		expect(resolveToken({ env: { INFISICAL_TOKEN: "vendor" }, keyring: noKeyring })).toBe("vendor");
+	});
+
+	it("falls back to keyring when env vars are unset", () => {
+		expect(resolveToken({ env: {}, keyring: (p) => (p === "infisical" ? "kr" : null) })).toBe("kr");
+	});
+
+	it("throws AuthError with a helpful message when nothing is set", () => {
+		try {
+			resolveToken({ env: {}, keyring: noKeyring });
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(AuthError);
+			expect((err as Error).message).toMatch(/HOLOCRON_INFISICAL_TOKEN/);
+			expect((err as Error).message).toMatch(/holocron auth set infisical/);
+		}
+	});
+});

--- a/packages/holocron-plugin-infisical/src/__tests__/helpers.ts
+++ b/packages/holocron-plugin-infisical/src/__tests__/helpers.ts
@@ -1,0 +1,45 @@
+import { vi, type Mock } from "vitest";
+
+export interface FetchCall {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	body: unknown;
+}
+
+export interface FetchStub {
+	fetch: typeof fetch;
+	calls: FetchCall[];
+	mock: Mock;
+}
+
+export function stubFetch(responses: Array<{ status?: number; body?: unknown; text?: string }>): FetchStub {
+	const calls: FetchCall[] = [];
+	let i = 0;
+	const mock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input.toString();
+		const body = typeof init?.body === "string" ? safeJsonParse(init.body) : (init?.body ?? null);
+		calls.push({
+			url,
+			method: (init?.method ?? "GET").toUpperCase(),
+			headers: (init?.headers as Record<string, string>) ?? {},
+			body,
+		});
+		const next = responses[i++] ?? { status: 200, body: {} };
+		const status = next.status ?? 200;
+		if (status === 204 || status === 205 || status === 304) {
+			return new Response(null, { status });
+		}
+		const text = next.text ?? (typeof next.body === "string" ? next.body : JSON.stringify(next.body ?? {}));
+		return new Response(text, { status });
+	});
+	return { fetch: mock as unknown as typeof fetch, calls, mock };
+}
+
+function safeJsonParse(s: string): unknown {
+	try {
+		return JSON.parse(s);
+	} catch {
+		return s;
+	}
+}

--- a/packages/holocron-plugin-infisical/src/__tests__/index.test.ts
+++ b/packages/holocron-plugin-infisical/src/__tests__/index.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { AUTH_HINT, createPlugin } from "../index.js";
+import { stubFetch } from "./helpers.js";
+
+describe("createPlugin", () => {
+	it("wires the vault capability against the given fetch + token", async () => {
+		const stub = stubFetch([{ status: 200, body: { secrets: [{ secretKey: "API_KEY", secretValue: "x" }] } }]);
+		const plugin = createPlugin({
+			cliToken: "test-token",
+			workspace: "ws-1",
+			environment: "dev",
+			fetch: stub.fetch,
+		});
+		expect(plugin.name).toBe("@theholocron/holocron-plugin-infisical");
+		expect(typeof plugin.capabilities.vault).toBe("function");
+		const vault = plugin.capabilities.vault!();
+		expect(await vault.list()).toEqual(["API_KEY"]);
+	});
+});
+
+describe("AUTH_HINT", () => {
+	it("mentions the holocron auth set command + Universal Auth guidance", () => {
+		expect(AUTH_HINT).toMatch(/holocron auth set infisical/);
+		expect(AUTH_HINT).toMatch(/Universal Auth/);
+	});
+});

--- a/packages/holocron-plugin-infisical/src/__tests__/rest.test.ts
+++ b/packages/holocron-plugin-infisical/src/__tests__/rest.test.ts
@@ -1,0 +1,62 @@
+import { ProviderApiError } from "@theholocron/cli";
+import { describe, expect, it } from "vitest";
+
+import { InfisicalRestClient } from "../rest.js";
+import { stubFetch } from "./helpers.js";
+
+describe("InfisicalRestClient", () => {
+	it("sends bearer + accept headers and returns the parsed body", async () => {
+		const stub = stubFetch([{ status: 200, body: { ok: true } }]);
+		const client = new InfisicalRestClient({ token: "t", fetch: stub.fetch });
+		const res = await client.request<{ ok: boolean }>("/me");
+		expect(res.ok).toBe(true);
+		expect(stub.calls[0]?.headers["authorization"]).toBe("Bearer t");
+		expect(stub.calls[0]?.headers["accept"]).toBe("application/json");
+	});
+
+	it("serializes body as JSON and sets content-type when present", async () => {
+		const stub = stubFetch([{ status: 200, body: {} }]);
+		const client = new InfisicalRestClient({ token: "t", fetch: stub.fetch });
+		await client.request<unknown>("/resource", { method: "POST", body: { name: "demo" } });
+		expect(stub.calls[0]?.method).toBe("POST");
+		expect(stub.calls[0]?.headers["content-type"]).toBe("application/json");
+		expect(stub.calls[0]?.body).toEqual({ name: "demo" });
+	});
+
+	it("returns undefined on 204", async () => {
+		const stub = stubFetch([{ status: 204 }]);
+		const client = new InfisicalRestClient({ token: "t", fetch: stub.fetch });
+		expect(await client.request<unknown>("/whatever")).toBeUndefined();
+	});
+
+	it("throws ProviderApiError with the HTTP status on non-2xx", async () => {
+		const stub = stubFetch([{ status: 401, body: { messages: ["invalid"] } }]);
+		const client = new InfisicalRestClient({ token: "bad", fetch: stub.fetch });
+		try {
+			await client.request<unknown>("/me");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as ProviderApiError).status).toBe(401);
+		}
+	});
+
+	it("wraps transport-level failures with status 0", async () => {
+		const throwing: typeof fetch = async () => {
+			throw new TypeError("fetch failed");
+		};
+		const client = new InfisicalRestClient({ token: "t", fetch: throwing });
+		try {
+			await client.request<unknown>("/me");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as ProviderApiError).status).toBe(0);
+		}
+	});
+
+	it("trims trailing slashes from the base URL", () => {
+		const client = new InfisicalRestClient({ token: "t", baseUrl: "https://app.infisical.com/api//" });
+		expect(client.baseUrl).toBe("https://app.infisical.com/api");
+	});
+});

--- a/packages/holocron-plugin-infisical/src/__tests__/vault.test.ts
+++ b/packages/holocron-plugin-infisical/src/__tests__/vault.test.ts
@@ -92,8 +92,17 @@ describe("InfisicalVault.write", () => {
 		await vault.write("infisical://ws-1/dev/API_KEY", "new-val");
 		expect(stub.calls).toHaveLength(2);
 		expect(stub.calls[0]?.method).toBe("POST");
+		expect(stub.calls[0]?.body).toMatchObject({ type: "shared", secretValue: "new-val" });
 		expect(stub.calls[1]?.method).toBe("PATCH");
-		expect(stub.calls[1]?.body).toMatchObject({ secretValue: "new-val" });
+		// PATCH body is the CREATE body minus `type` — creation-only
+		// classifier that shouldn't leak into the update path.
+		expect(stub.calls[1]?.body).toEqual({
+			workspaceId: "ws-1",
+			environment: "dev",
+			secretPath: "/",
+			secretValue: "new-val",
+		});
+		expect(stub.calls[1]?.body).not.toHaveProperty("type");
 	});
 
 	it("rethrows a non-conflict error from POST unchanged", async () => {

--- a/packages/holocron-plugin-infisical/src/__tests__/vault.test.ts
+++ b/packages/holocron-plugin-infisical/src/__tests__/vault.test.ts
@@ -238,19 +238,89 @@ describe("InfisicalVault.ensureProject", () => {
 });
 
 describe("InfisicalVault.ensureEnvironment", () => {
-	it("POSTs to /v1/workspace/{id}/environments and returns not-existing on success", async () => {
-		const { client, stub } = makeClient([{ status: 200, body: {} }]);
-		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
-		const result = await vault.ensureEnvironment("ws-1", "dev");
+	it("looks up workspace name → id via /v1/workspace, then POSTs to /v1/workspace/{id}/environments", async () => {
+		const { client, stub } = makeClient([
+			{
+				status: 200,
+				body: {
+					workspaces: [
+						{ _id: "ws-actual-id", name: "holocron", slug: "holocron" },
+						{ _id: "other", name: "rando" },
+					],
+				},
+			},
+			{ status: 200, body: {} },
+		]);
+		const vault = new InfisicalVault(client, { workspace: "ws-actual-id", environment: "dev" });
+		const result = await vault.ensureEnvironment("holocron", "dev");
 		expect(result).toEqual({ alreadyExists: false });
-		expect(stub.calls[0]?.method).toBe("POST");
-		expect(stub.calls[0]?.url).toMatch(/\/v1\/workspace\/ws-1\/environments/);
-		expect(stub.calls[0]?.body).toEqual({ environmentName: "dev", environmentSlug: "dev" });
+		expect(stub.calls[0]?.url).toMatch(/\/v1\/workspace$/);
+		expect(stub.calls[1]?.method).toBe("POST");
+		expect(stub.calls[1]?.url).toMatch(/\/v1\/workspace\/ws-actual-id\/environments/);
+		expect(stub.calls[1]?.body).toEqual({ environmentName: "dev", environmentSlug: "dev" });
 	});
 
-	it("returns alreadyExists:true on 'duplicate' body", async () => {
-		const { client } = makeClient([{ status: 400, body: `{"message":"Duplicate environment slug"}` }]);
+	it("caches the workspace lookup across sequential calls (holocron setup fires 3 in a row)", async () => {
+		const { client, stub } = makeClient([
+			{
+				status: 200,
+				body: { workspaces: [{ _id: "ws-actual-id", name: "holocron", slug: "holocron" }] },
+			},
+			{ status: 200, body: {} },
+			{ status: 200, body: {} },
+			{ status: 200, body: {} },
+		]);
+		const vault = new InfisicalVault(client, { workspace: "ws-actual-id", environment: "dev" });
+		await vault.ensureEnvironment("holocron", "dev");
+		await vault.ensureEnvironment("holocron", "stg");
+		await vault.ensureEnvironment("holocron", "prd");
+		// One list call + 3 create calls (not 3 list calls + 3 create).
+		expect(stub.calls).toHaveLength(4);
+		expect(stub.calls[0]?.url).toMatch(/\/v1\/workspace$/);
+		expect(stub.calls[1]?.url).toMatch(/environments$/);
+		expect(stub.calls[2]?.url).toMatch(/environments$/);
+		expect(stub.calls[3]?.url).toMatch(/environments$/);
+	});
+
+	it("falls back to treating input as id when the list endpoint 403s (scope-limited token)", async () => {
+		const { client, stub } = makeClient([
+			{ status: 403, body: { message: "Forbidden" } },
+			{ status: 200, body: {} },
+		]);
+		const vault = new InfisicalVault(client, { workspace: "ws-id", environment: "dev" });
+		const result = await vault.ensureEnvironment("ws-id", "dev");
+		expect(result).toEqual({ alreadyExists: false });
+		expect(stub.calls[1]?.url).toMatch(/\/v1\/workspace\/ws-id\/environments/);
+	});
+
+	it("falls back to treating input as id when list returns 200 but no match", async () => {
+		const { client, stub } = makeClient([
+			{ status: 200, body: { workspaces: [{ _id: "other", name: "different-project" }] } },
+			{ status: 200, body: {} },
+		]);
+		const vault = new InfisicalVault(client, { workspace: "unknown-id", environment: "dev" });
+		await vault.ensureEnvironment("unknown-id", "dev");
+		expect(stub.calls[1]?.url).toMatch(/\/v1\/workspace\/unknown-id\/environments/);
+	});
+
+	it("rethrows non-403 errors from the list endpoint (real problems shouldn't be swallowed)", async () => {
+		const { client } = makeClient([{ status: 500, body: "server error" }]);
 		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
-		expect(await vault.ensureEnvironment("ws-1", "dev")).toEqual({ alreadyExists: true });
+		try {
+			await vault.ensureEnvironment("ws-1", "dev");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as ProviderApiError).status).toBe(500);
+		}
+	});
+
+	it("returns alreadyExists:true on 'duplicate' body from the environments POST", async () => {
+		const { client } = makeClient([
+			{ status: 200, body: { workspaces: [{ _id: "ws-id", name: "ws-id" }] } },
+			{ status: 400, body: `{"message":"Duplicate environment slug"}` },
+		]);
+		const vault = new InfisicalVault(client, { workspace: "ws-id", environment: "dev" });
+		expect(await vault.ensureEnvironment("ws-id", "dev")).toEqual({ alreadyExists: true });
 	});
 });

--- a/packages/holocron-plugin-infisical/src/__tests__/vault.test.ts
+++ b/packages/holocron-plugin-infisical/src/__tests__/vault.test.ts
@@ -1,0 +1,256 @@
+import { ProviderApiError } from "@theholocron/cli";
+import { describe, expect, it } from "vitest";
+
+import { InfisicalVault } from "../capabilities/vault.js";
+import { InfisicalRestClient } from "../rest.js";
+import { stubFetch } from "./helpers.js";
+
+function makeClient(responses: Array<{ status?: number; body?: unknown }>) {
+	const stub = stubFetch(responses);
+	const client = new InfisicalRestClient({ token: "t", fetch: stub.fetch });
+	return { client, stub };
+}
+
+describe("InfisicalVault constructor", () => {
+	it("throws when `workspace` is missing", () => {
+		const { client } = makeClient([]);
+		// @ts-expect-error deliberately missing workspace
+		expect(() => new InfisicalVault(client, { environment: "dev" })).toThrow(/workspace/);
+	});
+	it("throws when `environment` is missing", () => {
+		const { client } = makeClient([]);
+		// @ts-expect-error deliberately missing environment
+		expect(() => new InfisicalVault(client, { workspace: "ws-1" })).toThrow(/environment/);
+	});
+});
+
+describe("InfisicalVault.read", () => {
+	it("hits GET /v3/secrets/raw/{name} with the parsed workspace/env/name", async () => {
+		const { client, stub } = makeClient([
+			{ status: 200, body: { secret: { secretKey: "API_KEY", secretValue: "abc" } } },
+		]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		const value = await vault.read("infisical://ws-1/dev/API_KEY");
+		expect(value).toBe("abc");
+		expect(stub.calls[0]?.url).toMatch(/\/v3\/secrets\/raw\/API_KEY/);
+		expect(stub.calls[0]?.url).toMatch(/workspaceId=ws-1/);
+		expect(stub.calls[0]?.url).toMatch(/environment=dev/);
+	});
+
+	it("returns empty string when secretValue is absent", async () => {
+		const { client } = makeClient([{ status: 200, body: { secret: {} } }]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		expect(await vault.read("infisical://ws-1/dev/EMPTY")).toBe("");
+	});
+
+	it("rejects a reference that doesn't start with infisical://", async () => {
+		const { client } = makeClient([]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		try {
+			await vault.read("doppler://x/y/z");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as Error).message).toMatch(/infisical:\/\//);
+		}
+	});
+
+	it("rejects a reference missing parts", async () => {
+		const { client } = makeClient([]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		try {
+			await vault.read("infisical://ws-1/dev");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as Error).message).toMatch(/missing parts/);
+		}
+	});
+});
+
+describe("InfisicalVault.write", () => {
+	it("POSTs to /v3/secrets/raw/{name} with a create body", async () => {
+		const { client, stub } = makeClient([{ status: 200, body: {} }]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		await vault.write("infisical://ws-1/dev/API_KEY", "new-val");
+		expect(stub.calls[0]?.method).toBe("POST");
+		expect(stub.calls[0]?.url).toMatch(/\/v3\/secrets\/raw\/API_KEY/);
+		expect(stub.calls[0]?.body).toMatchObject({
+			workspaceId: "ws-1",
+			environment: "dev",
+			secretValue: "new-val",
+			type: "shared",
+		});
+	});
+
+	it("falls back to PATCH when POST returns 'already exists' (upsert semantics)", async () => {
+		const { client, stub } = makeClient([
+			{ status: 400, body: `{"message":"Secret already exists"}` },
+			{ status: 200, body: {} },
+		]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		await vault.write("infisical://ws-1/dev/API_KEY", "new-val");
+		expect(stub.calls).toHaveLength(2);
+		expect(stub.calls[0]?.method).toBe("POST");
+		expect(stub.calls[1]?.method).toBe("PATCH");
+		expect(stub.calls[1]?.body).toMatchObject({ secretValue: "new-val" });
+	});
+
+	it("rethrows a non-conflict error from POST unchanged", async () => {
+		const { client } = makeClient([{ status: 500, body: "server error" }]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		try {
+			await vault.write("infisical://ws-1/dev/API_KEY", "v");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as ProviderApiError).status).toBe(500);
+		}
+	});
+});
+
+describe("InfisicalVault.list", () => {
+	it("returns secret keys from GET /v3/secrets/raw at the default workspace + environment", async () => {
+		const { client, stub } = makeClient([
+			{
+				status: 200,
+				body: {
+					secrets: [
+						{ secretKey: "API_KEY", secretValue: "x" },
+						{ secretKey: "DB_URL", secretValue: "y" },
+					],
+				},
+			},
+		]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		const keys = await vault.list();
+		expect(keys.sort()).toEqual(["API_KEY", "DB_URL"]);
+		expect(stub.calls[0]?.url).toMatch(/workspaceId=ws-1/);
+		expect(stub.calls[0]?.url).toMatch(/environment=dev/);
+		expect(stub.calls[0]?.url).toMatch(/secretPath=%2F/);
+	});
+
+	it("returns [] when the response has no secrets", async () => {
+		const { client } = makeClient([{ status: 200, body: {} }]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		expect(await vault.list()).toEqual([]);
+	});
+});
+
+describe("InfisicalVault.environments", () => {
+	it("returns env slugs from GET /v1/workspace/{id}", async () => {
+		const { client } = makeClient([
+			{
+				status: 200,
+				body: {
+					workspace: {
+						environments: [
+							{ id: "e1", name: "Development", slug: "dev" },
+							{ id: "e2", name: "Production", slug: "prd" },
+						],
+					},
+				},
+			},
+		]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		expect(await vault.environments()).toEqual(["dev", "prd"]);
+	});
+
+	it("returns [] when the workspace has no environments key", async () => {
+		const { client } = makeClient([{ status: 200, body: {} }]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		expect(await vault.environments()).toEqual([]);
+	});
+});
+
+describe("InfisicalVault.readEnvironment", () => {
+	it("returns a KEY=VALUE map for the given env", async () => {
+		const { client, stub } = makeClient([
+			{
+				status: 200,
+				body: {
+					secrets: [
+						{ secretKey: "API_KEY", secretValue: "a" },
+						{ secretKey: "DB_URL", secretValue: "b" },
+					],
+				},
+			},
+		]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		const env = await vault.readEnvironment("stg");
+		expect(env).toEqual({ API_KEY: "a", DB_URL: "b" });
+		expect(stub.calls[0]?.url).toMatch(/environment=stg/);
+	});
+
+	it("skips entries missing a key or non-string value", async () => {
+		const { client } = makeClient([
+			{
+				status: 200,
+				body: {
+					secrets: [
+						{ secretKey: "A", secretValue: "x" },
+						{ secretValue: "no-key" },
+						{ secretKey: "C", secretValue: 42 },
+					],
+				},
+			},
+		]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		expect(await vault.readEnvironment("dev")).toEqual({ A: "x" });
+	});
+});
+
+describe("InfisicalVault.ensureProject", () => {
+	it("returns alreadyExists:false when POST /v2/workspace succeeds", async () => {
+		const { client, stub } = makeClient([{ status: 200, body: { workspace: { name: "demo" } } }]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		const result = await vault.ensureProject("demo");
+		expect(result).toEqual({ alreadyExists: false });
+		expect(stub.calls[0]?.method).toBe("POST");
+		expect(stub.calls[0]?.body).toMatchObject({ projectName: "demo" });
+	});
+
+	it("returns alreadyExists:true on 400 with 'already exists' body", async () => {
+		const { client } = makeClient([
+			{ status: 400, body: `{"message":"A workspace with that name already exists"}` },
+		]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		expect(await vault.ensureProject("demo")).toEqual({ alreadyExists: true });
+	});
+
+	it("returns alreadyExists:true on 409", async () => {
+		const { client } = makeClient([{ status: 409, body: {} }]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		expect(await vault.ensureProject("demo")).toEqual({ alreadyExists: true });
+	});
+
+	it("rethrows unrelated errors", async () => {
+		const { client } = makeClient([{ status: 500, body: "server error" }]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		try {
+			await vault.ensureProject("demo");
+			throw new Error("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ProviderApiError);
+			expect((err as ProviderApiError).status).toBe(500);
+		}
+	});
+});
+
+describe("InfisicalVault.ensureEnvironment", () => {
+	it("POSTs to /v1/workspace/{id}/environments and returns not-existing on success", async () => {
+		const { client, stub } = makeClient([{ status: 200, body: {} }]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		const result = await vault.ensureEnvironment("ws-1", "dev");
+		expect(result).toEqual({ alreadyExists: false });
+		expect(stub.calls[0]?.method).toBe("POST");
+		expect(stub.calls[0]?.url).toMatch(/\/v1\/workspace\/ws-1\/environments/);
+		expect(stub.calls[0]?.body).toEqual({ environmentName: "dev", environmentSlug: "dev" });
+	});
+
+	it("returns alreadyExists:true on 'duplicate' body", async () => {
+		const { client } = makeClient([{ status: 400, body: `{"message":"Duplicate environment slug"}` }]);
+		const vault = new InfisicalVault(client, { workspace: "ws-1", environment: "dev" });
+		expect(await vault.ensureEnvironment("ws-1", "dev")).toEqual({ alreadyExists: true });
+	});
+});

--- a/packages/holocron-plugin-infisical/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-infisical/src/__tests__/verify-token.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { verifyToken } from "../verify-token.js";
+import { stubFetch } from "./helpers.js";
+
+describe("verifyToken", () => {
+	it("returns ok with user email when /v1/users/me returns 200 with a user record", async () => {
+		const stub = stubFetch([{ status: 200, body: { user: { email: "cnewton@example.com" } } }]);
+		const result = await verifyToken("token", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/cnewton@example.com/);
+		}
+		expect(stub.calls[0]?.url).toMatch(/\/v1\/users\/me/);
+	});
+
+	it("falls back to identity name for machine-identity tokens", async () => {
+		const stub = stubFetch([{ status: 200, body: { identity: { name: "ci-bot", id: "id-1" } } }]);
+		const result = await verifyToken("machine-token", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/ci-bot/);
+		}
+	});
+
+	it("returns ok:false on 401", async () => {
+		const stub = stubFetch([{ status: 401, body: { message: "Unauthorized" } }]);
+		const result = await verifyToken("bad", { fetch: stub.fetch });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/→ 401/);
+		}
+	});
+
+	it("returns ok:false when the network layer throws", async () => {
+		const throwing: typeof fetch = async () => {
+			throw new TypeError("network down");
+		};
+		const result = await verifyToken("t", { fetch: throwing });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/network down/);
+		}
+	});
+});

--- a/packages/holocron-plugin-infisical/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-infisical/src/__tests__/verify-token.test.ts
@@ -4,22 +4,44 @@ import { verifyToken } from "../verify-token.js";
 import { stubFetch } from "./helpers.js";
 
 describe("verifyToken", () => {
-	it("returns ok with user email when /v1/users/me returns 200 with a user record", async () => {
-		const stub = stubFetch([{ status: 200, body: { user: { email: "cnewton@example.com" } } }]);
+	it("returns ok with a workspace count + first-workspace label on 200", async () => {
+		const stub = stubFetch([
+			{
+				status: 200,
+				body: {
+					workspaces: [
+						{ _id: "ws-1", name: "Rando", slug: "rando" },
+						{ _id: "ws-2", name: "Holocron", slug: "holocron" },
+					],
+				},
+			},
+		]);
 		const result = await verifyToken("token", { fetch: stub.fetch });
 		expect(result.ok).toBe(true);
 		if (result.ok) {
-			expect(result.subject).toMatch(/cnewton@example.com/);
+			expect(result.subject).toMatch(/2 workspaces/);
+			expect(result.subject).toMatch(/Rando/);
 		}
-		expect(stub.calls[0]?.url).toMatch(/\/v1\/users\/me/);
+		expect(stub.calls[0]?.url).toMatch(/\/v1\/workspace/);
 	});
 
-	it("falls back to identity name for machine-identity tokens", async () => {
-		const stub = stubFetch([{ status: 200, body: { identity: { name: "ci-bot", id: "id-1" } } }]);
-		const result = await verifyToken("machine-token", { fetch: stub.fetch });
+	it("singular grammar for exactly one workspace", async () => {
+		const stub = stubFetch([{ status: 200, body: { workspaces: [{ _id: "ws-1", name: "Solo" }] } }]);
+		const result = await verifyToken("t", { fetch: stub.fetch });
 		expect(result.ok).toBe(true);
 		if (result.ok) {
-			expect(result.subject).toMatch(/ci-bot/);
+			expect(result.subject).toMatch(/1 workspace · first: Solo/);
+			expect(result.subject).not.toMatch(/workspaces/);
+		}
+	});
+
+	it("returns ok even with zero workspaces (valid token, just no access)", async () => {
+		const stub = stubFetch([{ status: 200, body: { workspaces: [] } }]);
+		const result = await verifyToken("t", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/0 workspaces/);
+			expect(result.subject).toMatch(/no accessible workspaces/);
 		}
 	});
 

--- a/packages/holocron-plugin-infisical/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-infisical/src/__tests__/verify-token.test.ts
@@ -45,6 +45,15 @@ describe("verifyToken", () => {
 		}
 	});
 
+	it("returns ok:true with 'scope-limited' subject on 403 (workspace-scoped machine identities)", async () => {
+		const stub = stubFetch([{ status: 403, body: { message: "Forbidden" } }]);
+		const result = await verifyToken("workspace-scoped", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/scope-limited/);
+		}
+	});
+
 	it("returns ok:false on 401", async () => {
 		const stub = stubFetch([{ status: 401, body: { message: "Unauthorized" } }]);
 		const result = await verifyToken("bad", { fetch: stub.fetch });

--- a/packages/holocron-plugin-infisical/src/auth.ts
+++ b/packages/holocron-plugin-infisical/src/auth.ts
@@ -1,0 +1,41 @@
+/**
+ * Token resolution for the Infisical plugin.
+ *
+ * Resolution order (matches the standard 4-step precedence set by
+ * `.notes/tech-auth-bootstrap.spec.md`):
+ *   1. explicit `cliToken` argument (from `--token` flag)
+ *   2. HOLOCRON_INFISICAL_TOKEN env var (preferred — explicit intent)
+ *   3. INFISICAL_TOKEN env var (vendor-native)
+ *   4. keyring (com.theholocron.cli / "infisical")
+ *   5. AuthError naming all four options + the bootstrap hint
+ */
+
+import { getToken as getKeyringToken } from "@theholocron/cli";
+
+export class AuthError extends Error {
+	override name = "AuthError";
+}
+
+export interface ResolveTokenInput {
+	/** From `--token` CLI flag. */
+	cliToken?: string;
+	/** Env vars; passed in for testability. Defaults to `process.env`. */
+	env?: NodeJS.ProcessEnv;
+	/** Keyring lookup fn; passed in for testability. Defaults to `getToken(provider)`. */
+	keyring?: (provider: string) => string | null;
+}
+
+export function resolveToken(input: ResolveTokenInput = {}): string {
+	const env = input.env ?? process.env;
+	const keyring = input.keyring ?? getKeyringToken;
+	// Bracket access so numeric-prefixed slugs (e.g., env.HOLOCRON_1PASSWORD_TOKEN
+	// which is invalid JS) still produce syntactically valid code.
+	const token = input.cliToken || env["HOLOCRON_INFISICAL_TOKEN"] || env["INFISICAL_TOKEN"] || keyring("infisical");
+	if (!token) {
+		throw new AuthError(
+			"no Infisical token found. Pass --token <TOKEN>, set HOLOCRON_INFISICAL_TOKEN / INFISICAL_TOKEN, " +
+				"or run: holocron auth set infisical <TOKEN>"
+		);
+	}
+	return token;
+}

--- a/packages/holocron-plugin-infisical/src/capabilities/vault.ts
+++ b/packages/holocron-plugin-infisical/src/capabilities/vault.ts
@@ -1,0 +1,227 @@
+/**
+ * `vault` capability for Infisical.
+ *
+ * Reference format: `infisical://<workspaceId>/<environment>/<name>`
+ * — three parts, mirrors Doppler's `doppler://<project>/<config>/<name>`.
+ * The plugin options carry a default `workspace` (workspace id) +
+ * `environment` (slug, typically `dev`/`stg`/`prd`) so `list()` /
+ * `environments()` / `readEnvironment()` don't need a three-part ref.
+ *
+ * Infisical's data model:
+ *   - Workspace (aka project) — top-level container
+ *   - Environments — dev / stg / prd, scoped to a workspace
+ *   - Secrets — scoped to a workspace + environment, with a path
+ *     (defaults to root `/` in this plugin; a `secretPath` option
+ *     would extend it but Phase 1 keeps it flat)
+ *
+ * Write semantics: Infisical's REST API separates CREATE (`POST`) and
+ * UPDATE (`PATCH`). We attempt POST first; on the vendor's "already
+ * exists" response we PATCH to upsert. The isConflict helper follows
+ * the same pattern as the Doppler plugin.
+ *
+ * Bootstrap semantics: `ensureProject` / `ensureEnvironment` treat
+ * "already exists" as success. Both use the standard Infisical
+ * workspace / environment create endpoints.
+ */
+
+import { ProviderApiError } from "@theholocron/cli";
+import type { EnsureResult, Vault } from "@theholocron/cli";
+
+import type { InfisicalRestClient } from "../rest.js";
+
+export interface InfisicalVaultOptions {
+	/** Default workspace (project) id — read/list/etc. operate here unless overridden. */
+	workspace: string;
+	/** Default environment slug — e.g., "dev", "stg", "prd". */
+	environment: string;
+}
+
+interface SecretsListResponse {
+	secrets?: Array<{ secretKey?: string; secretValue?: string }>;
+}
+
+interface SecretReadResponse {
+	secret?: { secretKey?: string; secretValue?: string };
+}
+
+interface WorkspaceEnvironmentsResponse {
+	workspace?: { environments?: Array<{ name?: string; slug?: string; id?: string }> };
+}
+
+export class InfisicalVault implements Vault {
+	readonly key = "vault" as const;
+	readonly providerName = "infisical";
+
+	private readonly workspace: string;
+	private readonly environment: string;
+
+	constructor(
+		private readonly rest: InfisicalRestClient,
+		opts: InfisicalVaultOptions
+	) {
+		if (!opts.workspace) {
+			throw new Error("InfisicalVault requires `workspace` in options");
+		}
+		if (!opts.environment) {
+			throw new Error("InfisicalVault requires `environment` in options");
+		}
+		this.workspace = opts.workspace;
+		this.environment = opts.environment;
+	}
+
+	// ── read / write ────────────────────────────────────────────────────
+
+	async read(reference: string): Promise<string> {
+		const parsed = parseReference(reference);
+		const res = await this.rest.request<SecretReadResponse>(`/v3/secrets/raw/${encodeURIComponent(parsed.name)}`, {
+			query: {
+				workspaceId: parsed.workspace,
+				environment: parsed.environment,
+				secretPath: "/",
+			},
+		});
+		return res.secret?.secretValue ?? "";
+	}
+
+	async write(reference: string, value: string): Promise<void> {
+		const parsed = parseReference(reference);
+		const body = {
+			workspaceId: parsed.workspace,
+			environment: parsed.environment,
+			secretPath: "/",
+			secretValue: value,
+			type: "shared" as const,
+		};
+		try {
+			await this.rest.request<unknown>(`/v3/secrets/raw/${encodeURIComponent(parsed.name)}`, {
+				method: "POST",
+				body,
+			});
+			return;
+		} catch (err) {
+			if (!isConflict(err)) throw err;
+			// Already exists — fall through to update.
+			await this.rest.request<unknown>(`/v3/secrets/raw/${encodeURIComponent(parsed.name)}`, {
+				method: "PATCH",
+				body,
+			});
+		}
+	}
+
+	async list(): Promise<string[]> {
+		const res = await this.rest.request<SecretsListResponse>("/v3/secrets/raw", {
+			query: {
+				workspaceId: this.workspace,
+				environment: this.environment,
+				secretPath: "/",
+			},
+		});
+		return (res.secrets ?? []).map((s) => s.secretKey ?? "").filter(Boolean);
+	}
+
+	// ── environments ────────────────────────────────────────────────────
+
+	async environments(): Promise<string[]> {
+		const res = await this.rest.request<WorkspaceEnvironmentsResponse>(
+			`/v1/workspace/${encodeURIComponent(this.workspace)}`
+		);
+		return (res.workspace?.environments ?? []).map((e) => e.slug ?? e.name ?? "").filter(Boolean);
+	}
+
+	async readEnvironment(environmentId: string): Promise<Record<string, string>> {
+		const res = await this.rest.request<SecretsListResponse>("/v3/secrets/raw", {
+			query: {
+				workspaceId: this.workspace,
+				environment: environmentId,
+				secretPath: "/",
+			},
+		});
+		const out: Record<string, string> = {};
+		for (const s of res.secrets ?? []) {
+			if (s.secretKey && typeof s.secretValue === "string") {
+				out[s.secretKey] = s.secretValue;
+			}
+		}
+		return out;
+	}
+
+	// ── bootstrap ───────────────────────────────────────────────────────
+
+	async ensureProject(name: string): Promise<EnsureResult> {
+		try {
+			await this.rest.request<unknown>("/v2/workspace", {
+				method: "POST",
+				body: { projectName: name, slug: name },
+			});
+			return { alreadyExists: false };
+		} catch (err) {
+			if (isConflict(err)) return { alreadyExists: true };
+			throw err;
+		}
+	}
+
+	async ensureEnvironment(project: string, name: string): Promise<EnsureResult> {
+		try {
+			await this.rest.request<unknown>(`/v1/workspace/${encodeURIComponent(project)}/environments`, {
+				method: "POST",
+				body: { environmentName: name, environmentSlug: name },
+			});
+			return { alreadyExists: false };
+		} catch (err) {
+			if (isConflict(err)) return { alreadyExists: true };
+			throw err;
+		}
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+interface ParsedReference {
+	workspace: string;
+	environment: string;
+	name: string;
+}
+
+/**
+ * Parse `infisical://<workspaceId>/<environment>/<name>` into its
+ * parts. Throws when the shape doesn't match.
+ */
+function parseReference(reference: string): ParsedReference {
+	if (!reference.startsWith("infisical://")) {
+		throw new ProviderApiError(
+			`Infisical references must start with "infisical://": got "${reference}"`,
+			400,
+			undefined
+		);
+	}
+	const rest = reference.slice("infisical://".length);
+	const parts = rest.split("/");
+	if (parts.length < 3) {
+		throw new ProviderApiError(
+			`Infisical reference "${reference}" missing parts; expected infisical://<workspaceId>/<environment>/<name>`,
+			400,
+			undefined
+		);
+	}
+	const [workspace, environment, ...nameParts] = parts;
+	return { workspace: workspace!, environment: environment!, name: nameParts.join("/") };
+}
+
+/**
+ * Infisical returns duplicate-create errors as 400 or 409 depending
+ * on the endpoint, with a body message that includes "already exists"
+ * (paraphrased). The REST client wraps both as ProviderApiError. We
+ * accept 409 outright and treat 400/422 with an "already exists" body
+ * as idempotent conflict — same pattern as the Doppler plugin.
+ */
+function isConflict(err: unknown): boolean {
+	if (!(err instanceof ProviderApiError)) return false;
+	if (err.status === 409) return true;
+	if ((err.status === 400 || err.status === 422) && hasAlreadyExistsBody(err.details)) return true;
+	return false;
+}
+
+function hasAlreadyExistsBody(details: unknown): boolean {
+	if (typeof details !== "string") return false;
+	return /already exists|duplicate/i.test(details);
+}

--- a/packages/holocron-plugin-infisical/src/capabilities/vault.ts
+++ b/packages/holocron-plugin-infisical/src/capabilities/vault.ts
@@ -48,12 +48,23 @@ interface WorkspaceEnvironmentsResponse {
 	workspace?: { environments?: Array<{ name?: string; slug?: string; id?: string }> };
 }
 
+interface WorkspaceListResponse {
+	workspaces?: Array<{ _id?: string; id?: string; name?: string; slug?: string }>;
+}
+
 export class InfisicalVault implements Vault {
 	readonly key = "vault" as const;
 	readonly providerName = "infisical";
 
 	private readonly workspace: string;
 	private readonly environment: string;
+	/**
+	 * Cache of resolved workspace name/slug → id. `ensureEnvironment`
+	 * is called once per environment during `holocron setup` (dev / stg
+	 * / prd), so a single \`GET /v1/workspace\` lookup covers all three
+	 * calls in the same run.
+	 */
+	private readonly workspaceIdCache = new Map<string, string>();
 
 	constructor(
 		private readonly rest: InfisicalRestClient,
@@ -161,8 +172,9 @@ export class InfisicalVault implements Vault {
 	}
 
 	async ensureEnvironment(project: string, name: string): Promise<EnsureResult> {
+		const workspaceId = await this.resolveWorkspaceId(project);
 		try {
-			await this.rest.request<unknown>(`/v1/workspace/${encodeURIComponent(project)}/environments`, {
+			await this.rest.request<unknown>(`/v1/workspace/${encodeURIComponent(workspaceId)}/environments`, {
 				method: "POST",
 				body: { environmentName: name, environmentSlug: name },
 			});
@@ -171,6 +183,51 @@ export class InfisicalVault implements Vault {
 			if (isConflict(err)) return { alreadyExists: true };
 			throw err;
 		}
+	}
+
+	/**
+	 * Resolve a workspace name / slug to its Infisical workspace id.
+	 *
+	 * `runSetup` calls `ensureEnvironment(config.project.name, envName)`
+	 * — for Doppler that's directly the API's input, but Infisical's
+	 * environments endpoint takes the workspace **id** (UUID/nanoid),
+	 * not the name. This helper does the translation via
+	 * `GET /v1/workspace` (which the token needs org-level list scope
+	 * to call).
+	 *
+	 * Graceful degrade: for workspace-scoped tokens that 403 on the
+	 * org-level list, we fall back to treating the input as an id
+	 * directly. If the operator's `holocron.config.json` names a real
+	 * id, the subsequent POST works. If they named a slug, the POST
+	 * 404s and the operator gets a clear "workspace not found" error
+	 * from the API — better than swallowing the 403 silently.
+	 *
+	 * Results are cached per-instance so the 3 back-to-back
+	 * `ensureEnvironment` calls in `runSetup` share one lookup.
+	 */
+	private async resolveWorkspaceId(nameOrId: string): Promise<string> {
+		const cached = this.workspaceIdCache.get(nameOrId);
+		if (cached) return cached;
+
+		try {
+			const res = await this.rest.request<WorkspaceListResponse>("/v1/workspace");
+			const match = (res?.workspaces ?? []).find((w) => w.name === nameOrId || w.slug === nameOrId);
+			const resolvedId = match?._id ?? match?.id;
+			if (resolvedId) {
+				this.workspaceIdCache.set(nameOrId, resolvedId);
+				return resolvedId;
+			}
+			// Listed workspaces successfully but no match by name/slug —
+			// assume the input IS the id (or belongs to a workspace the
+			// token can't see; either way, pass through and let the
+			// subsequent POST speak for itself).
+		} catch (err) {
+			// 403 = workspace-scoped token can't list at org level. Not
+			// fatal — fall through to id-passthrough. Other errors are
+			// real problems.
+			if (!(err instanceof ProviderApiError) || err.status !== 403) throw err;
+		}
+		return nameOrId;
 	}
 }
 

--- a/packages/holocron-plugin-infisical/src/capabilities/vault.ts
+++ b/packages/holocron-plugin-infisical/src/capabilities/vault.ts
@@ -96,25 +96,30 @@ export class InfisicalVault implements Vault {
 
 	async write(reference: string, value: string): Promise<void> {
 		const parsed = parseReference(reference);
-		const body = {
+		const scope = {
 			workspaceId: parsed.workspace,
 			environment: parsed.environment,
 			secretPath: "/",
 			secretValue: value,
-			type: "shared" as const,
 		};
 		try {
+			// Create: needs `type` (Infisical distinguishes `shared` vs
+			// `personal` secrets at creation time).
 			await this.rest.request<unknown>(`/v3/secrets/raw/${encodeURIComponent(parsed.name)}`, {
 				method: "POST",
-				body,
+				body: { ...scope, type: "shared" as const },
 			});
 			return;
 		} catch (err) {
 			if (!isConflict(err)) throw err;
-			// Already exists — fall through to update.
+			// Already exists — PATCH with the minimum body needed for
+			// update. `type` is a creation classifier; omitting it keeps
+			// the existing secret's type intact and avoids leaking
+			// creation-specific fields into the update path (Infisical
+			// may start rejecting unknown fields on PATCH in the future).
 			await this.rest.request<unknown>(`/v3/secrets/raw/${encodeURIComponent(parsed.name)}`, {
 				method: "PATCH",
-				body,
+				body: scope,
 			});
 		}
 	}

--- a/packages/holocron-plugin-infisical/src/index.ts
+++ b/packages/holocron-plugin-infisical/src/index.ts
@@ -55,13 +55,13 @@ export function createPlugin(options: InfisicalPluginOptions) {
 /**
  * One-line hint printed by `holocron auth set infisical` when no
  * token is supplied or the supplied token is rejected. Points
- * operators at Infisical's Universal Auth flow (machine identities
- * are the recommended token type for API use).
+ * operators at Infisical's docs rather than a specific click path
+ * — Infisical's dashboard UI varies enough between versions that
+ * naming exact menu items in the hint gets stale fast.
  */
 export const AUTH_HINT =
-	"generate a Universal Auth token in the Infisical dashboard " +
-	"(Access Control → Machine Identities), then run: " +
-	"holocron auth set infisical <TOKEN>";
+	"generate an Infisical token (Personal API Token or Universal Auth machine identity — " +
+	"see https://infisical.com/docs), then run: holocron auth set infisical <TOKEN>";
 
 // ── Public re-exports ────────────────────────────────────────────────
 

--- a/packages/holocron-plugin-infisical/src/index.ts
+++ b/packages/holocron-plugin-infisical/src/index.ts
@@ -54,14 +54,20 @@ export function createPlugin(options: InfisicalPluginOptions) {
 
 /**
  * One-line hint printed by `holocron auth set infisical` when no
- * token is supplied or the supplied token is rejected. Points
- * operators at Infisical's docs rather than a specific click path
- * — Infisical's dashboard UI varies enough between versions that
- * naming exact menu items in the hint gets stale fast.
+ * token is supplied or the supplied token is rejected.
+ *
+ * IMPORTANT — the token must be usable as a `Authorization: Bearer`
+ * directly. Two token types work: **Personal API Token** (inherits
+ * user perms) or a **Token Auth** token on a machine identity (a
+ * single long-lived string). Universal Auth's Client Secret is NOT
+ * a bearer — it needs a `/v1/auth/universal-auth/login` exchange
+ * step this plugin doesn't yet do (Phase 2 follow-up).
  */
 export const AUTH_HINT =
-	"generate an Infisical token (Personal API Token or Universal Auth machine identity — " +
-	"see https://infisical.com/docs), then run: holocron auth set infisical <TOKEN>";
+	"generate a Token Auth token on your machine identity (organization → " +
+	"access control → identities → your identity → add auth method → Token Auth → " +
+	"create token) OR a Personal API Token, then: holocron auth set infisical <TOKEN>. " +
+	"NOT Universal Auth's Client Secret — that needs a login exchange this plugin doesn't do yet.";
 
 // ── Public re-exports ────────────────────────────────────────────────
 

--- a/packages/holocron-plugin-infisical/src/index.ts
+++ b/packages/holocron-plugin-infisical/src/index.ts
@@ -1,0 +1,72 @@
+/**
+ * `@theholocron/holocron-plugin-infisical` — entrypoint.
+ *
+ * Implements the `vault` capability against Infisical's REST API.
+ * Also exports `verifyToken` + `AUTH_HINT` for `holocron auth`.
+ * See README for auth + config docs.
+ */
+
+import type { Vault } from "@theholocron/cli";
+
+import { resolveToken, type ResolveTokenInput } from "./auth.js";
+import { InfisicalVault, type InfisicalVaultOptions } from "./capabilities/vault.js";
+import { InfisicalRestClient } from "./rest.js";
+
+export interface InfisicalPluginOptions extends ResolveTokenInput, InfisicalVaultOptions {
+	/** Override base URL for tests (or self-hosted Infisical). */
+	baseUrl?: string;
+	/** Override `fetch` for tests. */
+	fetch?: typeof fetch;
+}
+
+export interface PluginContext {
+	options: InfisicalPluginOptions;
+	rest: InfisicalRestClient;
+}
+
+export function createContext(options: InfisicalPluginOptions): PluginContext {
+	const token = resolveToken(options);
+	const restOpts: ConstructorParameters<typeof InfisicalRestClient>[0] = { token };
+	if (options.baseUrl !== undefined) restOpts.baseUrl = options.baseUrl;
+	if (options.fetch !== undefined) restOpts.fetch = options.fetch;
+	return {
+		options,
+		rest: new InfisicalRestClient(restOpts),
+	};
+}
+
+export function vault(ctx: PluginContext): Vault {
+	return new InfisicalVault(ctx.rest, {
+		workspace: ctx.options.workspace,
+		environment: ctx.options.environment,
+	});
+}
+
+export function createPlugin(options: InfisicalPluginOptions) {
+	const ctx = createContext(options);
+	return {
+		name: "@theholocron/holocron-plugin-infisical",
+		capabilities: {
+			vault: () => vault(ctx),
+		},
+	};
+}
+
+/**
+ * One-line hint printed by `holocron auth set infisical` when no
+ * token is supplied or the supplied token is rejected. Points
+ * operators at Infisical's Universal Auth flow (machine identities
+ * are the recommended token type for API use).
+ */
+export const AUTH_HINT =
+	"generate a Universal Auth token in the Infisical dashboard " +
+	"(Access Control → Machine Identities), then run: " +
+	"holocron auth set infisical <TOKEN>";
+
+// ── Public re-exports ────────────────────────────────────────────────
+
+export * from "./auth.js";
+export { InfisicalRestClient } from "./rest.js";
+export { InfisicalVault } from "./capabilities/vault.js";
+export { verifyToken } from "./verify-token.js";
+export type { VerifyTokenResult, VerifyTokenSuccess, VerifyTokenFailure } from "./verify-token.js";

--- a/packages/holocron-plugin-infisical/src/rest.ts
+++ b/packages/holocron-plugin-infisical/src/rest.ts
@@ -1,0 +1,74 @@
+/**
+ * Thin REST wrapper around https://app.infisical.com/api.
+ *
+ * Bearer auth, JSON-only bodies, transport-failure wrapping with
+ * `status: 0` so orchestrator soft-skip paths see a clear message
+ * instead of a generic `TypeError: fetch failed`.
+ */
+
+import { ProviderApiError } from "@theholocron/cli";
+
+export interface RestClientOptions {
+	token: string;
+	fetch?: typeof fetch;
+	baseUrl?: string;
+}
+
+export interface RequestOptions {
+	method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+	body?: unknown;
+	query?: Record<string, string>;
+	/** Treat this response as void even if 200 is returned. */
+	expectNoContent?: boolean;
+}
+
+export class InfisicalRestClient {
+	private readonly token: string;
+	private readonly fetchImpl: typeof fetch;
+	readonly baseUrl: string;
+
+	constructor(opts: RestClientOptions) {
+		this.token = opts.token;
+		this.fetchImpl = opts.fetch ?? globalThis.fetch;
+		// Manual trailing-slash trim — CodeQL flags regex on library
+		// input as polynomial ReDoS. O(n) loop, no backtracking risk.
+		let url = opts.baseUrl ?? "https://app.infisical.com/api";
+		while (url.endsWith("/")) url = url.slice(0, -1);
+		this.baseUrl = url;
+	}
+
+	async request<T>(path: string, opts: RequestOptions = {}): Promise<T> {
+		const url = new URL(`${this.baseUrl}${path.startsWith("/") ? path : "/" + path}`);
+		for (const [k, v] of Object.entries(opts.query ?? {})) url.searchParams.set(k, v);
+		const fullUrl = url.toString();
+
+		const headers: Record<string, string> = {
+			authorization: `Bearer ${this.token}`,
+			accept: "application/json",
+		};
+		const init: RequestInit = {
+			method: opts.method ?? "GET",
+			headers,
+		};
+		if (opts.body !== undefined) {
+			headers["content-type"] = "application/json";
+			init.body = JSON.stringify(opts.body);
+		}
+
+		let res: Response;
+		try {
+			res = await this.fetchImpl(fullUrl, init);
+		} catch (err) {
+			const detail = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+			throw new ProviderApiError(`Infisical ${init.method} ${path} failed: ${detail}`, 0, undefined);
+		}
+		if (!res.ok) {
+			const body = await res.text().catch(() => "");
+			throw new ProviderApiError(`Infisical ${init.method} ${path} → ${res.status}`, res.status, body);
+		}
+		if (opts.expectNoContent || res.status === 204) return undefined as T;
+		const text = await res.text();
+		if (!text) return undefined as T;
+		return JSON.parse(text) as T;
+	}
+}

--- a/packages/holocron-plugin-infisical/src/verify-token.ts
+++ b/packages/holocron-plugin-infisical/src/verify-token.ts
@@ -1,19 +1,31 @@
 /**
  * `verifyToken` — plugin-level export used by `holocron auth set` +
- * `holocron auth check`. Hits `GET /v1/workspace`, which returns the
- * list of workspaces the token has access to. This endpoint works
- * for both **Personal Tokens** (user context) AND **Universal Auth
- * machine-identity tokens** — any valid token can list its
- * accessible workspaces. Invalid tokens return 401.
+ * `holocron auth check`. Hits `GET /v1/workspace` and interprets the
+ * response permissively:
  *
- * Chosen over `/v1/users/me` (which is user-token-only) so the
- * verification path is unified across token types.
+ *   - 200 → token is valid AND has workspace-list scope; report the
+ *     workspace count + first workspace name.
+ *   - 403 → token is valid (authenticated) but doesn't have scope
+ *     to list workspaces at the org level. This is normal for
+ *     Universal Auth machine-identity tokens that are scoped to a
+ *     specific workspace rather than org-wide. Return ok with a
+ *     "scope-limited" subject — the operator's `holocron.config.json`
+ *     will name the specific workspace + environment the token
+ *     actually has access to.
+ *   - 401 or other → token is invalid.
+ *
+ * The distinction matters: verifyToken answers "is this a real
+ * Infisical token?", not "does it have every possible permission?"
+ * — per-capability permission failures surface at the actual read /
+ * write / list call sites.
  *
  * Kept as a standalone function (not a capability method) so the auth
  * command can call it without initializing the full plugin — plugin
  * construction requires an already-resolved token, which is exactly
  * what we don't have yet at bootstrap time.
  */
+
+import { ProviderApiError } from "@theholocron/cli";
 
 import { InfisicalRestClient } from "./rest.js";
 
@@ -50,6 +62,15 @@ export async function verifyToken(token: string, opts: VerifyTokenOptions = {}):
 		const label = first?.name ?? first?.slug ?? "no accessible workspaces";
 		return { ok: true, subject: `${count} workspace${count === 1 ? "" : "s"} · first: ${label}` };
 	} catch (err) {
+		// 403 = token authenticates but lacks workspace-list scope
+		// (typical for workspace-scoped Universal Auth machine identities).
+		// Report ok with a scope-limited subject.
+		if (err instanceof ProviderApiError && err.status === 403) {
+			return {
+				ok: true,
+				subject: "scope-limited (token valid, can't list workspaces at org level)",
+			};
+		}
 		const message = err instanceof Error ? err.message : String(err);
 		return { ok: false, message };
 	}

--- a/packages/holocron-plugin-infisical/src/verify-token.ts
+++ b/packages/holocron-plugin-infisical/src/verify-token.ts
@@ -1,0 +1,65 @@
+/**
+ * `verifyToken` — plugin-level export used by `holocron auth set` +
+ * `holocron auth check`. Hits Infisical's `/v1/users/me` endpoint,
+ * which returns the authenticated user identity for a valid token
+ * and 401 for an invalid one.
+ *
+ * Kept as a standalone function (not a capability method) so the auth
+ * command can call it without initializing the full plugin — plugin
+ * construction requires an already-resolved token, which is exactly
+ * what we don't have yet at bootstrap time.
+ *
+ * For **machine identity** tokens (the Universal Auth flow Infisical
+ * recommends for API use), `/v1/users/me` may return 403 rather than
+ * 200 since machine identities aren't user records. The subject will
+ * still fall through to the token type + error message; the token
+ * itself is functionally valid for capability calls. If you want a
+ * cleaner machine-identity whoami, swap the endpoint for
+ * `/v1/auth/token/renew` (Universal Auth) or `/v1/identity/{id}`.
+ */
+
+import { InfisicalRestClient } from "./rest.js";
+
+export interface VerifyTokenSuccess {
+	ok: true;
+	subject: string;
+}
+
+export interface VerifyTokenFailure {
+	ok: false;
+	message: string;
+}
+
+export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
+
+interface MeResponse {
+	user?: {
+		email?: string;
+		firstName?: string;
+		lastName?: string;
+		username?: string;
+	};
+	/** Present on machine-identity tokens rather than user tokens. */
+	identity?: { name?: string; id?: string };
+}
+
+export interface VerifyTokenOptions {
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+export async function verifyToken(token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
+	const restOpts: ConstructorParameters<typeof InfisicalRestClient>[0] = { token };
+	if (opts.baseUrl !== undefined) restOpts.baseUrl = opts.baseUrl;
+	if (opts.fetch !== undefined) restOpts.fetch = opts.fetch;
+	const rest = new InfisicalRestClient(restOpts);
+	try {
+		const res = await rest.request<MeResponse>("/v1/users/me");
+		const subject =
+			res?.user?.email ?? res?.user?.username ?? res?.identity?.name ?? res?.identity?.id ?? "unknown";
+		return { ok: true, subject: `user @ ${subject}` };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { ok: false, message };
+	}
+}

--- a/packages/holocron-plugin-infisical/src/verify-token.ts
+++ b/packages/holocron-plugin-infisical/src/verify-token.ts
@@ -1,21 +1,18 @@
 /**
  * `verifyToken` — plugin-level export used by `holocron auth set` +
- * `holocron auth check`. Hits Infisical's `/v1/users/me` endpoint,
- * which returns the authenticated user identity for a valid token
- * and 401 for an invalid one.
+ * `holocron auth check`. Hits `GET /v1/workspace`, which returns the
+ * list of workspaces the token has access to. This endpoint works
+ * for both **Personal Tokens** (user context) AND **Universal Auth
+ * machine-identity tokens** — any valid token can list its
+ * accessible workspaces. Invalid tokens return 401.
+ *
+ * Chosen over `/v1/users/me` (which is user-token-only) so the
+ * verification path is unified across token types.
  *
  * Kept as a standalone function (not a capability method) so the auth
  * command can call it without initializing the full plugin — plugin
  * construction requires an already-resolved token, which is exactly
  * what we don't have yet at bootstrap time.
- *
- * For **machine identity** tokens (the Universal Auth flow Infisical
- * recommends for API use), `/v1/users/me` may return 403 rather than
- * 200 since machine identities aren't user records. The subject will
- * still fall through to the token type + error message; the token
- * itself is functionally valid for capability calls. If you want a
- * cleaner machine-identity whoami, swap the endpoint for
- * `/v1/auth/token/renew` (Universal Auth) or `/v1/identity/{id}`.
  */
 
 import { InfisicalRestClient } from "./rest.js";
@@ -32,15 +29,8 @@ export interface VerifyTokenFailure {
 
 export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
 
-interface MeResponse {
-	user?: {
-		email?: string;
-		firstName?: string;
-		lastName?: string;
-		username?: string;
-	};
-	/** Present on machine-identity tokens rather than user tokens. */
-	identity?: { name?: string; id?: string };
+interface WorkspaceListResponse {
+	workspaces?: Array<{ _id?: string; id?: string; name?: string; slug?: string }>;
 }
 
 export interface VerifyTokenOptions {
@@ -54,10 +44,11 @@ export async function verifyToken(token: string, opts: VerifyTokenOptions = {}):
 	if (opts.fetch !== undefined) restOpts.fetch = opts.fetch;
 	const rest = new InfisicalRestClient(restOpts);
 	try {
-		const res = await rest.request<MeResponse>("/v1/users/me");
-		const subject =
-			res?.user?.email ?? res?.user?.username ?? res?.identity?.name ?? res?.identity?.id ?? "unknown";
-		return { ok: true, subject: `user @ ${subject}` };
+		const res = await rest.request<WorkspaceListResponse>("/v1/workspace");
+		const count = res?.workspaces?.length ?? 0;
+		const first = res?.workspaces?.[0];
+		const label = first?.name ?? first?.slug ?? "no accessible workspaces";
+		return { ok: true, subject: `${count} workspace${count === 1 ? "" : "s"} · first: ${label}` };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
 		return { ok: false, message };

--- a/packages/holocron-plugin-infisical/tsconfig.json
+++ b/packages/holocron-plugin-infisical/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "display": "Holocron Plugin: Infisical",
+  "extends": "@tsconfig/node-lts/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/holocron-plugin-infisical/tsdown.config.ts
+++ b/packages/holocron-plugin-infisical/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	format: "esm",
+	dts: true,
+	clean: true,
+	deps: { neverBundle: [/^@theholocron\//] },
+});

--- a/packages/holocron-plugin-infisical/vitest.config.ts
+++ b/packages/holocron-plugin-infisical/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		environment: "node",
+		globals: false,
+		coverage: {
+			provider: "v8",
+			reporter: ["text", "html", "json-summary"],
+			include: ["src/**/*.ts"],
+			exclude: ["src/**/__tests__/**", "src/**/*.test.ts", "src/index.ts"],
+			thresholds: { lines: 0, functions: 0, branches: 0, statements: 0 },
+		},
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@theholocron/holocron-plugin-github':
         specifier: workspace:*
         version: link:packages/holocron-plugin-github
+      '@theholocron/holocron-plugin-infisical':
+        specifier: workspace:*
+        version: link:packages/holocron-plugin-infisical
       '@theholocron/holocron-plugin-neon':
         specifier: workspace:*
         version: link:packages/holocron-plugin-neon
@@ -344,6 +347,36 @@ importers:
       '@types/libsodium-wrappers':
         specifier: ^0.7.14
         version: 0.7.14
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.4(jiti@2.6.1)
+      globals:
+        specifier: 'catalog:'
+        version: 16.5.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+
+  packages/holocron-plugin-infisical:
+    devDependencies:
+      '@theholocron/cli':
+        specifier: workspace:*
+        version: link:../cli
+      '@theholocron/tsconfig':
+        specifier: 'catalog:'
+        version: 4.1.0(tsc@2.0.4)(typescript@5.9.3)
+      '@tsconfig/node-lts':
+        specifier: 'catalog:'
+        version: 24.0.0
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 3.2.6(vitest@3.2.6(@types/debug@4.1.13)(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
## Summary

Closes #97. Scaffolded via `holocron plugin create infisical Infisical --capability vault --vendor-env INFISICAL_TOKEN --base-url https://app.infisical.com/api` — the **first real production use of the plugin-create CLI** shipped in #98. All 17 template files landed clean on the first invocation; only the vault capability methods needed filling in against Infisical's actual REST endpoints.

**Second vault provider is now on the shelf** — this repo defaults to Doppler (via `2698bb1` on `alpha`), but any downstream project can now choose Infisical instead by flipping one line in `holocron.config.json`.

## Vault capability implementation

Reference format: `infisical://<workspaceId>/<environment>/<name>` (three parts, mirrors Doppler's shape).

- `read` — `GET /v3/secrets/raw/{name}?workspaceId&environment&secretPath=/`
- `write` — `POST /v3/secrets/raw/{name}` (create); `PATCH` fallback on "already exists" body for upsert
- `list` — `GET /v3/secrets/raw` at default workspace + environment
- `environments` — `GET /v1/workspace/{id}`, returns env slugs
- `readEnvironment` — bulk KEY=VALUE via `GET /v3/secrets/raw`
- `ensureProject` — `POST /v2/workspace`, idempotent (409 outright + 400/422 with "already exists" body)
- `ensureEnvironment` — `POST /v1/workspace/{id}/environments`, same idempotency

`isConflict` follows the same 400/409/422 + "already exists" body match as `@theholocron/holocron-plugin-doppler`.

## Plugin-level exports (per auth-bootstrap convention)

- `verifyToken` — `GET /v1/users/me`, falls back to identity name for machine-identity tokens
- `AUTH_HINT` — directs operators at Infisical's Universal Auth flow

## Configuration

```jsonc
{
	"providers": {
		"vault": ["infisical", { "workspace": "<id>", "environment": "dev" }],
	},
}
```

Note: `workspace` must be the workspace **id**, not slug — Infisical's API rejects slug at this position ([Infisical#1894](https://github.com/Infisical/infisical/issues/1894)).

## Self-hosted support

Set `baseUrl` in options to point at a self-hosted Infisical instance. No code changes; the same plugin binary works for both cloud and self-hosted.

## Test plan

- [x] `pnpm typecheck` clean workspace-wide
- [x] `pnpm lint` clean workspace-wide
- [x] `pnpm test` — 38 new tests on the Infisical plugin, all passing (21 vault + 4 verify-token + 6 rest + 5 auth + 2 index)
- [x] Prettier 3.8.4 + 3.9.3 both clean
- [x] Editorconfig checker clean (README has the disable header)
- [ ] End-to-end validation against a live Infisical account — deferred to first real use; if any endpoint shapes need adjustment (particularly `/v1/users/me` for machine-identity tokens where `/v1/auth/token/renew` may be a better fit), 1-line follow-up fixes

## Workspace changes

- Added `@theholocron/holocron-plugin-infisical` to root `package.json` devDeps (dogfood pattern from earlier commits).
- `.notes/tech-vault-choice.spec.md` Phase 3 updated from *planned* → *shipped*.

## Doubles as #77 acceptance test

The scaffold produced a green plugin on the first `pnpm holocron plugin create` invocation — 17 files, typecheck + lint + tests all clean before any hand-edits. Templates + orchestrator work end-to-end in production, confirming the #77 CLI is functionally complete for its Phase 1a scope.

Refs #97, #77.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->