### PR TITLE
fix(sync-github): read .ts config and fix with: override merging

### DIFF
--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -195,7 +195,7 @@ describe("runSyncGithub", () => {
 		});
 		const blobs = calls.filter((c) => c.method === "POST" && c.url.includes("/git/blobs"));
 		const releaseBlob = blobs.find(
-			(c) => typeof c.body?.content === "string" && (c.body.content as string).includes("name: Release"),
+			(c) => typeof c.body?.content === "string" && (c.body.content as string).includes("name: Release")
 		);
 		expect(releaseBlob?.body?.content).toContain("run-build: false");
 	});

--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -516,4 +516,29 @@ describe("generateThinCallerContent", () => {
 		expect(content).toContain("version: 1.2.3");
 		expect(content).toContain("secrets: inherit");
 	});
+
+	it("merges overrides into an existing with: block (lint template)", () => {
+		// lint already has `with:\n      enable-auto-commit: true` so the
+		// injection path can't append before `secrets: inherit` at end-of-file.
+		const content = generateThinCallerContent("lint", { "yaml-config": "custom.yml" });
+		expect(content).toContain("enable-auto-commit: true");
+		expect(content).toContain("yaml-config: custom.yml");
+	});
+
+	it("replaces an existing key when the override matches it (lint template)", () => {
+		const content = generateThinCallerContent("lint", { "enable-auto-commit": false });
+		// Should have exactly one occurrence of enable-auto-commit, set to false
+		const matches = content.match(/enable-auto-commit:/g);
+		expect(matches).toHaveLength(1);
+		expect(content).toContain("enable-auto-commit: false");
+	});
+
+	it("merges overrides into the sync-github with: block, replacing existing keys", () => {
+		// sync-github has `with:\n      secondary-repos: ...` before an explicit secrets: block.
+		// Overriding secondary-repos should replace it, not duplicate it.
+		const content = generateThinCallerContent("sync-github", { "secondary-repos": "theholocron/clients" });
+		const matches = content.match(/secondary-repos:/g);
+		expect(matches).toHaveLength(1);
+		expect(content).toContain("secondary-repos: theholocron/clients");
+	});
 });

--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -26,7 +26,7 @@ type FetchCall = { method: string; url: string; body?: Record<string, unknown> }
  * Files not in the map are treated as new (not in the tree).
  * configJson is the parsed content of holocron.config.json to serve from the repo.
  */
