### PR TITLE
feat(plugins): backfill scripts/validate.mjs across all 7 plugins (#101)

### DIFF
--- a/packages/holocron-plugin-1password/package.json
+++ b/packages/holocron-plugin-1password/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
     "@theholocron/cli": "workspace:*"
@@ -36,7 +37,8 @@
     "globals": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "tsdown": "catalog:"
+    "tsdown": "catalog:",
+    "tsx": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/holocron-plugin-1password/scripts/validate.mjs
+++ b/packages/holocron-plugin-1password/scripts/validate.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Read-only smoke test for @theholocron/holocron-plugin-1password.
+ *
+ * Different shape from the REST plugins because 1P shells out to
+ * the `op` CLI. Validates that `op` is installed + signed in + can
+ * list items in the configured vault.
+ *
+ * READ-ONLY. Never calls write().
+ *
+ * Auth: 1P doesn't use a bearer in the keyring; it uses `op`'s own
+ * auth (desktop biometric on laptop, OP_SERVICE_ACCOUNT_TOKEN in CI).
+ * The `verifyToken` export here ignores its token arg — it just
+ * runs `op whoami`.
+ *
+ * Usage:
+ *   pnpm --filter @theholocron/holocron-plugin-1password validate <vaultName>
+ */
+
+import { createPlugin, verifyToken } from "../src/index.ts";
+
+const [vaultName] = process.argv.slice(2);
+
+if (!vaultName) {
+	console.error("usage: pnpm --filter @theholocron/holocron-plugin-1password validate <vaultName>");
+	console.error("  the vaultName is the 1P vault items live in (e.g., 'holocron')");
+	process.exit(2);
+}
+
+console.log("Validating @theholocron/holocron-plugin-1password (READ-ONLY)");
+console.log(`  vault: ${vaultName}`);
+console.log("");
+
+console.log("[1/2] verifyToken  (runs `op whoami`)");
+// Token arg is ignored — see verify-token.ts
+const verifyResult = await verifyToken("");
+console.log(`      ${verifyResult.ok ? "✓" : "✗"} ${JSON.stringify(verifyResult)}`);
+if (!verifyResult.ok) {
+	const hint = hintFor(verifyResult.message);
+	if (hint) console.log(`         hint: ${hint}`);
+	console.log("");
+	console.log("`op` is not signed in — skipping further steps.");
+	process.exit(1);
+}
+console.log("");
+
+console.log(`[2/2] vault.list()  (vault: ${vaultName})`);
+try {
+	const plugin = createPlugin({ vault: vaultName });
+	const vault = plugin.capabilities.vault();
+	const keys = await vault.list();
+	console.log(`      ✓ ${keys.length} item${keys.length === 1 ? "" : "s"} in vault`);
+	if (keys.length > 0 && keys.length <= 25) keys.forEach((k) => console.log(`         · ${k}`));
+	else if (keys.length > 25) {
+		console.log(`         (${keys.length} total — showing first 25)`);
+		keys.slice(0, 25).forEach((k) => console.log(`         · ${k}`));
+	}
+} catch (err) {
+	const message = err instanceof Error ? err.message : String(err);
+	console.log(`      ✗ ERROR: ${message}`);
+	const hint = hintFor(message);
+	if (hint) console.log(`         hint: ${hint}`);
+}
+console.log("");
+console.log("Done. No writes.");
+
+function hintFor(message) {
+	if (/not found on PATH/i.test(message)) return "install: brew install 1password-cli";
+	if (/not currently signed in|whoami failed/i.test(message))
+		return "sign in: `op signin` on your laptop, OR set OP_SERVICE_ACCOUNT_TOKEN in CI";
+	if (/vault.*not found|no such vault/i.test(message)) return "vault name mismatch — check `op vault list`";
+	if (/failed|exit \d/i.test(message)) return "op CLI exited non-zero — inspect stderr for the underlying reason";
+	return null;
+}

--- a/packages/holocron-plugin-clerk/package.json
+++ b/packages/holocron-plugin-clerk/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
     "@theholocron/cli": "workspace:*"
@@ -36,7 +37,8 @@
     "globals": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "tsdown": "catalog:"
+    "tsdown": "catalog:",
+    "tsx": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/holocron-plugin-clerk/scripts/validate.mjs
+++ b/packages/holocron-plugin-clerk/scripts/validate.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Read-only smoke test for @theholocron/holocron-plugin-clerk.
+ *
+ * READ-ONLY. Tests auth.describe + auth.whoami — the two guaranteed
+ * capability methods.
+ *
+ * NOTE: no keyring / verifyToken yet — uses `--token` →
+ * HOLOCRON_CLERK_TOKEN → CLERK_SECRET_KEY only. Auth-modernization
+ * follow-up tracked separately.
+ *
+ * Usage:
+ *   pnpm --filter @theholocron/holocron-plugin-clerk validate
+ */
+
+import { AuthError, createPlugin, resolveToken } from "../src/index.ts";
+
+let token;
+try {
+	token = resolveToken();
+} catch (err) {
+	if (err instanceof AuthError) {
+		console.error(err.message);
+		console.error("  see: packages/holocron-plugin-clerk/README.md#auth");
+		process.exit(2);
+	}
+	throw err;
+}
+
+console.log("Validating @theholocron/holocron-plugin-clerk (READ-ONLY)");
+console.log("");
+
+const plugin = createPlugin({ cliToken: token });
+const auth = plugin.capabilities.auth();
+
+console.log("[1/2] auth.describe()");
+await runStep(async () => {
+	const desc = await auth.describe();
+	console.log(`      ✓ provider: ${desc.provider}`);
+	console.log(`         env keys: ${desc.envKeys.join(", ")}`);
+});
+console.log("");
+
+console.log("[2/2] auth.whoami()");
+await runStep(async () => {
+	const identity = await auth.whoami();
+	console.log(`      ✓ provider: ${identity.provider}`);
+	if (identity.details) {
+		Object.entries(identity.details)
+			.slice(0, 5)
+			.forEach(([k, v]) => console.log(`         · ${k}: ${String(v)}`));
+	}
+});
+console.log("");
+console.log("Done. No writes.");
+
+async function runStep(body) {
+	try {
+		await body();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.log(`      ✗ ERROR: ${message}`);
+		const hint = hintFor(message);
+		if (hint) console.log(`         hint: ${hint}`);
+	}
+}
+
+function hintFor(message) {
+	if (/→ 401|→ 403/.test(message))
+		return "secret key invalid or lacks scope — regenerate at https://dashboard.clerk.com → API Keys (use the SECRET key, not publishable)";
+	if (/→ 404/.test(message))
+		return "endpoint or resource not found — verify the base URL matches your Clerk instance's API domain";
+	if (/fetch failed|status: 0|network/i.test(message)) return "network error — check api.clerk.com reachable";
+	if (/→ 5\d\d/.test(message)) return "server error — check https://status.clerk.com";
+	return null;
+}

--- a/packages/holocron-plugin-doppler/package.json
+++ b/packages/holocron-plugin-doppler/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
     "@theholocron/cli": "workspace:*"
@@ -36,7 +37,8 @@
     "globals": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "tsdown": "catalog:"
+    "tsdown": "catalog:",
+    "tsx": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/holocron-plugin-doppler/scripts/validate.mjs
+++ b/packages/holocron-plugin-doppler/scripts/validate.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Read-only smoke test for @theholocron/holocron-plugin-doppler
+ * against a live Doppler account. Same convention as the other
+ * plugins — see `.notes/tool-plugin-create.spec.md` and
+ * `packages/holocron-plugin-infisical/scripts/validate.mjs`.
+ *
+ * READ-ONLY. Never calls write() or bootstrap methods.
+ *
+ * Usage:
+ *   pnpm --filter @theholocron/holocron-plugin-doppler validate \
+ *     <project> <config> [secretName]
+ */
+
+import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
+
+const [project, config, secretName] = process.argv.slice(2);
+
+if (!project || !config) {
+	console.error("usage: pnpm --filter @theholocron/holocron-plugin-doppler validate <project> <config> [secretName]");
+	process.exit(2);
+}
+
+let token;
+try {
+	token = resolveToken();
+} catch (err) {
+	if (err instanceof AuthError) {
+		console.error(err.message);
+		console.error("  see: packages/holocron-plugin-doppler/README.md#setup");
+		process.exit(2);
+	}
+	throw err;
+}
+
+console.log("Validating @theholocron/holocron-plugin-doppler (READ-ONLY)");
+console.log(`  project: ${project}`);
+console.log(`  config:  ${config}`);
+if (secretName) console.log(`  secret:  ${secretName}`);
+console.log("");
+
+console.log("[1/4] verifyToken");
+const verifyResult = await verifyToken(token);
+console.log(`      ${verifyResult.ok ? "✓" : "✗"} ${JSON.stringify(verifyResult)}`);
+if (!verifyResult.ok) {
+	const hint = hintFor(verifyResult.message);
+	if (hint) console.log(`         hint: ${hint}`);
+}
+console.log("");
+
+const plugin = createPlugin({ cliToken: token, project, config });
+const vault = plugin.capabilities.vault();
+
+console.log("[2/4] vault.environments()");
+await runStep(async () => {
+	const envs = await vault.environments();
+	console.log(`      ✓ ${envs.length} config${envs.length === 1 ? "" : "s"}: ${envs.join(", ") || "(none)"}`);
+});
+console.log("");
+
+console.log(`[3/4] vault.list()  (project: ${project}, config: ${config})`);
+await runStep(async () => {
+	const keys = await vault.list();
+	console.log(`      ✓ ${keys.length} secret${keys.length === 1 ? "" : "s"}`);
+	if (keys.length > 0 && keys.length <= 25) keys.forEach((k) => console.log(`         · ${k}`));
+	else if (keys.length > 25) {
+		console.log(`         (${keys.length} total — showing first 25)`);
+		keys.slice(0, 25).forEach((k) => console.log(`         · ${k}`));
+	}
+});
+console.log("");
+
+console.log("[4/4] vault.read()");
+if (!secretName) {
+	console.log("      · skipped (no secret name provided)");
+} else {
+	const reference = `doppler://${project}/${config}/${secretName}`;
+	console.log(`      · reference: ${reference}`);
+	await runStep(async () => {
+		const value = await vault.read(reference);
+		console.log(`      ✓ read succeeded — value is ${value.length} chars long`);
+	});
+}
+console.log("");
+console.log("Done. No writes, no bootstrap operations.");
+
+async function runStep(body) {
+	try {
+		await body();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.log(`      ✗ ERROR: ${message}`);
+		const hint = hintFor(message);
+		if (hint) console.log(`         hint: ${hint}`);
+	}
+}
+
+function hintFor(message) {
+	if (/→ 401/.test(message))
+		return "token invalid — regenerate via 'doppler login' or dashboard → Access → Service Tokens";
+	if (/→ 403/.test(message)) return "token lacks scope — check the token has access to this project + config";
+	if (/→ 404/.test(message))
+		return "project / config / secret not found — verify names match the Doppler dashboard exactly";
+	if (/fetch failed|status: 0|network/i.test(message))
+		return "network error — check https://api.doppler.com/v3 reachable";
+	if (/→ 5\d\d/.test(message)) return "server error — retry, check https://status.doppler.com";
+	return null;
+}

--- a/packages/holocron-plugin-github/package.json
+++ b/packages/holocron-plugin-github/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
     "@theholocron/cli": "workspace:*"
@@ -41,7 +42,8 @@
     "globals": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "tsdown": "catalog:"
+    "tsdown": "catalog:",
+    "tsx": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/holocron-plugin-github/scripts/validate.mjs
+++ b/packages/holocron-plugin-github/scripts/validate.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Read-only smoke test for @theholocron/holocron-plugin-github.
+ *
+ * READ-ONLY. Exercises a couple of representative capability methods
+ * across the multi-capability plugin (source / ci / issues) — enough
+ * to prove auth + endpoints + response parsing work.
+ *
+ * Usage:
+ *   pnpm --filter @theholocron/holocron-plugin-github validate <owner/repo>
+ */
+
+import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
+
+const [repo] = process.argv.slice(2);
+
+if (!repo || !repo.includes("/")) {
+	console.error("usage: pnpm --filter @theholocron/holocron-plugin-github validate <owner/repo>");
+	process.exit(2);
+}
+
+let token;
+try {
+	token = resolveToken();
+} catch (err) {
+	if (err instanceof AuthError) {
+		console.error(err.message);
+		console.error("  see: packages/holocron-plugin-github/README.md#setup");
+		process.exit(2);
+	}
+	throw err;
+}
+
+console.log("Validating @theholocron/holocron-plugin-github (READ-ONLY)");
+console.log(`  repo: ${repo}`);
+console.log("");
+
+console.log("[1/4] verifyToken");
+const verifyResult = await verifyToken(token);
+console.log(`      ${verifyResult.ok ? "✓" : "✗"} ${JSON.stringify(verifyResult)}`);
+if (!verifyResult.ok) {
+	const hint = hintFor(verifyResult.message);
+	if (hint) console.log(`         hint: ${hint}`);
+}
+console.log("");
+
+const plugin = createPlugin({ cliToken: token, repo });
+
+console.log("[2/4] source.whoami()");
+const source = plugin.capabilities.source();
+await runStep(async () => {
+	const me = await source.whoami();
+	console.log(`      ✓ authed as ${me.login}`);
+});
+console.log("");
+
+console.log(`[3/4] ci.listRuns({ limit: 3 })  (repo: ${repo})`);
+const ci = plugin.capabilities.ci();
+await runStep(async () => {
+	const runs = await ci.listRuns({ limit: 3 });
+	console.log(`      ✓ ${runs.length} recent run${runs.length === 1 ? "" : "s"}`);
+	runs.forEach((r) => console.log(`         · ${r.workflowName} (${r.status}) — ${r.branch}`));
+});
+console.log("");
+
+console.log("[4/4] issues.search({ openOnly: true, limit: 3 })");
+const issues = plugin.capabilities.issues();
+await runStep(async () => {
+	const results = await issues.search({ openOnly: true, limit: 3 });
+	console.log(`      ✓ ${results.length} open issue${results.length === 1 ? "" : "s"}`);
+	results.forEach((i) => console.log(`         · ${i.key} ${i.summary}`));
+});
+console.log("");
+console.log("Done. No writes.");
+
+async function runStep(body) {
+	try {
+		await body();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.log(`      ✗ ERROR: ${message}`);
+		const hint = hintFor(message);
+		if (hint) console.log(`         hint: ${hint}`);
+	}
+}
+
+function hintFor(message) {
+	if (/→ 401/.test(message)) return "token invalid — regenerate PAT at https://github.com/settings/tokens";
+	if (/→ 403/.test(message)) return "token lacks scope — need repo (+ admin:repo_hook for org-level ops)";
+	if (/→ 404/.test(message)) return "repo not found or no access — verify owner/name and token permissions";
+	if (/fetch failed|status: 0|network/i.test(message)) return "network error — check api.github.com reachable";
+	if (/→ 5\d\d/.test(message)) return "server error — check https://www.githubstatus.com";
+	return null;
+}

--- a/packages/holocron-plugin-neon/package.json
+++ b/packages/holocron-plugin-neon/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
     "@theholocron/cli": "workspace:*"
@@ -36,7 +37,8 @@
     "globals": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "tsdown": "catalog:"
+    "tsdown": "catalog:",
+    "tsx": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/holocron-plugin-neon/scripts/validate.mjs
+++ b/packages/holocron-plugin-neon/scripts/validate.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Read-only smoke test for @theholocron/holocron-plugin-neon.
+ *
+ * READ-ONLY. Tests storage.listBranches — proves auth + endpoint.
+ *
+ * NOTE: no keyring / verifyToken yet — this plugin still uses
+ * `--token` → HOLOCRON_NEON_API_KEY → NEON_API_KEY only.
+ * Auth-modernization follow-up tracked separately.
+ *
+ * Usage:
+ *   pnpm --filter @theholocron/holocron-plugin-neon validate <projectId>
+ */
+
+import { AuthError, createPlugin, resolveToken } from "../src/index.ts";
+
+const [projectId] = process.argv.slice(2);
+
+if (!projectId) {
+	console.error("usage: pnpm --filter @theholocron/holocron-plugin-neon validate <projectId>");
+	console.error("  find projectId at https://console.neon.tech → your project → Settings → General");
+	process.exit(2);
+}
+
+let token;
+try {
+	token = resolveToken();
+} catch (err) {
+	if (err instanceof AuthError) {
+		console.error(err.message);
+		console.error("  see: packages/holocron-plugin-neon/README.md#auth");
+		process.exit(2);
+	}
+	throw err;
+}
+
+console.log("Validating @theholocron/holocron-plugin-neon (READ-ONLY)");
+console.log(`  projectId: ${projectId}`);
+console.log("");
+
+const plugin = createPlugin({ cliToken: token, projectId });
+const storage = plugin.capabilities.storage();
+
+console.log("[1/1] storage.listBranches()");
+await runStep(async () => {
+	const branches = await storage.listBranches();
+	console.log(`      ✓ ${branches.length} branch${branches.length === 1 ? "" : "es"}`);
+	if (branches.length > 0 && branches.length <= 10) {
+		branches.forEach((b) => console.log(`         · ${b.name} (${b.id}) parent=${b.parentId ?? "(root)"}`));
+	} else if (branches.length > 10) {
+		console.log(`         (${branches.length} total — showing first 10)`);
+		branches.slice(0, 10).forEach((b) => console.log(`         · ${b.name} (${b.id})`));
+	}
+});
+console.log("");
+console.log("Done. No writes.");
+
+async function runStep(body) {
+	try {
+		await body();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.log(`      ✗ ERROR: ${message}`);
+		const hint = hintFor(message);
+		if (hint) console.log(`         hint: ${hint}`);
+	}
+}
+
+function hintFor(message) {
+	if (/→ 401|→ 403/.test(message))
+		return "token invalid or lacks scope — regenerate at https://console.neon.tech/app/settings/api-keys";
+	if (/→ 404/.test(message))
+		return "project not found — verify projectId. Vercel-managed Neon orgs need the project provisioned via `vercel install neon` first";
+	if (/fetch failed|status: 0|network/i.test(message)) return "network error — check console.neon.tech reachable";
+	if (/→ 5\d\d/.test(message)) return "server error — check https://neonstatus.com";
+	return null;
+}

--- a/packages/holocron-plugin-postman/package.json
+++ b/packages/holocron-plugin-postman/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
     "@theholocron/cli": "workspace:*"
@@ -36,7 +37,8 @@
     "globals": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "tsdown": "catalog:"
+    "tsdown": "catalog:",
+    "tsx": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/holocron-plugin-postman/scripts/validate.mjs
+++ b/packages/holocron-plugin-postman/scripts/validate.mjs
@@ -10,10 +10,18 @@
  * follow-up tracked separately.
  *
  * Usage:
- *   pnpm --filter @theholocron/holocron-plugin-postman validate
+ *   pnpm --filter @theholocron/holocron-plugin-postman validate <workspaceId>
  */
 
 import { AuthError, createPlugin, resolveToken } from "../src/index.ts";
+
+const [workspaceId] = process.argv.slice(2);
+
+if (!workspaceId) {
+	console.error("usage: pnpm --filter @theholocron/holocron-plugin-postman validate <workspaceId>");
+	console.error("  find workspaceId at https://postman.co → your workspace → Settings → General → Info");
+	process.exit(2);
+}
 
 let token;
 try {
@@ -28,9 +36,10 @@ try {
 }
 
 console.log("Validating @theholocron/holocron-plugin-postman (READ-ONLY)");
+console.log(`  workspaceId: ${workspaceId}`);
 console.log("");
 
-const plugin = createPlugin({ cliToken: token });
+const plugin = createPlugin({ cliToken: token, workspaceId });
 const toolings = plugin.capabilities.tooling;
 // `tooling` is many-cardinality — resolves to an array. Postman may be
 // the only one loaded here since we constructed the plugin directly.

--- a/packages/holocron-plugin-postman/scripts/validate.mjs
+++ b/packages/holocron-plugin-postman/scripts/validate.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Read-only smoke test for @theholocron/holocron-plugin-postman.
+ *
+ * READ-ONLY. Tests tooling.doctor which returns whether Postman is
+ * reachable and the auth is valid.
+ *
+ * NOTE: no keyring / verifyToken yet — uses `--token` →
+ * HOLOCRON_POSTMAN_API_KEY → POSTMAN_API_KEY only. Auth-modernization
+ * follow-up tracked separately.
+ *
+ * Usage:
+ *   pnpm --filter @theholocron/holocron-plugin-postman validate
+ */
+
+import { AuthError, createPlugin, resolveToken } from "../src/index.ts";
+
+let token;
+try {
+	token = resolveToken();
+} catch (err) {
+	if (err instanceof AuthError) {
+		console.error(err.message);
+		console.error("  see: packages/holocron-plugin-postman/README.md#auth");
+		process.exit(2);
+	}
+	throw err;
+}
+
+console.log("Validating @theholocron/holocron-plugin-postman (READ-ONLY)");
+console.log("");
+
+const plugin = createPlugin({ cliToken: token });
+const toolings = plugin.capabilities.tooling;
+// `tooling` is many-cardinality — resolves to an array. Postman may be
+// the only one loaded here since we constructed the plugin directly.
+const tools =
+	typeof toolings === "function"
+		? [toolings()]
+		: Array.isArray(toolings)
+			? toolings.map((t) => (typeof t === "function" ? t() : t))
+			: [];
+
+console.log(`[1/1] tooling.doctor()  (${tools.length} tooling provider${tools.length === 1 ? "" : "s"})`);
+for (const tool of tools) {
+	await runStep(async () => {
+		const report = await tool.doctor();
+		console.log(`      ${report.ok ? "✓" : "✗"} ${tool.providerName ?? "postman"}: ${report.message}`);
+	});
+}
+console.log("");
+console.log("Done. No writes.");
+
+async function runStep(body) {
+	try {
+		await body();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.log(`      ✗ ERROR: ${message}`);
+		const hint = hintFor(message);
+		if (hint) console.log(`         hint: ${hint}`);
+	}
+}
+
+function hintFor(message) {
+	if (/→ 401|→ 403/.test(message))
+		return "API key invalid or lacks scope — regenerate at https://postman.co/settings/me/api-keys";
+	if (/→ 404/.test(message)) return "endpoint or workspace not found";
+	if (/fetch failed|status: 0|network/i.test(message)) return "network error — check api.getpostman.com reachable";
+	if (/→ 5\d\d/.test(message)) return "server error — check https://status.postman.com";
+	return null;
+}

--- a/packages/holocron-plugin-vercel/package.json
+++ b/packages/holocron-plugin-vercel/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
     "@theholocron/cli": "workspace:*"
@@ -36,7 +37,8 @@
     "globals": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "tsdown": "catalog:"
+    "tsdown": "catalog:",
+    "tsx": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/holocron-plugin-vercel/scripts/validate.mjs
+++ b/packages/holocron-plugin-vercel/scripts/validate.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Read-only smoke test for @theholocron/holocron-plugin-vercel.
+ *
+ * READ-ONLY. Tests deployment.listProjects — proves auth + endpoint.
+ *
+ * NOTE: this plugin hasn't been auth-modernized yet (no keyring
+ * lookup, no verifyToken export). Uses the plugin's own resolveToken
+ * which reads `--token` → HOLOCRON_VERCEL_TOKEN → VERCEL_TOKEN.
+ * A follow-up will add keyring + verifyToken support.
+ *
+ * Usage:
+ *   pnpm --filter @theholocron/holocron-plugin-vercel validate [projectId]
+ */
+
+import { AuthError, createPlugin, resolveToken } from "../src/index.ts";
+
+const [projectId] = process.argv.slice(2);
+
+let token;
+try {
+	token = resolveToken();
+} catch (err) {
+	if (err instanceof AuthError) {
+		console.error(err.message);
+		console.error("  see: packages/holocron-plugin-vercel/README.md#setup");
+		process.exit(2);
+	}
+	throw err;
+}
+
+console.log("Validating @theholocron/holocron-plugin-vercel (READ-ONLY)");
+if (projectId) console.log(`  projectId: ${projectId}`);
+console.log("");
+
+const plugin = createPlugin({ cliToken: token });
+const deployment = plugin.capabilities.deployment();
+
+console.log("[1/2] deployment.listProjects()");
+await runStep(async () => {
+	const projects = await deployment.listProjects();
+	console.log(`      ✓ ${projects.length} project${projects.length === 1 ? "" : "s"}`);
+	if (projects.length > 0 && projects.length <= 10) {
+		projects.forEach((p) => console.log(`         · ${p.name} (${p.id})`));
+	} else if (projects.length > 10) {
+		console.log(`         (${projects.length} total — showing first 10)`);
+		projects.slice(0, 10).forEach((p) => console.log(`         · ${p.name} (${p.id})`));
+	}
+});
+console.log("");
+
+console.log("[2/2] deployment.listEnvVars(projectId, 'production')");
+if (!projectId) {
+	console.log("      · skipped (no projectId provided)");
+} else {
+	await runStep(async () => {
+		const names = await deployment.listEnvVars(projectId, "production");
+		console.log(`      ✓ ${names.length} env var${names.length === 1 ? "" : "s"} in production`);
+	});
+}
+console.log("");
+console.log("Done. No writes.");
+
+async function runStep(body) {
+	try {
+		await body();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.log(`      ✗ ERROR: ${message}`);
+		const hint = hintFor(message);
+		if (hint) console.log(`         hint: ${hint}`);
+	}
+}
+
+function hintFor(message) {
+	if (/→ 401|→ 403/.test(message))
+		return "token invalid or lacks scope — regenerate at https://vercel.com/account/tokens with 'Full Account' scope";
+	if (/→ 404/.test(message))
+		return "project not found — verify the projectId from https://vercel.com/<team>/<project>/settings/general";
+	if (/fetch failed|status: 0|network/i.test(message)) return "network error — check api.vercel.com reachable";
+	if (/→ 5\d\d/.test(message)) return "server error — check https://www.vercel-status.com";
+	return null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -289,6 +292,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -319,6 +325,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -359,6 +368,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -422,6 +434,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -452,6 +467,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -482,6 +500,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
## Summary

Closes #101. Every plugin now ships the `scripts/validate.mjs` + `pnpm validate` convention that the plugin-create scaffold produces automatically for new plugins (since #98). Uniform operator invocation across all seven existing plugins:

```
pnpm --filter @theholocron/holocron-plugin-<slug> validate <args>
```

## Per-plugin

| Plugin | Args | Tests |
|---|---|---|
| **doppler** | `<project> <config> [secretName]` | verifyToken + environments + list + optional read |
| **github** | `<owner/repo>` | verifyToken + source.whoami + ci.listRuns + issues.search |
| **1password** | `<vaultName>` | verifyToken (via `op whoami`) + vault.list |
| **vercel** | `[projectId]` | deployment.listProjects + optional listEnvVars |
| **neon** | `<projectId>` | storage.listBranches |
| **clerk** | (none) | auth.describe + auth.whoami |
| **postman** | (none) | tooling.doctor across every configured provider |

Each script includes a vendor-customized `hintFor` — points operators at the right dashboard URL / docs page for 401 / 403 / 404 / network / 5xx failures.

## Auth precedence

- **Plugins that have been auth-modernized** (doppler, github, 1p — infisical was done in #99): `validate.mjs` uses the plugin's own `resolveToken` for full 4-step keyring precedence (`--token` → `HOLOCRON_<X>_TOKEN` → `<vendor>-native` → keyring).
- **Plugins that haven't yet** (vercel, neon, clerk, postman): `validate.mjs` uses their current `resolveToken` which only consults `--token` and env vars. Auth-modernization for these four is tracked in **#103** as a separate follow-up.

## Package.json

Each plugin gets:

- `"validate": "tsx scripts/validate.mjs"` in scripts
- `"tsx": "catalog:"` in devDependencies

## Verified

- Full workspace `pnpm typecheck` + `pnpm lint` + `pnpm test` — all green.
- Prettier 3.8.4 + 3.9.3 clean.
- Live end-to-end: `pnpm --filter @theholocron/holocron-plugin-doppler validate holocron dev` against this repo's real Doppler workspace — verifyToken ✓, 3 configs listed (dev, stg, prd), 3 secrets enumerated.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] Live Doppler smoke test
- [ ] Live github validate — run `pnpm --filter @theholocron/holocron-plugin-github validate theholocron/holocron` with GH_TOKEN in env
- [ ] Live 1p validate (requires `op signin` + a vault name)
- [ ] The four laggards (vercel/neon/clerk/postman) — deferred until they're auth-modernized in #103

Closes #101 for the "every plugin has a validate script" goal.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->