### PR TITLE
fix(ci): skip pnpm setup in lint workflow for repos without pnpm-lock.yaml

### DIFF
--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -361,9 +361,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	// ── source: labeler config ───────────────────────────────────────────
 	if (
 		loader.has("source") &&
-		(config.project.workflows ?? [])
-			.map((e) => (typeof e === "string" ? e : e.name))
-			.includes("bookkeeping-pr")
+		(config.project.workflows ?? []).map((e) => (typeof e === "string" ? e : e.name)).includes("bookkeeping-pr")
 	) {
 		const source = loader.get("source") as Source;
 		steps.push(

--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -341,6 +341,7 @@ jobs:
 
       - uses: theholocron/.github/.github/actions/setup@main
         name: Setup
+        if: \${{ hashFiles('pnpm-lock.yaml') != '' }}
 
       - uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         name: Run Super Linter


### PR DESCRIPTION
## Summary

- Adds `if: ${{ hashFiles('pnpm-lock.yaml') != '' }}` to the Setup step in the shared `lint.yml` reusable workflow template
- Repos with no pnpm workspace (e.g. `.github-private`) will now skip pnpm/node install but still run super-linter — the same guard already used in the bookkeeping workflow (line 527 of templates/index.ts)

## Why

`.github-private/pull/7` was failing with `Error: No pnpm version is specified` because `pnpm/action-setup` reads the pnpm version from the `packageManager` field in `package.json` — and `.github-private` has no `package.json`. Super-linter itself runs in Docker and doesn't need pnpm at all.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, sync-github pushes updated `lint.yml` to `theholocron/.github`
- [ ] Re-run `.github-private/pull/7` lint — should pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->