### PR TITLE
fix(bookkeeping-pr): allow Node 20 for issue-labeler until action is updated

### DIFF
--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -146,6 +146,9 @@ jobs:
 
       - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
         if: \${{ hashFiles(inputs.configuration-path || '.github/labeler.yml') != '' }}
+        # v3.4 bundles Node 20; allow it to run under Actions' current default.
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
         with:
           # Fall back to default path when triggered directly (not via workflow_call)
           # because inputs.* defaults only apply on workflow_call events.


### PR DESCRIPTION
## Summary

`github/issue-labeler@v3.4` bundles Node 20 internally. GitHub Actions now runs actions with Node 24 by default, which breaks the action (the `punycode` built-in module is deprecated/removed and `url.parse()` throws on certain inputs in Node 24).

Adds `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` to the labeler step as a temporary workaround. The proper fix is to update the action pin to a version compiled for Node 22+, but no such release is available yet.

## Test plan

- [ ] CI passes
- [ ] After merge + sync, bookkeeping-pr runs successfully on subsequent PRs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->