### PR TITLE
docs: mark label unification spec as complete

### DIFF
--- a/.notes/ci-label-unification.spec.md
+++ b/.notes/ci-label-unification.spec.md
@@ -1,9 +1,12 @@
-# Spec: Unified org-wide label management
+---
+status: archived # draft → proposed (issue filed) → approved (milestone attached) → archived (shipped)
+---
 
-> **Status: complete** — all steps shipped as of 2026-07-15.
-> Implementation: holocron#138 (label sync), holocron#139 (bookkeeping-pr permissions fix).
-> Docs: .github#40 (public label table), .github-private runbook updated.
-> Open follow-up: org custom properties — see `.notes/org-custom-properties.spec.md` (not yet written).
+<!-- Implementation: holocron#138 (label sync), holocron#139 (bookkeeping-pr permissions fix) -->
+<!-- Docs: .github#40 (public label table), .github-private runbook updated, 2026-07-15 -->
+<!-- Follow-up: org custom properties — .notes/org-custom-properties.spec.md (not yet written) -->
+
+# Spec: Unified org-wide label management
 
 ## Problem
 

--- a/.notes/ci-label-unification.spec.md
+++ b/.notes/ci-label-unification.spec.md
@@ -1,5 +1,10 @@
 # Spec: Unified org-wide label management
 
+> **Status: complete** — all steps shipped as of 2026-07-15.
+> Implementation: holocron#138 (label sync), holocron#139 (bookkeeping-pr permissions fix).
+> Docs: .github#40 (public label table), .github-private runbook updated.
+> Open follow-up: org custom properties — see `.notes/org-custom-properties.spec.md` (not yet written).
+
 ## Problem
 
 Labels are inconsistent across the five active repos. Key pain points:


### PR DESCRIPTION
Marks the spec complete with pointers to the implementation PRs and the open custom-properties follow-up.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->