### PR TITLE
fix(setup): auto-derive required check contexts from configured workflows

### DIFF
--- a/.notes/ci-sync-github-smoke-test.spec.md
+++ b/.notes/ci-sync-github-smoke-test.spec.md
@@ -1,9 +1,11 @@
 ## <!-- editorconfig-checker-disable-file -->
----
-status: proposed
-issue: 115
+
 ---
 
+status: proposed
+issue: 115
+
+---
 
 # Smoke-test synced actions in sync-github workflow
 

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -466,12 +466,13 @@ describe("runSetup", () => {
 		expect(policySteps[0]?.status).toBe("ok");
 	});
 
-	it("includes required_status_checks rule when preset is 'strict'", async () => {
+	it("derives required_status_checks from configured workflows when preset is 'strict'", async () => {
 		let rulesetPayload: Record<string, unknown> | null = null;
 		const loaded = loadedFrom({
 			project: {
 				name: "demo",
-				repoPolicy: { preset: "strict", requiredChecks: ["lint", "typecheck", "test"] },
+				repoPolicy: { preset: "strict" },
+				workflows: ["lint", "test", "typecheck"],
 			},
 			providers: { vault: "1password", source: "github" },
 		});
@@ -491,6 +492,7 @@ describe("runSetup", () => {
 						rulesetPayload = p;
 						return { id: 1, name: "holocron-default-branch", enforcement: "active" };
 					},
+					writeWorkflowFile: async () => {},
 				},
 			}),
 		});
@@ -502,7 +504,56 @@ describe("runSetup", () => {
 		const checksRule = rules.find((r) => r.type === "required_status_checks");
 		expect(checksRule).toBeDefined();
 		expect(checksRule?.parameters).toMatchObject({
-			required_status_checks: [{ context: "lint" }, { context: "typecheck" }, { context: "test" }],
+			required_status_checks: [
+				{ context: "DCO" },
+				{ context: "Lint / Lint entire codebase" },
+				{ context: "Test / Run tests and collect coverage" },
+				{ context: "Typecheck / tsc --noEmit" },
+			],
+		});
+	});
+
+	it("appends extra requiredChecks from config to the auto-derived list", async () => {
+		let rulesetPayload: Record<string, unknown> | null = null;
+		const loaded = loadedFrom({
+			project: {
+				name: "demo",
+				repoPolicy: { preset: "strict", requiredChecks: ["some-extra-check"] },
+				workflows: ["lint"],
+			},
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", {
+				vault: { list: async () => [] },
+			}),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					updateRepoSettings: async () => {},
+					listRulesets: async () => [],
+					createRuleset: async (p: Record<string, unknown>) => {
+						rulesetPayload = p;
+						return { id: 1, name: "holocron-default-branch", enforcement: "active" };
+					},
+					writeWorkflowFile: async () => {},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		const rules = (rulesetPayload as unknown as { rules: Array<{ type: string; parameters?: unknown }> }).rules;
+		const checksRule = rules.find((r) => r.type === "required_status_checks");
+		expect(checksRule?.parameters).toMatchObject({
+			required_status_checks: [
+				{ context: "DCO" },
+				{ context: "Lint / Lint entire codebase" },
+				{ context: "some-extra-check" },
+			],
 		});
 	});
 

--- a/packages/cli/src/commands/setup-workflows.ts
+++ b/packages/cli/src/commands/setup-workflows.ts
@@ -285,6 +285,20 @@ jobs:
 export const KNOWN_WORKFLOWS = new Set(Object.keys(WORKFLOW_TEMPLATES));
 
 /**
+ * GitHub check context name each CI workflow produces on a PR.
+ *
+ * The format is "{caller-workflow-name} / {reusable-job-name}". The caller
+ * job's own `name:` field does NOT appear in the external check name — only
+ * the calling workflow's top-level `name:` and the inner reusable-workflow
+ * job name matter. Only workflows that gate merges are listed here.
+ */
+export const WORKFLOW_CHECK_CONTEXTS: Partial<Record<string, string>> = {
+	lint: "Lint / Lint entire codebase",
+	test: "Test / Run tests and collect coverage",
+	typecheck: "Typecheck / tsc --noEmit",
+};
+
+/**
  * Generate the thin caller content for a workflow, optionally injecting
  * `with:` inputs before `secrets: inherit` in the jobs block.
  */

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -22,7 +22,7 @@ import type { Auth, Deployment, Environments, RepoSettings, Source, Tooling, Vau
 import { ProviderApiError } from "../capabilities/index.js";
 import type { LoadedConfig } from "../load-config.js";
 import { PluginLoader, type RuntimeContext } from "../loader.js";
-import { workflowHeader, KNOWN_WORKFLOWS, generateThinCallerContent } from "./setup-workflows.js";
+import { workflowHeader, KNOWN_WORKFLOWS, generateThinCallerContent, WORKFLOW_CHECK_CONTEXTS } from "./setup-workflows.js";
 
 // ── alex config ──────────────────────────────────────────────────────
 // Canonical allow-list for the alex prose linter. Shared across all
@@ -262,7 +262,20 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			);
 			print(formatStep(steps[steps.length - 1]!));
 
