### PR TITLE
feat(plugins): auth-modernize vercel/neon/clerk/postman (#103)

### DIFF
--- a/packages/holocron-plugin-clerk/scripts/validate.mjs
+++ b/packages/holocron-plugin-clerk/scripts/validate.mjs
@@ -2,18 +2,14 @@
 /**
  * Read-only smoke test for @theholocron/holocron-plugin-clerk.
  *
- * READ-ONLY. Tests auth.describe + auth.whoami — the two guaranteed
- * capability methods.
- *
- * NOTE: no keyring / verifyToken yet — uses `--token` →
- * HOLOCRON_CLERK_TOKEN → CLERK_SECRET_KEY only. Auth-modernization
- * follow-up tracked separately.
+ * READ-ONLY. Tests verifyToken + auth.describe + auth.whoami — proves
+ * auth, endpoint, and the two guaranteed capability methods.
  *
  * Usage:
  *   pnpm --filter @theholocron/holocron-plugin-clerk validate
  */
 
-import { AuthError, createPlugin, resolveToken } from "../src/index.ts";
+import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
 
 let token;
 try {
@@ -30,10 +26,19 @@ try {
 console.log("Validating @theholocron/holocron-plugin-clerk (READ-ONLY)");
 console.log("");
 
+console.log("[1/3] verifyToken");
+const verifyResult = await verifyToken(token);
+console.log(`      ${verifyResult.ok ? "✓" : "✗"} ${JSON.stringify(verifyResult)}`);
+if (!verifyResult.ok) {
+	const hint = hintFor(verifyResult.message);
+	if (hint) console.log(`         hint: ${hint}`);
+}
+console.log("");
+
 const plugin = createPlugin({ cliToken: token });
 const auth = plugin.capabilities.auth();
 
-console.log("[1/2] auth.describe()");
+console.log("[2/3] auth.describe()");
 await runStep(async () => {
 	const desc = await auth.describe();
 	console.log(`      ✓ provider: ${desc.provider}`);
@@ -41,7 +46,7 @@ await runStep(async () => {
 });
 console.log("");
 
-console.log("[2/2] auth.whoami()");
+console.log("[3/3] auth.whoami()");
 await runStep(async () => {
 	const identity = await auth.whoami();
 	console.log(`      ✓ provider: ${identity.provider}`);

--- a/packages/holocron-plugin-clerk/src/__tests__/auth.test.ts
+++ b/packages/holocron-plugin-clerk/src/__tests__/auth.test.ts
@@ -25,7 +25,7 @@ describe("resolveToken", () => {
 	});
 
 	it("throws AuthError with a helpful message when nothing is set", () => {
-		expect(() => resolveToken({ env: {} })).toThrow(AuthError);
-		expect(() => resolveToken({ env: {} })).toThrow(/HOLOCRON_CLERK_SECRET_KEY/);
+		expect(() => resolveToken({ env: {}, keyring: () => null })).toThrow(AuthError);
+		expect(() => resolveToken({ env: {}, keyring: () => null })).toThrow(/HOLOCRON_CLERK_SECRET_KEY/);
 	});
 });

--- a/packages/holocron-plugin-clerk/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-clerk/src/__tests__/verify-token.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { verifyToken } from "../verify-token.js";
+import { stubFetch } from "./helpers.js";
+
+describe("verifyToken", () => {
+	it("returns ok with env + id when /instance returns 200", async () => {
+		const stub = stubFetch([{ status: 200, body: { id: "ins_abc123", environment_type: "development" } }]);
+		const result = await verifyToken("sk_test_abc", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/development instance ins_abc123/);
+		}
+	});
+
+	it("hits /instance without doubling the /v1 base-URL prefix", async () => {
+		const stub = stubFetch([{ status: 200, body: { id: "ins_1", environment_type: "production" } }]);
+		await verifyToken("sk_live", { fetch: stub.fetch });
+		// Default base URL is https://api.clerk.com/v1 — path must NOT
+		// start with /v1 or the final URL becomes …/v1/v1/instance.
+		expect(stub.calls[0]?.url).toBe("https://api.clerk.com/v1/instance");
+	});
+
+	it("falls back to 'unknown' when instance metadata is missing", async () => {
+		const stub = stubFetch([{ status: 200, body: {} }]);
+		const result = await verifyToken("sk_test", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/unknown instance unknown/);
+		}
+	});
+
+	it("returns ok:false with the error message on 401", async () => {
+		const stub = stubFetch([{ status: 401, body: { errors: [{ message: "invalid" }] } }]);
+		const result = await verifyToken("bad", { fetch: stub.fetch });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/→ 401/);
+		}
+	});
+
+	it("returns ok:false when the network layer throws", async () => {
+		const throwing: typeof fetch = async () => {
+			throw new TypeError("network down");
+		};
+		const result = await verifyToken("t", { fetch: throwing });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/network down/);
+		}
+	});
+
+	it("hits the configured base URL", async () => {
+		const stub = stubFetch([{ status: 200, body: { id: "ins", environment_type: "staging" } }]);
+		await verifyToken("t", { fetch: stub.fetch, baseUrl: "https://api.clerk.example/v1" });
+		expect(stub.calls[0]?.url).toMatch(/^https:\/\/api\.clerk\.example\/v1\/instance/);
+	});
+});

