### PR TITLE
chore: add secondary repos to workflow template sync

### DIFF
--- a/.github/workflows/sync-workflow-templates.yml
+++ b/.github/workflows/sync-workflow-templates.yml
@@ -15,5 +15,6 @@ jobs:
     uses: theholocron/.github/.github/workflows/sync-github.yml@main
     with:
       primary-repo: theholocron/.github
+      secondary-repos: theholocron/.github-private
     secrets:
       SYNC_TOKEN: ${{ secrets.SYNC_TOKEN }}

--- a/.github/workflows/sync-workflow-templates.yml
+++ b/.github/workflows/sync-workflow-templates.yml
@@ -15,6 +15,9 @@ jobs:
     uses: theholocron/.github/.github/workflows/sync-github.yml@main
     with:
       primary-repo: theholocron/.github
-      secondary-repos: theholocron/.github-private
+      secondary-repos: |
+        theholocron/.github-private
+        theholocron/configs
+        theholocron/clients
     secrets:
       SYNC_TOKEN: ${{ secrets.SYNC_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github-private`, `configs`, and `clients` as permanent secondary targets in the sync-workflow-templates workflow
- Uses a YAML block scalar (`|`) for the repo list — one per line — instead of a space-separated string, for readability as the list grows
- On every push to `main`/`alpha` that touches `packages/cli/src/templates/**`, the sync now pushes updated reusable workflows + thin callers to all three repos directly (no PR needed for secondary repos)

## Test plan

- [ ] After merge, trigger workflow dispatch to confirm all three secondary repos receive the updated workflows