-function makeFetch(existingBlobs: Record<string, string> = {}, configJson?: unknown) {
+function makeFetch(existingBlobs: Record<string, string> = {}, configJson?: unknown, configTs?: string) {
 	const calls: FetchCall[] = [];
 	const fn = async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
 		const urlStr = url.toString();
@@ -50,6 +50,12 @@ function makeFetch(existingBlobs: Record<string, string> = {}, configJson?: unkn
 		if (method === "GET" && urlStr.includes("/contents/holocron.config.json")) {
 			if (!configJson) return new Response(JSON.stringify({ message: "Not Found" }), { status: 404 });
 			const content = Buffer.from(JSON.stringify(configJson)).toString("base64");
+			return new Response(JSON.stringify({ content }), { status: 200 });
+		}
+		// holocron.config.ts (fallback when .json absent)
+		if (method === "GET" && urlStr.includes("/contents/holocron.config.ts")) {
+			if (!configTs) return new Response(JSON.stringify({ message: "Not Found" }), { status: 404 });
+			const content = Buffer.from(configTs).toString("base64");
 			return new Response(JSON.stringify({ content }), { status: 200 });
 		}
 		// Tree (recursive)
@@ -158,6 +164,40 @@ describe("runSyncGithub", () => {
 			})
 			.filter(Boolean);
 		expect(blobPaths).toHaveLength(allowedNames.length);
+	});
+
+	it("reads workflow allowlist from holocron.config.ts when .json is absent", async () => {
+		const allowedNames = ["lint", "review", "stale"];
+		const configTs = `export default defineConfig({ project: { workflows: ${JSON.stringify(allowedNames)} } })`;
+		const { fn } = makeFetch({}, undefined, configTs);
+		const report = await runSyncGithub({
+			token: "ghp_test",
+			repo: "theholocron/.github-private",
+			branch: "chore/sync",
+			dryRun: false,
+			print: () => {},
+			fetch: fn,
+		});
+		expect(report.status).toBe("ok");
+		expect(report.created).toBe(allowedNames.length);
+	});
+
+	it("applies per-workflow with: overrides from config to thin callers", async () => {
+		const configTs = `export default defineConfig({ project: { workflows: [{ name: "release", with: { "run-build": false } }] } })`;
+		const { fn, calls } = makeFetch({}, undefined, configTs);
+		await runSyncGithub({
+			token: "ghp_test",
+			repo: "theholocron/.github-private",
+			branch: "chore/sync",
+			dryRun: false,
+			print: () => {},
+			fetch: fn,
+		});
+		const blobs = calls.filter((c) => c.method === "POST" && c.url.includes("/git/blobs"));
+		const releaseBlob = blobs.find(
+			(c) => typeof c.body?.content === "string" && (c.body.content as string).includes("name: Release"),
+		);
+		expect(releaseBlob?.body?.content).toContain("run-build: false");
 	});
 
 	it("skips unchanged files and omits them from the commit tree", async () => {

--- a/packages/cli/src/commands/setup-workflows.ts
+++ b/packages/cli/src/commands/setup-workflows.ts
@@ -299,15 +299,53 @@ export const WORKFLOW_CHECK_CONTEXTS: Partial<Record<string, string>> = {
 };
 
 /**
- * Generate the thin caller content for a workflow, optionally injecting
- * `with:` inputs before `secrets: inherit` in the jobs block.
+ * Generate the thin caller content for a workflow, optionally injecting or
+ * merging `with:` overrides into the jobs block.
+ *
+ * Two strategies are used depending on the template:
+ * - Templates that already have a `with:` block (e.g. lint, sync-github):
+ *   the override entries are merged in, replacing existing keys and appending
+ *   new ones.
+ * - Templates that end with `    secrets: inherit`: a new `with:` block is
+ *   injected immediately before `secrets: inherit`.
+ * If neither pattern matches the template, a warning is emitted and the
+ * base template is returned unchanged.
  */
 export function generateThinCallerContent(name: string, withOverrides?: Record<string, unknown>): string {
 	const base = WORKFLOW_TEMPLATES[name];
 	if (!base) return "";
 	if (!withOverrides || Object.keys(withOverrides).length === 0) return base;
-	const withBlock = Object.entries(withOverrides)
-		.map(([k, v]) => `      ${k}: ${v === true ? "true" : v === false ? "false" : String(v)}`)
-		.join("\n");
-	return base.replace(/ {4}secrets: inherit\n$/, `    with:\n${withBlock}\n    secrets: inherit\n`);
+
+	const fmt = (k: string, v: unknown) =>
+		`      ${k}: ${v === true ? "true" : v === false ? "false" : String(v)}`;
+
+	// If the template already has a with: block, merge overrides into it.
+	// Existing keys are replaced; new keys are appended.
+	const withBlockRe = /( {4}with:\n)((?:[ ]{6}[^\n]+\n)*)/;
+	const existingMatch = base.match(withBlockRe);
+	if (existingMatch) {
+		const existingEntries = new Map(
+			existingMatch[2]
+				.split("\n")
+				.filter(Boolean)
+				.map((line) => {
+					const m = line.match(/^ {6}([^:]+):\s*(.*)/);
+					return m ? ([m[1].trim(), m[2].trim()] as [string, string]) : null;
+				})
+				.filter((e): e is [string, string] => e !== null),
+		);
+		for (const [k, v] of Object.entries(withOverrides)) {
+			existingEntries.set(k, v === true ? "true" : v === false ? "false" : String(v));
+		}
+		const merged = [...existingEntries.entries()].map(([k, v]) => `      ${k}: ${v}`).join("\n");
+		return base.replace(withBlockRe, `    with:\n${merged}\n`);
+	}
+
+	// No existing with: block — inject before `    secrets: inherit` at end.
+	const withBlock = Object.entries(withOverrides).map(([k, v]) => fmt(k, v)).join("\n");
+	const result = base.replace(/ {4}secrets: inherit\n$/, `    with:\n${withBlock}\n    secrets: inherit\n`);
+	if (result === base) {
+		console.warn(`[generateThinCallerContent] could not inject with: overrides into "${name}" template`);
+	}
+	return result;
 }

--- a/packages/cli/src/commands/setup-workflows.ts
+++ b/packages/cli/src/commands/setup-workflows.ts
@@ -316,8 +316,7 @@ export function generateThinCallerContent(name: string, withOverrides?: Record<s
 	if (!base) return "";
 	if (!withOverrides || Object.keys(withOverrides).length === 0) return base;
 
-	const fmt = (k: string, v: unknown) =>
-		`      ${k}: ${v === true ? "true" : v === false ? "false" : String(v)}`;
+	const fmt = (k: string, v: unknown) => `      ${k}: ${v === true ? "true" : v === false ? "false" : String(v)}`;
 
 	// If the template already has a with: block, merge overrides into it.
 	// Existing keys are replaced; new keys are appended.
@@ -332,7 +331,7 @@ export function generateThinCallerContent(name: string, withOverrides?: Record<s
 					const m = line.match(/^ {6}([^:]+):\s*(.*)/);
 					return m ? ([m[1].trim(), m[2].trim()] as [string, string]) : null;
 				})
-				.filter((e): e is [string, string] => e !== null),
+				.filter((e): e is [string, string] => e !== null)
 		);
 		for (const [k, v] of Object.entries(withOverrides)) {
 			existingEntries.set(k, v === true ? "true" : v === false ? "false" : String(v));
@@ -342,7 +341,9 @@ export function generateThinCallerContent(name: string, withOverrides?: Record<s
 	}
 
 	// No existing with: block — inject before `    secrets: inherit` at end.
-	const withBlock = Object.entries(withOverrides).map(([k, v]) => fmt(k, v)).join("\n");
+	const withBlock = Object.entries(withOverrides)
+		.map(([k, v]) => fmt(k, v))
+		.join("\n");
 	const result = base.replace(/ {4}secrets: inherit\n$/, `    with:\n${withBlock}\n    secrets: inherit\n`);
 	if (result === base) {
 		console.warn(`[generateThinCallerContent] could not inject with: overrides into "${name}" template`);

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -48,6 +48,59 @@ export interface SyncGithubReport {
 }
 
 type FileBatch = Array<{ path: string; content: string }>;
+type WorkflowEntry = { name: string; with?: Record<string, unknown> };
+
+/**
+ * Extracts the `project.workflows` array from a `holocron.config.ts` source string.
+ * Handles both plain string entries and `{ name, with }` object entries.
+ * Falls back to an empty array if the array cannot be found or parsed.
+ */
+function parseWorkflowsFromTs(source: string): WorkflowEntry[] {
+	const keyMatch = source.match(/\bworkflows\s*:\s*\[/);
+	if (!keyMatch) return [];
+
+	// Walk forward to find the matching ]
+	const start = keyMatch.index! + keyMatch[0].length;
+	let depth = 1;
+	let i = start;
+	while (i < source.length && depth > 0) {
+		if (source[i] === "[") depth++;
+		else if (source[i] === "]") depth--;
+		i++;
+	}
+	const body = source.slice(start, i - 1);
+
+	const entries: Array<{ pos: number; entry: WorkflowEntry }> = [];
+	const objSpans: Array<[number, number]> = [];
+
+	// Pass 1: object entries — { name: "foo", with: { ... } }
+	// The `with` value must be a flat object (no nested braces) to keep the regex simple.
+	const objRe = /\{\s*name\s*:\s*"([^"]+)"(?:\s*,\s*with\s*:\s*(\{[^}]*\}))?\s*\}/g;
+	let m: RegExpExecArray | null;
+	while ((m = objRe.exec(body)) !== null) {
+		objSpans.push([m.index, m.index + m[0].length]);
+		let withObj: Record<string, unknown> | undefined;
+		if (m[2]) {
+			try {
+				withObj = JSON.parse(m[2]);
+			} catch {
+				/* ignore malformed with: value */
+			}
+		}
+		entries.push({ pos: m.index, entry: { name: m[1], ...(withObj && { with: withObj }) } });
+	}
+
+	// Pass 2: simple string entries — "workflowname" — skip chars inside object spans
+	const strRe = /"([^"]+)"/g;
+	while ((m = strRe.exec(body)) !== null) {
+		if (!objSpans.some(([s, e]) => m!.index >= s && m!.index < e)) {
+			entries.push({ pos: m.index, entry: { name: m[1] } });
+		}
+	}
+
+	entries.sort((a, b) => a.pos - b.pos);
+	return entries.map(({ entry }) => entry);
+}
 
 function reusableHeader(source: string): string {
 	return [
@@ -74,7 +127,11 @@ function thinCallerHeader(forPrimary = false): string {
 	].join("\n");
 }
 
-function buildBatch(repo: string, allowedWorkflows?: Set<string>): FileBatch {
+function buildBatch(
+	repo: string,
+	allowedWorkflows?: Set<string>,
+	withOverrides?: Map<string, Record<string, unknown>>,
+): FileBatch {
 	const files: FileBatch = [];
 	const isPrimaryGithubRepo = repo === DEFAULT_REPO;
 
@@ -122,7 +179,7 @@ function buildBatch(repo: string, allowedWorkflows?: Set<string>): FileBatch {
 		// a repo receives via project.workflows; undefined means all.
 		for (const name of Object.keys(REUSABLE_WORKFLOWS)) {
 			if (allowedWorkflows && !allowedWorkflows.has(name)) continue;
-			const content = generateThinCallerContent(name);
+			const content = generateThinCallerContent(name, withOverrides?.get(name));
 			if (!content) continue;
 			files.push({
 				path: `.github/workflows/${name}.yml`,
@@ -218,33 +275,50 @@ export async function runSyncGithub(input: RunSyncGithubInput): Promise<SyncGith
 	};
 	const existingBlobs = new Map(existingTree.filter((i) => i.type === "blob").map((i) => [i.path, i.sha]));
 
-	// ── 3. Fetch workflow allowlist from target repo config ───────────────────
-	// Secondary repos may declare which reusable workflows they want via their
-	// own holocron.config.json. If present and non-empty, only those workflows
-	// are synced; missing or empty config means all workflows are synced.
+	// ── 3. Fetch workflow allowlist + per-workflow overrides from target repo ─
+	// Reads holocron.config.json first; falls back to holocron.config.ts.
+	// If present and non-empty, only listed workflows are synced.
+	// Object entries ({ name, with }) also carry per-caller with: overrides.
 	let allowedWorkflows: Set<string> | undefined;
+	let withOverrides: Map<string, Record<string, unknown>> | undefined;
 	if (repo !== DEFAULT_REPO) {
 		try {
-			const configRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/contents/holocron.config.json`, {
+			let entries: WorkflowEntry[] = [];
+
+			const jsonRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/contents/holocron.config.json`, {
 				headers,
 			});
-			if (configRes.ok) {
-				const configData = (await configRes.json()) as { content: string };
+			if (jsonRes.ok) {
+				const data = (await jsonRes.json()) as { content: string };
 				const raw = JSON.parse(
-					Buffer.from(configData.content.replace(/\n/g, ""), "base64").toString("utf8")
-				) as { project?: { workflows?: Array<string | { name: string }> } };
-				const workflows = raw?.project?.workflows ?? [];
-				if (workflows.length > 0) {
-					allowedWorkflows = new Set(workflows.map((w) => (typeof w === "string" ? w : w.name)));
+					Buffer.from(data.content.replace(/\n/g, ""), "base64").toString("utf8"),
+				) as { project?: { workflows?: Array<string | WorkflowEntry> } };
+				entries = (raw?.project?.workflows ?? []).map((w) =>
+					typeof w === "string" ? { name: w } : w,
+				);
+			} else {
+				const tsRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/contents/holocron.config.ts`, {
+					headers,
+				});
+				if (tsRes.ok) {
+					const data = (await tsRes.json()) as { content: string };
+					const source = Buffer.from(data.content.replace(/\n/g, ""), "base64").toString("utf8");
+					entries = parseWorkflowsFromTs(source);
 				}
 			}
+
+			if (entries.length > 0) {
+				allowedWorkflows = new Set(entries.map((e) => e.name));
+				const overrideEntries = entries.filter((e) => e.with != null).map((e) => [e.name, e.with!] as const);
+				if (overrideEntries.length > 0) withOverrides = new Map(overrideEntries);
+			}
 		} catch {
-			// No config or parse error — sync all workflows
+			// No config or parse error — sync all workflows with no overrides
 		}
 	}
 
 	// ── 4. Build file batch ──────────────────────────────────────────────────
-	const batch = buildBatch(repo, allowedWorkflows);
+	const batch = buildBatch(repo, allowedWorkflows, withOverrides);
 
 	// ── 5. Detect changes ────────────────────────────────────────────────────
 	let created = 0;

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -130,7 +130,7 @@ function thinCallerHeader(forPrimary = false): string {
 function buildBatch(
 	repo: string,
 	allowedWorkflows?: Set<string>,
-	withOverrides?: Map<string, Record<string, unknown>>,
+	withOverrides?: Map<string, Record<string, unknown>>
 ): FileBatch {
 	const files: FileBatch = [];
 	const isPrimaryGithubRepo = repo === DEFAULT_REPO;
@@ -290,12 +290,10 @@ export async function runSyncGithub(input: RunSyncGithubInput): Promise<SyncGith
 			});
 			if (jsonRes.ok) {
 				const data = (await jsonRes.json()) as { content: string };
-				const raw = JSON.parse(
-					Buffer.from(data.content.replace(/\n/g, ""), "base64").toString("utf8"),
-				) as { project?: { workflows?: Array<string | WorkflowEntry> } };
-				entries = (raw?.project?.workflows ?? []).map((w) =>
-					typeof w === "string" ? { name: w } : w,
-				);
+				const raw = JSON.parse(Buffer.from(data.content.replace(/\n/g, ""), "base64").toString("utf8")) as {
+					project?: { workflows?: Array<string | WorkflowEntry> };
+				};
+				entries = (raw?.project?.workflows ?? []).map((w) => (typeof w === "string" ? { name: w } : w));
 			} else {
 				const tsRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/contents/holocron.config.ts`, {
 					headers,


### PR DESCRIPTION
## Summary

Two bugs both rooted in how secondary-repo config is read and applied:

**1. `holocron.config.ts` was never read** — the CLI only fetched `holocron.config.json`. Repos like `configs` that use the TypeScript config format got all 12 workflows synced instead of their declared allowlist, and per-workflow `with:` overrides were silently ignored.

Fix: try `.json` first; fall back to `.ts` on 404 using `parseWorkflowsFromTs` — a two-pass regex that extracts string entries and `{ name, with }` object entries while skipping content inside object spans.

**2. `generateThinCallerContent` silently dropped overrides for templates with an existing `with:` block** — the injection regex `/ {4}secrets: inherit\n$/` only matches templates that *end* with bare `secrets: inherit`. The `lint` template ends with `with:\n      enable-auto-commit: true` and `sync-github` uses an explicit `secrets:` block, so both silently discarded any passed overrides.

Fix: detect an existing `with:` block first and merge overrides into it (replacing existing keys, appending new ones). Fall back to the end-of-file injection for templates without a pre-existing block. Emit a `console.warn` if neither pattern matches.

## Test plan

- [ ] CI passes
- [ ] After merge, close configs#230 and re-trigger sync — configs should receive only the 8 workflows from its config, with `release.yml` containing `run-build: false`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->