--- a/packages/holocron-plugin-clerk/src/auth.ts
+++ b/packages/holocron-plugin-clerk/src/auth.ts
@@ -1,14 +1,19 @@
 /**
  * Token resolution for the Clerk plugin.
  *
- * Resolution order:
+ * Resolution order (matches the standard 4-step precedence set by
+ * `.notes/tech-auth-bootstrap.spec.md`):
  *   1. explicit `cliToken` argument (from `--token` flag)
  *   2. HOLOCRON_CLERK_SECRET_KEY env var (preferred — explicit intent)
  *   3. CLERK_SECRET_KEY env var (the default Clerk's docs reference)
+ *   4. keyring (com.theholocron.cli / "clerk")
+ *   5. AuthError naming all four options + the bootstrap hint
  *
  * The key (sk_test_* / sk_live_*) determines which Clerk instance —
  * Development or Production — every call hits.
  */
+
+import { getToken as getKeyringToken } from "@theholocron/cli";
 
 export class AuthError extends Error {
 	override name = "AuthError";
@@ -19,14 +24,18 @@ export interface ResolveTokenInput {
 	cliToken?: string;
 	/** Env vars; passed in for testability. Defaults to `process.env`. */
 	env?: NodeJS.ProcessEnv;
+	/** Keyring lookup fn; passed in for testability. Defaults to `getToken(provider)`. */
+	keyring?: (provider: string) => string | null;
 }
 
 export function resolveToken(input: ResolveTokenInput = {}): string {
 	const env = input.env ?? process.env;
-	const token = input.cliToken || env.HOLOCRON_CLERK_SECRET_KEY || env.CLERK_SECRET_KEY;
+	const keyring = input.keyring ?? getKeyringToken;
+	const token = input.cliToken || env["HOLOCRON_CLERK_SECRET_KEY"] || env["CLERK_SECRET_KEY"] || keyring("clerk");
 	if (!token) {
 		throw new AuthError(
-			"no Clerk secret key found. Pass --token <KEY>, or set HOLOCRON_CLERK_SECRET_KEY / CLERK_SECRET_KEY."
+			"no Clerk secret key found. Pass --token <KEY>, set HOLOCRON_CLERK_SECRET_KEY / CLERK_SECRET_KEY, " +
+				"or run: holocron auth set clerk <KEY>"
 		);
 	}
 	return token;

--- a/packages/holocron-plugin-clerk/src/index.ts
+++ b/packages/holocron-plugin-clerk/src/index.ts
@@ -48,9 +48,21 @@ export function createPlugin(options: ClerkPluginOptions = {}) {
 	};
 }
 
+/**
+ * One-line hint printed by `holocron auth set clerk` when no token
+ * is supplied or the supplied token is rejected. Points operators at
+ * the Clerk dashboard's API Keys section — MUST be the SECRET key
+ * (sk_test_* / sk_live_*), not the publishable key.
+ */
+export const AUTH_HINT =
+	"grab your SECRET key (sk_test_* / sk_live_*) at https://dashboard.clerk.com → API Keys, " +
+	"then run: holocron auth set clerk <KEY>. Do NOT use the publishable key.";
+
 // ── Public re-exports ────────────────────────────────────────────────
 
 export * from "./auth.js";
 export { ClerkRestClient } from "./rest.js";
 export { ClerkAuth } from "./capabilities/auth.js";
 export { parseWebhook } from "./parse-webhook.js";
+export { verifyToken } from "./verify-token.js";
+export type { VerifyTokenResult, VerifyTokenSuccess, VerifyTokenFailure } from "./verify-token.js";

--- a/packages/holocron-plugin-clerk/src/verify-token.ts
+++ b/packages/holocron-plugin-clerk/src/verify-token.ts
@@ -1,0 +1,51 @@
+/**
+ * `verifyToken` — plugin-level export used by `holocron auth set` +
+ * `holocron auth check`. Hits Clerk's `/v1/instance` endpoint, which
+ * requires a valid secret key and returns instance metadata (id,
+ * environment_type, etc.). Invalid keys → 401.
+ *
+ * Clerk doesn't have a traditional user-oriented whoami — the "authed
+ * entity" is your Clerk INSTANCE, not a user. `/v1/instance` is the
+ * canonical "is this secret key valid?" endpoint.
+ */
+
+import { ClerkRestClient } from "./rest.js";
+
+export interface VerifyTokenSuccess {
+	ok: true;
+	subject: string;
+}
+
+export interface VerifyTokenFailure {
+	ok: false;
+	message: string;
+}
+
+export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
+
+interface InstanceResponse {
+	id?: string;
+	environment_type?: string; // "development" | "production" | "staging"
+	object?: string;
+}
+
+export interface VerifyTokenOptions {
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+export async function verifyToken(token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
+	const restOpts: ConstructorParameters<typeof ClerkRestClient>[0] = { token };
+	if (opts.baseUrl !== undefined) restOpts.baseUrl = opts.baseUrl;
+	if (opts.fetch !== undefined) restOpts.fetch = opts.fetch;
+	const rest = new ClerkRestClient(restOpts);
+	try {
+		const instance = await rest.request<InstanceResponse>("/v1/instance");
+		const env = instance?.environment_type ?? "unknown";
+		const id = instance?.id ?? "unknown";
+		return { ok: true, subject: `${env} instance ${id}` };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { ok: false, message };
+	}
+}

--- a/packages/holocron-plugin-clerk/src/verify-token.ts
+++ b/packages/holocron-plugin-clerk/src/verify-token.ts
@@ -40,7 +40,7 @@ export async function verifyToken(token: string, opts: VerifyTokenOptions = {}):
 	if (opts.fetch !== undefined) restOpts.fetch = opts.fetch;
 	const rest = new ClerkRestClient(restOpts);
 	try {
-		const instance = await rest.request<InstanceResponse>("/v1/instance");
+		const instance = await rest.request<InstanceResponse>("/instance");
 		const env = instance?.environment_type ?? "unknown";
 		const id = instance?.id ?? "unknown";
 		return { ok: true, subject: `${env} instance ${id}` };

--- a/packages/holocron-plugin-neon/scripts/validate.mjs
+++ b/packages/holocron-plugin-neon/scripts/validate.mjs
@@ -2,17 +2,14 @@
 /**
  * Read-only smoke test for @theholocron/holocron-plugin-neon.
  *
- * READ-ONLY. Tests storage.listBranches — proves auth + endpoint.
- *
- * NOTE: no keyring / verifyToken yet — this plugin still uses
- * `--token` → HOLOCRON_NEON_API_KEY → NEON_API_KEY only.
- * Auth-modernization follow-up tracked separately.
+ * READ-ONLY. Tests verifyToken + storage.listBranches — proves auth,
+ * endpoint, and response parsing.
  *
  * Usage:
  *   pnpm --filter @theholocron/holocron-plugin-neon validate <projectId>
  */
 
-import { AuthError, createPlugin, resolveToken } from "../src/index.ts";
+import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
 
 const [projectId] = process.argv.slice(2);
 
@@ -38,10 +35,19 @@ console.log("Validating @theholocron/holocron-plugin-neon (READ-ONLY)");
 console.log(`  projectId: ${projectId}`);
 console.log("");
 
+console.log("[1/2] verifyToken");
+const verifyResult = await verifyToken(token);
+console.log(`      ${verifyResult.ok ? "✓" : "✗"} ${JSON.stringify(verifyResult)}`);
+if (!verifyResult.ok) {
+	const hint = hintFor(verifyResult.message);
+	if (hint) console.log(`         hint: ${hint}`);
+}
+console.log("");
+
 const plugin = createPlugin({ cliToken: token, projectId });
 const storage = plugin.capabilities.storage();
 
-console.log("[1/1] storage.listBranches()");
+console.log("[2/2] storage.listBranches()");
 await runStep(async () => {
 	const branches = await storage.listBranches();
 	console.log(`      ✓ ${branches.length} branch${branches.length === 1 ? "" : "es"}`);

--- a/packages/holocron-plugin-neon/src/__tests__/auth.test.ts
+++ b/packages/holocron-plugin-neon/src/__tests__/auth.test.ts
@@ -25,7 +25,7 @@ describe("resolveToken", () => {
 	});
 
 	it("throws AuthError when nothing is set", () => {
-		expect(() => resolveToken({ env: {} })).toThrow(AuthError);
-		expect(() => resolveToken({ env: {} })).toThrow(/HOLOCRON_NEON_API_KEY/);
+		expect(() => resolveToken({ env: {}, keyring: () => null })).toThrow(AuthError);
+		expect(() => resolveToken({ env: {}, keyring: () => null })).toThrow(/HOLOCRON_NEON_API_KEY/);
 	});
 });

--- a/packages/holocron-plugin-neon/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-neon/src/__tests__/verify-token.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { verifyToken } from "../verify-token.js";
+import { stubFetch } from "./helpers.js";
+
+describe("verifyToken", () => {
+	it("returns ok with the user email when /users/me returns 200", async () => {
+		const stub = stubFetch([{ status: 200, body: { email: "c@example.com", login: "cnewton" } }]);
+		const result = await verifyToken("pat-abc", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/user @ c@example.com/);
+		}
+		expect(stub.calls[0]?.url).toMatch(/\/users\/me/);
+	});
+
+	it("falls back to login when email is absent", async () => {
+		const stub = stubFetch([{ status: 200, body: { login: "cnewton" } }]);
+		const result = await verifyToken("pat-abc", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/user @ cnewton/);
+		}
+	});
+
+	it("falls back to 'unknown' when the body is empty", async () => {
+		const stub = stubFetch([{ status: 200, body: {} }]);
+		const result = await verifyToken("pat-abc", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/user @ unknown/);
+		}
+	});
+
+	it("returns ok:false with the error message on 401", async () => {
+		const stub = stubFetch([{ status: 401, body: { message: "Unauthorized" } }]);
+		const result = await verifyToken("bad", { fetch: stub.fetch });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/→ 401/);
+		}
+	});
+
+	it("returns ok:false when the network layer throws", async () => {
+		const throwing: typeof fetch = async () => {
+			throw new TypeError("network down");
+		};
+		const result = await verifyToken("t", { fetch: throwing });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/network down/);
+		}
+	});
+
+	it("hits the configured base URL", async () => {
+		const stub = stubFetch([{ status: 200, body: { email: "x@y.com" } }]);
+		await verifyToken("t", { fetch: stub.fetch, baseUrl: "https://console.neon.example/api/v2" });
+		expect(stub.calls[0]?.url).toMatch(/^https:\/\/console\.neon\.example\/api\/v2\/users\/me/);
+	});
+});