-			const requiredChecks = preset === "strict" ? (policy.requiredChecks ?? []) : [];
+			const configuredWorkflowNames = (config.project.workflows ?? []).map(
+					(entry) => (typeof entry === "string" ? entry : entry.name)
+				);
+				const requiredChecks =
+					preset === "strict"
+						? [
+								"DCO",
+								...configuredWorkflowNames.flatMap((name) => {
+									const ctx = WORKFLOW_CHECK_CONTEXTS[name];
+									return ctx ? [ctx] : [];
+								}),
+								...(policy.requiredChecks ?? []),
+							]
+						: [];
 			steps.push(await upsertBranchProtection(source, dryRun, requiredChecks));
 			print(formatStep(steps[steps.length - 1]!));
 		}

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -22,7 +22,12 @@ import type { Auth, Deployment, Environments, RepoSettings, Source, Tooling, Vau
 import { ProviderApiError } from "../capabilities/index.js";
 import type { LoadedConfig } from "../load-config.js";
 import { PluginLoader, type RuntimeContext } from "../loader.js";
-import { workflowHeader, KNOWN_WORKFLOWS, generateThinCallerContent, WORKFLOW_CHECK_CONTEXTS } from "./setup-workflows.js";
+import {
+	workflowHeader,
+	KNOWN_WORKFLOWS,
+	generateThinCallerContent,
+	WORKFLOW_CHECK_CONTEXTS,
+} from "./setup-workflows.js";
 
 // ── alex config ──────────────────────────────────────────────────────
 // Canonical allow-list for the alex prose linter. Shared across all
@@ -262,20 +267,20 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			);
 			print(formatStep(steps[steps.length - 1]!));
 
-			const configuredWorkflowNames = (config.project.workflows ?? []).map(
-					(entry) => (typeof entry === "string" ? entry : entry.name)
-				);
-				const requiredChecks =
-					preset === "strict"
-						? [
-								"DCO",
-								...configuredWorkflowNames.flatMap((name) => {
-									const ctx = WORKFLOW_CHECK_CONTEXTS[name];
-									return ctx ? [ctx] : [];
-								}),
-								...(policy.requiredChecks ?? []),
-							]
-						: [];
+			const configuredWorkflowNames = (config.project.workflows ?? []).map((entry) =>
+				typeof entry === "string" ? entry : entry.name
+			);
+			const requiredChecks =
+				preset === "strict"
+					? [
+							"DCO",
+							...configuredWorkflowNames.flatMap((name) => {
+								const ctx = WORKFLOW_CHECK_CONTEXTS[name];
+								return ctx ? [ctx] : [];
+							}),
+							...(policy.requiredChecks ?? []),
+						]
+					: [];
 			steps.push(await upsertBranchProtection(source, dryRun, requiredChecks));
 			print(formatStep(steps[steps.length - 1]!));
 		}


### PR DESCRIPTION
## Summary

- Adds `WORKFLOW_CHECK_CONTEXTS` to `setup-workflows.ts` — a map from workflow name to the GitHub Actions check context string it produces (`"Lint / Lint entire codebase"`, `"Test / Run tests and collect coverage"`, `"Typecheck / tsc --noEmit"`)
- Updates `setup.ts` so the "strict" preset auto-derives required status checks from the configured `workflows` list; `DCO` is always included; `requiredChecks` in config remains as an additive override for edge cases
- Updates the "strict preset" test to assert the correct auto-derived contexts; adds a new test for the additive override

## Why

The check context name format is `{caller-workflow-name} / {reusable-job-name}`. The caller job's own `name:` does NOT appear in the external check name, making the correct strings non-obvious. Repos with `preset: "strict"` ended up with wrong names like `"Lint / Lint"` instead of `"Lint / Lint entire codebase"`, causing required checks to wait forever on every PR.

## Test plan

- [ ] `pnpm --filter @theholocron/cli test` passes (241 tests)
- [ ] A repo with `preset: "strict"` and `workflows: ["lint", "test", "typecheck"]` gets the correct contexts in its ruleset after running `holocron setup`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->