### PR TITLE
fix(bookkeeping-pr): add issues: write permission for label API access

### DIFF
--- a/packages/cli/src/commands/setup-workflows.ts
+++ b/packages/cli/src/commands/setup-workflows.ts
@@ -229,6 +229,7 @@ on: # yamllint disable-line rule:truthy
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:

--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -132,6 +132,7 @@ jobs:
     name: Add Labels to PRs
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

- Adds `issues: write` to both the reusable `bookkeeping-pr` template (`templates/index.ts`) and the thin-caller template (`setup-workflows.ts`)
- The `github/issue-labeler` action applies labels via the GitHub Issues API — `pull-requests: write` alone is insufficient; `issues: write` is also required
- Without this, the labeler step fails with "Resource not accessible by integration" on private repos

## Test plan

- [ ] After merge to alpha, trigger `sync-workflow-templates` to push the fix to all repos
- [ ] Re-run `bookkeeping-pr` on an open PR to confirm labeling succeeds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->