--- a/packages/holocron-plugin-neon/src/auth.ts
+++ b/packages/holocron-plugin-neon/src/auth.ts
@@ -1,11 +1,16 @@
 /**
  * Token resolution for the Neon plugin.
  *
- * Resolution order:
+ * Resolution order (matches the standard 4-step precedence set by
+ * `.notes/tech-auth-bootstrap.spec.md`):
  *   1. explicit `cliToken` argument (from `--token` flag)
  *   2. HOLOCRON_NEON_API_KEY env var (preferred — explicit intent)
  *   3. NEON_API_KEY env var (the default Neon CLI reads)
+ *   4. keyring (com.theholocron.cli / "neon")
+ *   5. AuthError naming all four options + the bootstrap hint
  */
+
+import { getToken as getKeyringToken } from "@theholocron/cli";
 
 export class AuthError extends Error {
 	override name = "AuthError";
@@ -16,13 +21,19 @@ export interface ResolveTokenInput {
 	cliToken?: string;
 	/** Env vars; passed in for testability. Defaults to `process.env`. */
 	env?: NodeJS.ProcessEnv;
+	/** Keyring lookup fn; passed in for testability. Defaults to `getToken(provider)`. */
+	keyring?: (provider: string) => string | null;
 }
 
 export function resolveToken(input: ResolveTokenInput = {}): string {
 	const env = input.env ?? process.env;
-	const token = input.cliToken || env.HOLOCRON_NEON_API_KEY || env.NEON_API_KEY;
+	const keyring = input.keyring ?? getKeyringToken;
+	const token = input.cliToken || env["HOLOCRON_NEON_API_KEY"] || env["NEON_API_KEY"] || keyring("neon");
 	if (!token) {
-		throw new AuthError("no Neon API key found. Pass --token <KEY>, or set HOLOCRON_NEON_API_KEY / NEON_API_KEY.");
+		throw new AuthError(
+			"no Neon API key found. Pass --token <KEY>, set HOLOCRON_NEON_API_KEY / NEON_API_KEY, " +
+				"or run: holocron auth set neon <KEY>"
+		);
 	}
 	return token;
 }

--- a/packages/holocron-plugin-neon/src/index.ts
+++ b/packages/holocron-plugin-neon/src/index.ts
@@ -53,8 +53,20 @@ export function createPlugin(options: NeonPluginOptions) {
 	};
 }
 
