### PR TITLE
fix(sync-github): open PRs for secondary repos instead of pushing directly to main

### DIFF
--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -757,12 +757,13 @@ on: # yamllint disable-line rule:truthy
       secondary-repos:
         description: >
           Space-separated list of secondary repos (reusable workflows + thin
-          callers only, no composite actions). Pushed directly to main.
+          callers only, no composite actions). Changes are delivered via pull
+          request, same as the primary repo.
         type: string
         required: false
         default: ""
       sync-branch:
-        description: Branch name used for the primary-repo PR
+        description: Branch name used for the primary and secondary repo PRs
         type: string
         required: false
         default: chore/sync-templates

--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -814,15 +814,24 @@ jobs:
           PRIMARY_REPO: \${{ inputs.primary-repo }}
           SYNC_BRANCH: \${{ inputs.sync-branch }}
 
-      - name: Sync secondary repos (direct push)
+      - name: Sync secondary repos (PR)
         if: \${{ inputs.secondary-repos != '' }}
         run: |
+          GIT_NAME=$(gh api user --jq .name 2>/dev/null || echo "github-actions[bot]")
+          GIT_EMAIL=$(gh api user --jq '"\\(.id)+\\(.login)@users.noreply.github.com"' 2>/dev/null || echo "41898282+github-actions[bot]@users.noreply.github.com")
+          COMMIT_MSG="chore: sync from theholocron/holocron"$'\\n\\n'"Signed-off-by: $GIT_NAME <$GIT_EMAIL>"
           for repo in $SECONDARY_REPOS; do
-            node packages/cli/dist/cli.mjs sync-github --repo "$repo"
+            node packages/cli/dist/cli.mjs sync-github \\
+              --repo "$repo" \\
+              --branch "$SYNC_BRANCH" \\
+              --pr \\
+              --message "$COMMIT_MSG"
           done
         env:
           GITHUB_TOKEN: \${{ secrets.SYNC_TOKEN }}
+          GH_TOKEN: \${{ secrets.SYNC_TOKEN }}
           SECONDARY_REPOS: \${{ inputs.secondary-repos }}
+          SYNC_BRANCH: \${{ inputs.sync-branch }}
 `,
 
 	typecheck: `\


### PR DESCRIPTION
## Summary

- Secondary repos were being pushed to `main` directly, bypassing branch protection and CI
- Now mirrors the primary repo behaviour: builds a DCO-signed commit, opens a PR on `$SYNC_BRANCH`, and lets CI run before anything merges

## Test plan

- [ ] Merge and trigger `sync-workflow-templates` dispatch — each of `.github-private`, `configs`, and `clients` should receive a PR titled `chore: sync from theholocron/holocron` rather than a direct push
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->