+/**
+ * One-line hint printed by `holocron auth set neon` when no token
+ * is supplied or the supplied token is rejected. Points operators
+ * at https://console.neon.tech/app/settings/api-keys where API keys
+ * are minted.
+ */
+export const AUTH_HINT =
+	"generate a Neon API key at https://console.neon.tech/app/settings/api-keys, " +
+	"then run: holocron auth set neon <KEY>";
+
 // ── Public re-exports ────────────────────────────────────────────────
 
 export * from "./auth.js";
 export { NeonRestClient } from "./rest.js";
 export { NeonStorage } from "./capabilities/storage.js";
+export { verifyToken } from "./verify-token.js";
+export type { VerifyTokenResult, VerifyTokenSuccess, VerifyTokenFailure } from "./verify-token.js";

--- a/packages/holocron-plugin-neon/src/verify-token.ts
+++ b/packages/holocron-plugin-neon/src/verify-token.ts
@@ -1,0 +1,47 @@
+/**
+ * `verifyToken` — plugin-level export used by `holocron auth set` +
+ * `holocron auth check`. Hits Neon's `/users/me` endpoint and
+ * translates the response into the normalized `VerifyTokenResult`
+ * shape.
+ */
+
+import { NeonRestClient } from "./rest.js";
+
+export interface VerifyTokenSuccess {
+	ok: true;
+	subject: string;
+}
+
+export interface VerifyTokenFailure {
+	ok: false;
+	message: string;
+}
+
+export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
+
+interface MeResponse {
+	id?: string;
+	email?: string;
+	name?: string;
+	login?: string;
+}
+
+export interface VerifyTokenOptions {
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+export async function verifyToken(token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
+	const restOpts: ConstructorParameters<typeof NeonRestClient>[0] = { token };
+	if (opts.baseUrl !== undefined) restOpts.baseUrl = opts.baseUrl;
+	if (opts.fetch !== undefined) restOpts.fetch = opts.fetch;
+	const rest = new NeonRestClient(restOpts);
+	try {
+		const me = await rest.request<MeResponse>("/users/me");
+		const subject = me?.email ?? me?.login ?? me?.name ?? me?.id ?? "unknown";
+		return { ok: true, subject: `user @ ${subject}` };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { ok: false, message };
+	}
+}

--- a/packages/holocron-plugin-postman/scripts/validate.mjs
+++ b/packages/holocron-plugin-postman/scripts/validate.mjs
@@ -2,18 +2,14 @@
 /**
  * Read-only smoke test for @theholocron/holocron-plugin-postman.
  *
- * READ-ONLY. Tests tooling.doctor which returns whether Postman is
- * reachable and the auth is valid.
- *
- * NOTE: no keyring / verifyToken yet — uses `--token` →
- * HOLOCRON_POSTMAN_API_KEY → POSTMAN_API_KEY only. Auth-modernization
- * follow-up tracked separately.
+ * READ-ONLY. Tests verifyToken + tooling.doctor — proves auth,
+ * endpoint, and vendor reachability.
  *
  * Usage:
  *   pnpm --filter @theholocron/holocron-plugin-postman validate <workspaceId>
  */
 
-import { AuthError, createPlugin, resolveToken } from "../src/index.ts";
+import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
 
 const [workspaceId] = process.argv.slice(2);
 
@@ -39,6 +35,15 @@ console.log("Validating @theholocron/holocron-plugin-postman (READ-ONLY)");
 console.log(`  workspaceId: ${workspaceId}`);
 console.log("");
 
+console.log("[1/2] verifyToken");
+const verifyResult = await verifyToken(token);
+console.log(`      ${verifyResult.ok ? "✓" : "✗"} ${JSON.stringify(verifyResult)}`);
+if (!verifyResult.ok) {
+	const hint = hintFor(verifyResult.message);
+	if (hint) console.log(`         hint: ${hint}`);
+}
+console.log("");
+
 const plugin = createPlugin({ cliToken: token, workspaceId });
 const toolings = plugin.capabilities.tooling;
 // `tooling` is many-cardinality — resolves to an array. Postman may be
@@ -50,7 +55,7 @@ const tools =
 			? toolings.map((t) => (typeof t === "function" ? t() : t))
 			: [];
 
-console.log(`[1/1] tooling.doctor()  (${tools.length} tooling provider${tools.length === 1 ? "" : "s"})`);
+console.log(`[2/2] tooling.doctor()  (${tools.length} tooling provider${tools.length === 1 ? "" : "s"})`);
 for (const tool of tools) {
 	await runStep(async () => {
 		const report = await tool.doctor();

--- a/packages/holocron-plugin-postman/src/__tests__/auth.test.ts
+++ b/packages/holocron-plugin-postman/src/__tests__/auth.test.ts
@@ -26,7 +26,7 @@ describe("resolveToken", () => {
 
 	it("throws AuthError when nothing is set", () => {
 		try {
-			resolveToken({ env: {} });
+			resolveToken({ env: {}, keyring: () => null });
 			throw new Error("expected throw");
 		} catch (err) {
 			expect(err).toBeInstanceOf(AuthError);

--- a/packages/holocron-plugin-postman/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-postman/src/__tests__/verify-token.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { verifyToken } from "../verify-token.js";
+import { stubFetch } from "./helpers.js";
+
+describe("verifyToken", () => {
+	it("returns ok with the user email when /me returns 200", async () => {
+		const stub = stubFetch([
+			{ status: 200, body: { user: { id: 42, email: "c@example.com", username: "cnewton" } } },
+		]);
+		const result = await verifyToken("PMAK-abc", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/user @ c@example.com/);
+		}
+		expect(stub.calls[0]?.url).toMatch(/\/me/);
+	});
+
+	it("falls back to username when email is absent", async () => {
+		const stub = stubFetch([{ status: 200, body: { user: { id: 42, username: "cnewton" } } }]);
+		const result = await verifyToken("PMAK-abc", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/user @ cnewton/);
+		}
+	});
+
+	it("falls back to id when username + email + fullName are absent", async () => {
+		const stub = stubFetch([{ status: 200, body: { user: { id: 42 } } }]);
+		const result = await verifyToken("PMAK-abc", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/user @ 42/);
+		}
+	});
+
+	it("falls back to 'unknown' when the user body is empty", async () => {
+		const stub = stubFetch([{ status: 200, body: { user: {} } }]);
+		const result = await verifyToken("PMAK-abc", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/user @ unknown/);
+		}
+	});
+
+	it("returns ok:false with the error message on 401", async () => {
+		const stub = stubFetch([{ status: 401, body: { error: { name: "AuthenticationError" } } }]);
+		const result = await verifyToken("bad", { fetch: stub.fetch });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/→ 401/);
+		}
+	});
+
+	it("returns ok:false when the network layer throws", async () => {
+		const throwing: typeof fetch = async () => {
+			throw new TypeError("network down");
+		};
+		const result = await verifyToken("t", { fetch: throwing });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/network down/);
+		}
+	});
+
+	it("hits the configured base URL", async () => {
+		const stub = stubFetch([{ status: 200, body: { user: { email: "x@y.com" } } }]);
+		await verifyToken("t", { fetch: stub.fetch, baseUrl: "https://api.postman.example" });
+		expect(stub.calls[0]?.url).toMatch(/^https:\/\/api\.postman\.example\/me/);
+	});
+});

--- a/packages/holocron-plugin-postman/src/auth.ts
+++ b/packages/holocron-plugin-postman/src/auth.ts
@@ -1,11 +1,16 @@
 /**
  * Token resolution for the Postman plugin.
  *
- * Resolution order:
+ * Resolution order (matches the standard 4-step precedence set by
+ * `.notes/tech-auth-bootstrap.spec.md`):
  *   1. explicit `cliToken` argument (from `--token` flag)
  *   2. HOLOCRON_POSTMAN_API_KEY env var (preferred — explicit intent)
  *   3. POSTMAN_API_KEY env var (Postman's own default)
+ *   4. keyring (com.theholocron.cli / "postman")
+ *   5. AuthError naming all four options + the bootstrap hint
  */
+
+import { getToken as getKeyringToken } from "@theholocron/cli";
 
 export class AuthError extends Error {
 	override name = "AuthError";
@@ -16,14 +21,18 @@ export interface ResolveTokenInput {
 	cliToken?: string;
 	/** Env vars; passed in for testability. Defaults to `process.env`. */
 	env?: NodeJS.ProcessEnv;
+	/** Keyring lookup fn; passed in for testability. Defaults to `getToken(provider)`. */
+	keyring?: (provider: string) => string | null;
 }
 
 export function resolveToken(input: ResolveTokenInput = {}): string {
 	const env = input.env ?? process.env;
-	const token = input.cliToken || env.HOLOCRON_POSTMAN_API_KEY || env.POSTMAN_API_KEY;
+	const keyring = input.keyring ?? getKeyringToken;
+	const token = input.cliToken || env["HOLOCRON_POSTMAN_API_KEY"] || env["POSTMAN_API_KEY"] || keyring("postman");
 	if (!token) {
 		throw new AuthError(
-			"no Postman API key found. Pass --token <KEY>, or set HOLOCRON_POSTMAN_API_KEY / POSTMAN_API_KEY."
+			"no Postman API key found. Pass --token <KEY>, set HOLOCRON_POSTMAN_API_KEY / POSTMAN_API_KEY, " +
+				"or run: holocron auth set postman <KEY>"
 		);
 	}
 	return token;

--- a/packages/holocron-plugin-postman/src/index.ts
+++ b/packages/holocron-plugin-postman/src/index.ts
@@ -59,9 +59,19 @@ export function createPlugin(options: PostmanPluginOptions) {
 	};
 }
 
+/**
+ * One-line hint printed by `holocron auth set postman` when no
+ * token is supplied or the supplied token is rejected.
+ */
+export const AUTH_HINT =
+	"generate a Postman API key at https://postman.co/settings/me/api-keys, " +
+	"then run: holocron auth set postman <KEY>";
+
 // ── Public re-exports ────────────────────────────────────────────────
 
 export * from "./auth.js";
 export { PostmanPlanLimitError, detectPlanLimit } from "./errors.js";
 export { PostmanRestClient } from "./rest.js";
 export { PostmanTooling } from "./capabilities/tooling.js";
+export { verifyToken } from "./verify-token.js";
+export type { VerifyTokenResult, VerifyTokenSuccess, VerifyTokenFailure } from "./verify-token.js";

--- a/packages/holocron-plugin-postman/src/verify-token.ts
+++ b/packages/holocron-plugin-postman/src/verify-token.ts
@@ -1,0 +1,49 @@
+/**
+ * `verifyToken` — plugin-level export used by `holocron auth set` +
+ * `holocron auth check`. Hits Postman's `/me` endpoint (returns the
+ * authenticated user).
+ */
+
+import { PostmanRestClient } from "./rest.js";
+
+export interface VerifyTokenSuccess {
+	ok: true;
+	subject: string;
+}
+
+export interface VerifyTokenFailure {
+	ok: false;
+	message: string;
+}
+
+export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
+
+interface MeResponse {
+	user?: {
+		id?: string | number;
+		username?: string;
+		email?: string;
+		fullName?: string;
+	};
+}
+
+export interface VerifyTokenOptions {
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+export async function verifyToken(token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
+	const restOpts: ConstructorParameters<typeof PostmanRestClient>[0] = { token };
+	if (opts.baseUrl !== undefined) restOpts.baseUrl = opts.baseUrl;
+	if (opts.fetch !== undefined) restOpts.fetch = opts.fetch;
+	const rest = new PostmanRestClient(restOpts);
+	try {
+		const res = await rest.request<MeResponse>("/me");
+		const subject =
+			res?.user?.email ?? res?.user?.username ?? res?.user?.fullName ?? String(res?.user?.id ?? "unknown");
+		return { ok: true, subject: `user @ ${subject}` };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { ok: false, message };
+	}
+}

--- a/packages/holocron-plugin-vercel/scripts/validate.mjs
+++ b/packages/holocron-plugin-vercel/scripts/validate.mjs
@@ -2,18 +2,14 @@
 /**
  * Read-only smoke test for @theholocron/holocron-plugin-vercel.
  *
- * READ-ONLY. Tests deployment.listProjects — proves auth + endpoint.
- *
- * NOTE: this plugin hasn't been auth-modernized yet (no keyring
- * lookup, no verifyToken export). Uses the plugin's own resolveToken
- * which reads `--token` → HOLOCRON_VERCEL_TOKEN → VERCEL_TOKEN.
- * A follow-up will add keyring + verifyToken support.
+ * READ-ONLY. Tests verifyToken + deployment.listProjects — proves
+ * auth, endpoint, and response parsing.
  *
  * Usage:
  *   pnpm --filter @theholocron/holocron-plugin-vercel validate [projectId]
  */
 
-import { AuthError, createPlugin, resolveToken } from "../src/index.ts";
+import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
 
 const [projectId] = process.argv.slice(2);
 
@@ -33,10 +29,19 @@ console.log("Validating @theholocron/holocron-plugin-vercel (READ-ONLY)");
 if (projectId) console.log(`  projectId: ${projectId}`);
 console.log("");
 
+console.log("[1/3] verifyToken");
+const verifyResult = await verifyToken(token);
+console.log(`      ${verifyResult.ok ? "✓" : "✗"} ${JSON.stringify(verifyResult)}`);
+if (!verifyResult.ok) {
+	const hint = hintFor(verifyResult.message);
+	if (hint) console.log(`         hint: ${hint}`);
+}
+console.log("");
+
 const plugin = createPlugin({ cliToken: token });
 const deployment = plugin.capabilities.deployment();
 
-console.log("[1/2] deployment.listProjects()");
+console.log("[2/3] deployment.listProjects()");
 await runStep(async () => {
 	const projects = await deployment.listProjects();
 	console.log(`      ✓ ${projects.length} project${projects.length === 1 ? "" : "s"}`);
@@ -49,7 +54,7 @@ await runStep(async () => {
 });
 console.log("");
 
-console.log("[2/2] deployment.listEnvVars(projectId, 'production')");
+console.log("[3/3] deployment.listEnvVars(projectId, 'production')");
 if (!projectId) {
 	console.log("      · skipped (no projectId provided)");
 } else {

--- a/packages/holocron-plugin-vercel/src/__tests__/auth.test.ts
+++ b/packages/holocron-plugin-vercel/src/__tests__/auth.test.ts
@@ -25,7 +25,7 @@ describe("resolveToken", () => {
 	});
 
 	it("throws AuthError with a helpful message when nothing is set", () => {
-		expect(() => resolveToken({ env: {} })).toThrow(AuthError);
-		expect(() => resolveToken({ env: {} })).toThrow(/HOLOCRON_VERCEL_TOKEN/);
+		expect(() => resolveToken({ env: {}, keyring: () => null })).toThrow(AuthError);
+		expect(() => resolveToken({ env: {}, keyring: () => null })).toThrow(/HOLOCRON_VERCEL_TOKEN/);
 	});
 });

--- a/packages/holocron-plugin-vercel/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-vercel/src/__tests__/verify-token.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { verifyToken } from "../verify-token.js";
+import { stubFetch } from "./helpers.js";
+
+describe("verifyToken", () => {
+	it("returns ok with the user email when /v2/user returns 200", async () => {
+		const stub = stubFetch([{ status: 200, body: { user: { email: "c@example.com", username: "cnewton" } } }]);
+		const result = await verifyToken("pat-abc", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/user @ c@example.com/);
+		}
+		expect(stub.calls[0]?.url).toMatch(/\/v2\/user/);
+	});
+
+	it("falls back to username when email is absent", async () => {
+		const stub = stubFetch([{ status: 200, body: { user: { username: "cnewton" } } }]);
+		const result = await verifyToken("pat-abc", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/user @ cnewton/);
+		}
+	});
+
+	it("falls back to 'unknown' when the user body is empty", async () => {
+		const stub = stubFetch([{ status: 200, body: { user: {} } }]);
+		const result = await verifyToken("pat-abc", { fetch: stub.fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.subject).toMatch(/user @ unknown/);
+		}
+	});
+
+	it("returns ok:false with the error message on 401", async () => {
+		const stub = stubFetch([{ status: 401, body: { error: { code: "forbidden" } } }]);
+		const result = await verifyToken("bad", { fetch: stub.fetch });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/→ 401/);
+		}
+	});
+
+	it("returns ok:false when the network layer throws", async () => {
+		const throwing: typeof fetch = async () => {
+			throw new TypeError("network down");
+		};
+		const result = await verifyToken("t", { fetch: throwing });
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toMatch(/network down/);
+		}
+	});
+
+	it("hits the configured base URL", async () => {
+		const stub = stubFetch([{ status: 200, body: { user: { email: "x@y.com" } } }]);
+		await verifyToken("t", { fetch: stub.fetch, baseUrl: "https://vercel.example.com" });
+		expect(stub.calls[0]?.url).toMatch(/^https:\/\/vercel\.example\.com\/v2\/user/);
+	});
+});

--- a/packages/holocron-plugin-vercel/src/auth.ts
+++ b/packages/holocron-plugin-vercel/src/auth.ts
@@ -1,14 +1,19 @@
 /**
  * Token resolution for the Vercel plugin.
  *
- * Resolution order:
+ * Resolution order (matches the standard 4-step precedence set by
+ * `.notes/tech-auth-bootstrap.spec.md`):
  *   1. explicit `cliToken` argument (from `--token` flag)
  *   2. HOLOCRON_VERCEL_TOKEN env var (preferred — explicit intent)
  *   3. VERCEL_TOKEN env var (the default the Vercel CLI also reads)
+ *   4. keyring (com.theholocron.cli / "vercel")
+ *   5. AuthError naming all four options + the bootstrap hint
  *
  * No `vercel auth` fallback — Vercel CLI auth is per-account-scoped
  * and the resulting tokens don't always cover team operations.
  */
+
+import { getToken as getKeyringToken } from "@theholocron/cli";
 
 export class AuthError extends Error {
 	override name = "AuthError";
@@ -19,13 +24,19 @@ export interface ResolveTokenInput {
 	cliToken?: string;
 	/** Env vars; passed in for testability. Defaults to `process.env`. */
 	env?: NodeJS.ProcessEnv;
+	/** Keyring lookup fn; passed in for testability. Defaults to `getToken(provider)`. */
+	keyring?: (provider: string) => string | null;
 }
 
 export function resolveToken(input: ResolveTokenInput = {}): string {
 	const env = input.env ?? process.env;
-	const token = input.cliToken || env.HOLOCRON_VERCEL_TOKEN || env.VERCEL_TOKEN;
+	const keyring = input.keyring ?? getKeyringToken;
+	const token = input.cliToken || env["HOLOCRON_VERCEL_TOKEN"] || env["VERCEL_TOKEN"] || keyring("vercel");
 	if (!token) {
-		throw new AuthError("no Vercel token found. Pass --token <PAT>, or set HOLOCRON_VERCEL_TOKEN / VERCEL_TOKEN.");
+		throw new AuthError(
+			"no Vercel token found. Pass --token <PAT>, set HOLOCRON_VERCEL_TOKEN / VERCEL_TOKEN, " +
+				"or run: holocron auth set vercel <PAT>"
+		);
 	}
 	return token;
 }

--- a/packages/holocron-plugin-vercel/src/index.ts
+++ b/packages/holocron-plugin-vercel/src/index.ts
@@ -57,8 +57,20 @@ export function createPlugin(options: VercelPluginOptions = {}) {
 	};
 }
 
+/**
+ * One-line hint printed by `holocron auth set vercel` when no token
+ * is supplied or the supplied token is rejected. Points operators at
+ * https://vercel.com/account/tokens where PATs are minted with
+ * "Full Account" scope for team-level ops.
+ */
+export const AUTH_HINT =
+	"generate a Vercel Personal Access Token at https://vercel.com/account/tokens " +
+	"(scope: Full Account for team ops), then run: holocron auth set vercel <PAT>";
+
 // ── Public re-exports ────────────────────────────────────────────────
 
 export * from "./auth.js";
 export { VercelRestClient } from "./rest.js";
 export { VercelDeployment } from "./capabilities/deployment.js";
+export { verifyToken } from "./verify-token.js";
+export type { VerifyTokenResult, VerifyTokenSuccess, VerifyTokenFailure } from "./verify-token.js";

--- a/packages/holocron-plugin-vercel/src/verify-token.ts
+++ b/packages/holocron-plugin-vercel/src/verify-token.ts
@@ -1,0 +1,48 @@
+/**
+ * `verifyToken` — plugin-level export used by `holocron auth set` +
+ * `holocron auth check`. Hits `GET /v2/user` and translates the
+ * response into the normalized `VerifyTokenResult` shape.
+ */
+
+import { VercelRestClient } from "./rest.js";
+
+export interface VerifyTokenSuccess {
+	ok: true;
+	subject: string;
+}
+
+export interface VerifyTokenFailure {
+	ok: false;
+	message: string;
+}
+
+export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
+
+interface UserResponse {
+	user?: {
+		id?: string;
+		username?: string;
+		email?: string;
+		name?: string;
+	};
+}
+
+export interface VerifyTokenOptions {
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+export async function verifyToken(token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
+	const restOpts: ConstructorParameters<typeof VercelRestClient>[0] = { token };
+	if (opts.baseUrl !== undefined) restOpts.baseUrl = opts.baseUrl;
+	if (opts.fetch !== undefined) restOpts.fetch = opts.fetch;
+	const rest = new VercelRestClient(restOpts);
+	try {
+		const res = await rest.request<UserResponse>("/v2/user");
+		const subject = res?.user?.email ?? res?.user?.username ?? res?.user?.name ?? res?.user?.id ?? "unknown";
+		return { ok: true, subject: `user @ ${subject}` };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { ok: false, message };
+	}
+}


### PR DESCRIPTION
## Summary

Brings the four remaining plugins to the same auth surface as `doppler` / `github` / `infisical`, closing out the auth-modernize follow-up (#103):

- **4-step precedence** in `resolveToken` for all four:
  `--token` → `HOLOCRON_<VENDOR>_TOKEN` → `<vendor>`-native env → keyring
- **`verifyToken(token)`** plugin-level export hitting a lightweight identity endpoint:
  - vercel  → `GET /v2/user`
  - neon    → `GET /users/me`
  - clerk   → `GET /v1/instance`
  - postman → `GET /me`
- **`AUTH_HINT`** one-liner pointing operators at the token mint URL
- **`scripts/validate.mjs`** now runs `verifyToken` as step 1 across all four — matches the doppler / github / infisical shape

Uniform auth story across all 8 plugins.

## Stack

Depends on #104 (validate-backfill). Merge #104 first, then this. The extra commits below the auth-modernize commit belong to #104 and will drop out of the diff once #104 lands on `alpha`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — clean (vercel 32, neon 26, clerk 37, postman 39)
- [ ] Live `pnpm --filter <plugin> validate` smoke run on at least one plugin

Closes: #103.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->