### PR TITLE
feat(config): unified repo metadata config (Steps 1–5)

### DIFF
--- a/.notes/tech-repo-metadata.spec.md
+++ b/.notes/tech-repo-metadata.spec.md
@@ -115,7 +115,8 @@ Topics are not auto-derived; they must be set explicitly. Conventions:
 ## Derivation rules for custom properties
 
 **`branch_protection_level`** — read from `repo.protection` (or `repoPolicy.preset`
-during the migration window). Defaults to `balanced`.
+during the migration window). Only written when explicitly set and not `"none"`; omitting
+`protection` leaves the property unset.
 
 **`monorepo`** — `true` when `pnpm-workspace.yaml` exists at the repo root.
 

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -5,9 +5,16 @@ export default defineConfig({
 		name: "holocron",
 		description:
 			"The Holocron CLI — pluggable, capability-based infrastructure orchestrator. This file makes the repo self-hosted: holocron commands work inside it.",
-		repo: "theholocron/holocron",
-		repoPolicy: {
-			preset: "strict",
+		repo: {
+			name: "theholocron/holocron",
+			protection: "strict",
+			topics: ["automation", "cli", "developer-tools", "holocron", "nodejs", "typescript"],
+			properties: {
+				lifecycle: "active",
+				open_source: true,
+				runtime_environment: "node",
+				uses_external_packages: true,
+			},
 		},
 		workflows: [
 			"lint",

--- a/packages/cli/src/__tests__/define-config.test.ts
+++ b/packages/cli/src/__tests__/define-config.test.ts
@@ -13,7 +13,7 @@ describe("defineConfig", () => {
 
 	it("preserves nested options", () => {
 		const config = {
-			project: { name: "my-app", repo: "org/my-app" },
+			project: { name: "my-app", repo: { name: "org/my-app" } },
 			providers: {
 				vault: ["1password", { vault: "my-app" }] as [string, Record<string, unknown>],
 				source: "github" as const,

--- a/packages/cli/src/__tests__/loader.test.ts
+++ b/packages/cli/src/__tests__/loader.test.ts
@@ -163,7 +163,7 @@ describe("PluginLoader — project.repo defaults", () => {
 	it("injects config.project.repo into plugin options when context.repo is absent", async () => {
 		const captured: Record<string, unknown> = {};
 		const config = resolveConfig({
-			project: { name: "demo", repo: "acme/foo" },
+			project: { name: "demo", repo: { name: "acme/foo" } },
 			providers: { vault: "1password", source: "github" },
 		});
 		const importer = vi.fn(async (pkg: string) => {
@@ -185,7 +185,7 @@ describe("PluginLoader — project.repo defaults", () => {
 	it("context.repo (CLI --repo flag) overrides config.project.repo", async () => {
 		const captured: Record<string, unknown> = {};
 		const config = resolveConfig({
-			project: { name: "demo", repo: "acme/from-config" },
+			project: { name: "demo", repo: { name: "acme/from-config" } },
 			providers: { vault: "1password", source: "github" },
 		});
 		const importer = vi.fn(async (pkg: string) => {
@@ -211,7 +211,7 @@ describe("PluginLoader — project.repo defaults", () => {
 	it("per-plugin tuple options override both context and project defaults", async () => {
 		const captured: Record<string, unknown> = {};
 		const config = resolveConfig({
-			project: { name: "demo", repo: "acme/from-config" },
+			project: { name: "demo", repo: { name: "acme/from-config" } },
 			providers: {
 				vault: "1password",
 				source: ["github", { repo: "override/from-tuple" }],

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1010,6 +1010,256 @@ describe("runSetup", () => {
 		expect(written[".github/labeler.yml"]).toBeUndefined();
 	});
 
+	it("calls syncProperties with derived and manual properties when source supports it", async () => {
+		let captured: Record<string, string> | null = null;
+		const loaded = loadedFrom({
+			project: {
+				name: "demo",
+				repo: {
+					name: "theholocron/demo",
+					protection: "strict",
+					properties: {
+						lifecycle: "active",
+						open_source: true,
+						runtime_environment: "node",
+						uses_external_packages: false,
+					},
+				},
+			},
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", {
+				vault: { list: async () => [] },
+			}),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					enableDependencyGraph: async () => {},
+					enableCodeScanning: async () => "run 1",
+					updateRepoSettings: async () => {},
+					listRulesets: async () => [],
+					createRuleset: async () => ({ id: 1, name: "holocron-default-branch", enforcement: "active" }),
+					writeRepoFile: async () => {},
+					syncProperties: async (values: Record<string, string>) => {
+						captured = values;
+						return `${Object.keys(values).length} properties set`;
+					},
+				},
+			}),
+		});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(captured).not.toBeNull();
+		expect(captured!["branch_protection_level"]).toBe("strict");
+		expect(captured!["monorepo"]).toBe("false"); // /tmp/test has no pnpm-workspace.yaml
+		expect(captured!["lifecycle"]).toBe("active");
+		expect(captured!["open_source"]).toBe("true");
+		expect(captured!["runtime_environment"]).toBe("node");
+		expect(captured!["uses_external_packages"]).toBe("false");
+		const step = report.steps.find((s) => s.step === "sync properties");
+		expect(step?.status).toBe("ok");
+		expect(step?.message).toContain("properties set");
+	});
+
+	it("does not set branch_protection_level property when no protection is configured", async () => {
+		let captured: Record<string, string> | null = null;
+		const loaded = loadedFrom({
+			project: {
+				name: "demo",
+				repo: { name: "theholocron/demo", properties: { lifecycle: "experimental" } },
+			},
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", {
+				vault: { list: async () => [] },
+			}),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeRepoFile: async () => {},
+					syncProperties: async (values: Record<string, string>) => {
+						captured = values;
+						return `${Object.keys(values).length} properties set`;
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(captured).not.toBeNull();
+		expect(captured!["branch_protection_level"]).toBeUndefined();
+		expect(captured!["lifecycle"]).toBe("experimental");
+	});
+
+	it("calls syncTopics with the configured topics", async () => {
+		let capturedTopics: string[] | null = null;
+		const loaded = loadedFrom({
+			project: {
+				name: "demo",
+				repo: { name: "theholocron/demo", topics: ["cli", "nodejs", "typescript"] },
+			},
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", {
+				vault: { list: async () => [] },
+			}),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeRepoFile: async () => {},
+					syncTopics: async (topics: string[]) => {
+						capturedTopics = topics;
+						return `${topics.length} topics set`;
+					},
+				},
+			}),
+		});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(capturedTopics).toEqual(["cli", "nodejs", "typescript"]);
+		const step = report.steps.find((s) => s.step === "sync topics");
+		expect(step?.status).toBe("ok");
+		expect(step?.message).toBe("3 topics set");
+	});
+
+	it("skips syncTopics when topics list is empty", async () => {
+		let called = false;
+		const loaded = loadedFrom({
+			project: {
+				name: "demo",
+				repo: { name: "theholocron/demo", topics: [] },
+			},
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", {
+				vault: { list: async () => [] },
+			}),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeRepoFile: async () => {},
+					syncTopics: async () => {
+						called = true;
+						return "0 topics set";
+					},
+				},
+			}),
+		});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(called).toBe(false);
+		expect(report.steps.some((s) => s.step === "sync topics")).toBe(false);
+	});
+
+	it("skips syncTopics when repo has no topics field", async () => {
+		let called = false;
+		const loaded = loadedFrom({
+			project: { name: "demo" },
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", {
+				vault: { list: async () => [] },
+			}),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeRepoFile: async () => {},
+					syncTopics: async () => {
+						called = true;
+						return "0 topics set";
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(called).toBe(false);
+	});
+
+	it("skips dependabot when repo.protection is 'none'", async () => {
+		const written: string[] = [];
+		const loaded = loadedFrom({
+			project: {
+				name: "demo",
+				repo: { name: "theholocron/demo", protection: "none" },
+			},
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", {
+				vault: { list: async () => [] },
+			}),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeRepoFile: async (path: string) => {
+						written.push(path);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(written).not.toContain(".github/dependabot.yml");
+	});
+
+	it("writes dependabot when no protection is configured (effectivePreset undefined)", async () => {
+		const written: string[] = [];
+		const loaded = loadedFrom({
+			project: { name: "demo" },
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", {
+				vault: { list: async () => [] },
+			}),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeRepoFile: async (path: string) => {
+						written.push(path);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(written).toContain(".github/dependabot.yml");
+	});
+
 	it("dry-run does not write .alexrc.json", async () => {
 		let writeCalled = false;
 		const loaded = loadedFrom({

--- a/packages/cli/src/capabilities/index.ts
+++ b/packages/cli/src/capabilities/index.ts
@@ -174,6 +174,18 @@ export interface Source extends ProviderIdentity {
 	 * Optional — providers that have no label concept omit this.
 	 */
 	syncLabels?(canonical: ReadonlyArray<LabelDef>, stale: ReadonlyArray<string>): Promise<string>;
+
+	/**
+	 * Set org-level custom property values on the repo.
+	 * Optional — providers that don't support custom properties omit this.
+	 */
+	syncProperties?(values: Record<string, string>): Promise<string>;
+
+	/**
+	 * Replace the repo's topic set with the supplied list.
+	 * Optional — providers that don't support topics omit this.
+	 */
+	syncTopics?(topics: string[]): Promise<string>;
 }
 
 // ───────────────────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -372,6 +372,8 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	const config = input.loaded.resolved;
 	const dryRun = input.context.dryRun ?? false;
 	const steps: SetupStepResult[] = [];
+	const repo = config.project.repo;
+	const effectivePreset = repo?.protection ?? config.project.repoPolicy?.preset;
 
 	print(`Holocron setup — ${config.project.name}${dryRun ? " (dry-run)" : ""}`);
 	print(`  config: ${input.loaded.filepath}`);
@@ -415,10 +417,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		);
 		print(formatStep(steps[steps.length - 1]!));
 
-		const policy = config.project.repoPolicy;
-		if (policy && policy.preset !== "none") {
-			const preset = policy.preset ?? "balanced";
-
+		if (effectivePreset && effectivePreset !== "none") {
 			steps.push(
 				await runStep("source", "updateRepoSettings", dryRun, async () => {
 					await source.updateRepoSettings(BALANCED_REPO_SETTINGS);
@@ -430,14 +429,14 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 				typeof entry === "string" ? entry : entry.name
 			);
 			const requiredChecks =
-				preset === "strict"
+				effectivePreset === "strict"
 					? [
 							"DCO",
 							...configuredWorkflowNames.flatMap((name) => {
 								const ctx = WORKFLOW_CHECK_CONTEXTS[name];
 								return ctx ? [ctx] : [];
 							}),
-							...(policy.requiredChecks ?? []),
+							...(repo?.requiredChecks ?? config.project.repoPolicy?.requiredChecks ?? []),
 						]
 					: [];
 			steps.push(await upsertBranchProtection(source, dryRun, requiredChecks));
@@ -533,11 +532,9 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			print(formatStep(steps[steps.length - 1]!));
 		}
 
-		const repo = config.project.repo;
 		const properties: Record<string, string> = {};
 
-		const preset = repo?.protection ?? config.project.repoPolicy?.preset ?? "balanced";
-		if (preset !== "none") properties["branch_protection_level"] = preset;
+		if (effectivePreset && effectivePreset !== "none") properties["branch_protection_level"] = effectivePreset;
 
 		const isMonorepo = await access("pnpm-workspace.yaml")
 			.then(() => true)

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -490,7 +490,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	}
 
 	// ── source: dependabot config ────────────────────────────────────────
-	if (loader.has("source") && config.project.repoPolicy?.preset !== "none") {
+	if (loader.has("source") && effectivePreset !== "none") {
 		const source = loader.get("source") as Source;
 		steps.push(
 			await runStep("source", "write .github/dependabot.yml", dryRun, async () => {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -534,8 +534,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			print(formatStep(steps[steps.length - 1]!));
 		}
 
-		const repoConfig: Partial<RepoConfig> =
-			typeof config.project.repo === "object" ? config.project.repo : {};
+		const repoConfig: Partial<RepoConfig> = typeof config.project.repo === "object" ? config.project.repo : {};
 		const properties: Record<string, string> = {};
 
 		const preset = repoConfig.protection ?? config.project.repoPolicy?.preset ?? "balanced";
@@ -554,17 +553,13 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			properties["uses_external_packages"] = String(manual.uses_external_packages);
 
 		if (source.syncProperties) {
-			steps.push(
-				await runStep("source", "sync properties", dryRun, () => source.syncProperties!(properties))
-			);
+			steps.push(await runStep("source", "sync properties", dryRun, () => source.syncProperties!(properties)));
 			print(formatStep(steps[steps.length - 1]!));
 		}
 
 		const topics = repoConfig.topics ?? [];
 		if (topics.length > 0 && source.syncTopics) {
-			steps.push(
-				await runStep("source", "sync topics", dryRun, () => source.syncTopics!(topics))
-			);
+			steps.push(await runStep("source", "sync topics", dryRun, () => source.syncTopics!(topics)));
 			print(formatStep(steps[steps.length - 1]!));
 		}
 	}

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -18,8 +18,11 @@
  * one central place.
  */
 
+import { access } from "node:fs/promises";
+
 import type { Auth, Deployment, Environments, RepoSettings, Source, Tooling, Vault } from "../capabilities/index.js";
 import { ProviderApiError } from "../capabilities/index.js";
+import type { RepoConfig } from "../config.js";
 import type { LoadedConfig } from "../load-config.js";
 import { PluginLoader, type RuntimeContext } from "../loader.js";
 import {
@@ -527,6 +530,40 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 				await runStep("source", "sync labels", dryRun, async () => {
 					return source.syncLabels!(CANONICAL_LABELS, STALE_LABELS);
 				})
+			);
+			print(formatStep(steps[steps.length - 1]!));
+		}
+
+		const repoConfig: Partial<RepoConfig> =
+			typeof config.project.repo === "object" ? config.project.repo : {};
+		const properties: Record<string, string> = {};
+
+		const preset = repoConfig.protection ?? config.project.repoPolicy?.preset ?? "balanced";
+		if (preset !== "none") properties["branch_protection_level"] = preset;
+
+		const isMonorepo = await access("pnpm-workspace.yaml")
+			.then(() => true)
+			.catch(() => false);
+		properties["monorepo"] = String(isMonorepo);
+
+		const manual = repoConfig.properties ?? {};
+		if (manual.lifecycle) properties["lifecycle"] = manual.lifecycle;
+		if (manual.open_source !== undefined) properties["open_source"] = String(manual.open_source);
+		if (manual.runtime_environment) properties["runtime_environment"] = manual.runtime_environment;
+		if (manual.uses_external_packages !== undefined)
+			properties["uses_external_packages"] = String(manual.uses_external_packages);
+
+		if (source.syncProperties) {
+			steps.push(
+				await runStep("source", "sync properties", dryRun, () => source.syncProperties!(properties))
+			);
+			print(formatStep(steps[steps.length - 1]!));
+		}
+
+		const topics = repoConfig.topics ?? [];
+		if (topics.length > 0 && source.syncTopics) {
+			steps.push(
+				await runStep("source", "sync topics", dryRun, () => source.syncTopics!(topics))
 			);
 			print(formatStep(steps[steps.length - 1]!));
 		}

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -19,6 +19,7 @@
  */
 
 import { access } from "node:fs/promises";
+import { join } from "node:path";
 
 import type { Auth, Deployment, Environments, RepoSettings, Source, Tooling, Vault } from "../capabilities/index.js";
 import { ProviderApiError } from "../capabilities/index.js";
@@ -536,7 +537,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 
 		if (effectivePreset && effectivePreset !== "none") properties["branch_protection_level"] = effectivePreset;
 
-		const isMonorepo = await access("pnpm-workspace.yaml")
+		const isMonorepo = await access(join(input.context.repoRoot, "pnpm-workspace.yaml"))
 			.then(() => true)
 			.catch(() => false);
 		properties["monorepo"] = String(isMonorepo);

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -22,7 +22,6 @@ import { access } from "node:fs/promises";
 
 import type { Auth, Deployment, Environments, RepoSettings, Source, Tooling, Vault } from "../capabilities/index.js";
 import { ProviderApiError } from "../capabilities/index.js";
-import type { RepoConfig } from "../config.js";
 import type { LoadedConfig } from "../load-config.js";
 import { PluginLoader, type RuntimeContext } from "../loader.js";
 import {
@@ -534,10 +533,10 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			print(formatStep(steps[steps.length - 1]!));
 		}
 
-		const repoConfig: Partial<RepoConfig> = typeof config.project.repo === "object" ? config.project.repo : {};
+		const repo = config.project.repo;
 		const properties: Record<string, string> = {};
 
-		const preset = repoConfig.protection ?? config.project.repoPolicy?.preset ?? "balanced";
+		const preset = repo?.protection ?? config.project.repoPolicy?.preset ?? "balanced";
 		if (preset !== "none") properties["branch_protection_level"] = preset;
 
 		const isMonorepo = await access("pnpm-workspace.yaml")
@@ -545,7 +544,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			.catch(() => false);
 		properties["monorepo"] = String(isMonorepo);
 
-		const manual = repoConfig.properties ?? {};
+		const manual = repo?.properties ?? {};
 		if (manual.lifecycle) properties["lifecycle"] = manual.lifecycle;
 		if (manual.open_source !== undefined) properties["open_source"] = String(manual.open_source);
 		if (manual.runtime_environment) properties["runtime_environment"] = manual.runtime_environment;
@@ -557,7 +556,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			print(formatStep(steps[steps.length - 1]!));
 		}
 
-		const topics = repoConfig.topics ?? [];
+		const topics = repo?.topics ?? [];
 		if (topics.length > 0 && source.syncTopics) {
 			steps.push(await runStep("source", "sync topics", dryRun, () => source.syncTopics!(topics)));
 			print(formatStep(steps[steps.length - 1]!));

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -92,8 +92,8 @@ export interface RepoConfig {
 	/** "owner/name" — the GitHub repository coordinate. */
 	name: string;
 	/**
-	 * Branch protection preset applied by `holocron setup`.
-	 * @default "balanced"
+	 * Branch protection preset applied by `holocron setup`. When omitted,
+	 * no protection is applied and no `branch_protection_level` property is set.
 	 */
 	protection?: RepoProtection;
 	/** CI check context names required on the default branch (only used when `protection` is "strict"). */

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -119,13 +119,12 @@ export interface HolocronConfig {
 		name: string;
 		description?: string;
 		/**
-		 * Repository identity and metadata. Accepts a bare `"owner/name"` string
-		 * or a full `RepoConfig` object. When set, `PluginLoader` injects the repo
-		 * name into every plugin's `RuntimeContext.repo` so plugins that need a repo
-		 * (github, etc.) don't require `--repo` on every invocation. `--repo` on the
-		 * command line still overrides.
+		 * Repository identity and metadata. When set, `PluginLoader` injects
+		 * `repo.name` into every plugin's `RuntimeContext.repo` so plugins that
+		 * need a repo (github, etc.) don't require `--repo` on every invocation.
+		 * `--repo` on the command line still overrides.
 		 */
-		repo?: string | RepoConfig;
+		repo?: RepoConfig;
 		/**
 		 * Repo-level policy applied by `holocron setup`. Defines merge
 		 * strategy, branch protection rulesets, and security defaults.

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -69,10 +69,39 @@ export interface RepoPolicyConfig {
 	 * "none" — skips repo settings + ruleset entirely.
 	 *
 	 * @default "balanced"
+	 * @deprecated Use `project.repo.protection` instead.
 	 */
 	preset?: "balanced" | "strict" | "none";
-	/** CI check context names required on the default branch (used by "strict"). */
+	/**
+	 * CI check context names required on the default branch (used by "strict").
+	 * @deprecated Use `project.repo.requiredChecks` instead.
+	 */
 	requiredChecks?: string[];
+}
+
+export type RepoProtection = "balanced" | "strict" | "none";
+
+export interface RepoProperties {
+	lifecycle?: "active" | "experimental" | "deprecated";
+	open_source?: boolean;
+	runtime_environment?: "node" | "browser" | "universal" | "none";
+	uses_external_packages?: boolean;
+}
+
+export interface RepoConfig {
+	/** "owner/name" — the GitHub repository coordinate. */
+	name: string;
+	/**
+	 * Branch protection preset applied by `holocron setup`.
+	 * @default "balanced"
+	 */
+	protection?: RepoProtection;
+	/** CI check context names required on the default branch (only used when `protection` is "strict"). */
+	requiredChecks?: string[];
+	/** GitHub topics set on the repository. */
+	topics?: string[];
+	/** GitHub custom properties synced to the org dashboard. */
+	properties?: RepoProperties;
 }
 
 export interface AppConfig {
@@ -90,12 +119,13 @@ export interface HolocronConfig {
 		name: string;
 		description?: string;
 		/**
-		 * Repo coord — `"owner/name"`. When set, `PluginLoader` injects
-		 * it into every plugin's `RuntimeContext.repo` so plugins that
-		 * need a repo (github, etc.) don't require `--repo` on every
-		 * invocation. `--repo` on the command line still overrides.
+		 * Repository identity and metadata. Accepts a bare `"owner/name"` string
+		 * or a full `RepoConfig` object. When set, `PluginLoader` injects the repo
+		 * name into every plugin's `RuntimeContext.repo` so plugins that need a repo
+		 * (github, etc.) don't require `--repo` on every invocation. `--repo` on the
+		 * command line still overrides.
 		 */
-		repo?: string;
+		repo?: string | RepoConfig;
 		/**
 		 * Repo-level policy applied by `holocron setup`. Defines merge
 		 * strategy, branch protection rulesets, and security defaults.

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -183,7 +183,8 @@ export class PluginLoader {
 	 */
 	private projectDefaults(): Partial<RuntimeContext> {
 		const defaults: Partial<RuntimeContext> = {};
-		if (this.config.project.repo) defaults.repo = this.config.project.repo;
+		const repo = this.config.project.repo;
+		if (repo) defaults.repo = typeof repo === "string" ? repo : repo.name;
 		return defaults;
 	}
 }

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -184,6 +184,7 @@ export class PluginLoader {
 	private projectDefaults(): Partial<RuntimeContext> {
 		const defaults: Partial<RuntimeContext> = {};
 		const repo = this.config.project.repo;
+		// Runtime guard: JSON configs may still carry the old string form during rollout.
 		if (repo) defaults.repo = typeof repo === "string" ? repo : repo.name;
 		return defaults;
 	}

--- a/packages/holocron-plugin-github/src/__tests__/properties.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/properties.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { syncProperties } from "../capabilities/properties.js";
+import { createGitHubRestClient } from "../rest.js";
+
+import { stubFetch } from "./helpers.js";
+
+const REPO = "theholocron/holocron";
+
+function makeRest(responses: Parameters<typeof stubFetch>[0]) {
+	const { fetch, calls } = stubFetch(responses);
+	const rest = createGitHubRestClient({ token: "pat", fetch });
+	return { rest, calls };
+}
+
+describe("syncProperties", () => {
+	it("PATCHes /repos/{owner}/{name}/properties/values with mapped entries", async () => {
+		const { rest, calls } = makeRest([{ status: 204, body: null }]);
+
+		const result = await syncProperties(rest, REPO, {
+			branch_protection_level: "strict",
+			lifecycle: "active",
+			monorepo: "false",
+		});
+
+		expect(result).toBe("3 properties set");
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).toMatchObject({
+			method: "PATCH",
+			url: expect.stringContaining("/repos/theholocron/holocron/properties/values"),
+			body: {
+				properties: expect.arrayContaining([
+					{ property_name: "branch_protection_level", value: "strict" },
+					{ property_name: "lifecycle", value: "active" },
+					{ property_name: "monorepo", value: "false" },
+				]),
+			},
+		});
+	});
+
+	it("returns '0 properties set' for an empty values map", async () => {
+		const { rest, calls } = makeRest([{ status: 204, body: null }]);
+
+		const result = await syncProperties(rest, REPO, {});
+
+		expect(result).toBe("0 properties set");
+		expect(calls[0]?.body).toMatchObject({ properties: [] });
+	});
+
+	it("uses owner/name from the repo coordinate", async () => {
+		const { rest, calls } = makeRest([{ status: 204, body: null }]);
+
+		await syncProperties(rest, "acme/my-lib", { open_source: "true" });
+
+		expect(calls[0]?.url).toContain("/repos/acme/my-lib/properties/values");
+	});
+});

--- a/packages/holocron-plugin-github/src/__tests__/topics.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/topics.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { syncTopics } from "../capabilities/topics.js";
+import { createGitHubRestClient } from "../rest.js";
+
+import { stubFetch } from "./helpers.js";
+
+const REPO = "theholocron/holocron";
+
+function makeRest(responses: Parameters<typeof stubFetch>[0]) {
+	const { fetch, calls } = stubFetch(responses);
+	const rest = createGitHubRestClient({ token: "pat", fetch });
+	return { rest, calls };
+}
+
+describe("syncTopics", () => {
+	it("PUTs /repos/{owner}/{name}/topics with names array", async () => {
+		const { rest, calls } = makeRest([{ status: 200, body: { names: ["cli", "nodejs"] } }]);
+
+		const result = await syncTopics(rest, REPO, ["cli", "nodejs"]);
+
+		expect(result).toBe("2 topics set");
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).toMatchObject({
+			method: "PUT",
+			url: expect.stringContaining("/repos/theholocron/holocron/topics"),
+			body: { names: ["cli", "nodejs"] },
+		});
+	});
+
+	it("returns '0 topics set' for an empty list", async () => {
+		const { rest, calls } = makeRest([{ status: 200, body: { names: [] } }]);
+
+		const result = await syncTopics(rest, REPO, []);
+
+		expect(result).toBe("0 topics set");
+		expect(calls[0]?.body).toMatchObject({ names: [] });
+	});
+
+	it("uses owner/name from the repo coordinate", async () => {
+		const { rest, calls } = makeRest([{ status: 200, body: { names: ["cli"] } }]);
+
+		await syncTopics(rest, "acme/my-lib", ["cli"]);
+
+		expect(calls[0]?.url).toContain("/repos/acme/my-lib/topics");
+	});
+});

--- a/packages/holocron-plugin-github/src/capabilities/properties.ts
+++ b/packages/holocron-plugin-github/src/capabilities/properties.ts
@@ -1,0 +1,25 @@
+import { parseRepo } from "../repo.js";
+import type { RestClient } from "@theholocron/cli";
+
+/**
+ * Sync custom property values for a repo to the org-defined schema.
+ *
+ * Calls `PATCH /repos/{owner}/{name}/properties/values` with the full
+ * map — GitHub replaces only the supplied keys, leaving others untouched.
+ */
+export async function syncProperties(
+	rest: RestClient,
+	repo: string,
+	values: Record<string, string>
+): Promise<string> {
+	const { owner, name } = parseRepo(repo);
+
+	const properties = Object.entries(values).map(([property_name, value]) => ({ property_name, value }));
+
+	await rest.request<void>(`/repos/${owner}/${name}/properties/values`, {
+		method: "PATCH",
+		body: { properties },
+	});
+
+	return `${properties.length} properties set`;
+}

--- a/packages/holocron-plugin-github/src/capabilities/properties.ts
+++ b/packages/holocron-plugin-github/src/capabilities/properties.ts
@@ -7,11 +7,7 @@ import type { RestClient } from "@theholocron/cli";
  * Calls `PATCH /repos/{owner}/{name}/properties/values` with the full
  * map — GitHub replaces only the supplied keys, leaving others untouched.
  */
-export async function syncProperties(
-	rest: RestClient,
-	repo: string,
-	values: Record<string, string>
-): Promise<string> {
+export async function syncProperties(rest: RestClient, repo: string, values: Record<string, string>): Promise<string> {
 	const { owner, name } = parseRepo(repo);
 
 	const properties = Object.entries(values).map(([property_name, value]) => ({ property_name, value }));

--- a/packages/holocron-plugin-github/src/capabilities/source.ts
+++ b/packages/holocron-plugin-github/src/capabilities/source.ts
@@ -17,6 +17,8 @@ import type { LabelDef, RepoRef, RepoSettings, Ruleset, Source } from "@theholoc
 import { parseRepo } from "../repo.js";
 import type { RestClient } from "@theholocron/cli";
 import { syncLabels } from "./labels.js";
+import { syncProperties } from "./properties.js";
+import { syncTopics } from "./topics.js";
 
 export interface SourceOptions {
 	repo: string;
@@ -210,6 +212,14 @@ export class GitHubSource implements Source {
 
 	async syncLabels(canonical: ReadonlyArray<LabelDef>, stale: ReadonlyArray<string>): Promise<string> {
 		return syncLabels(this.rest, `${this.owner}/${this.name}`, canonical, stale);
+	}
+
+	async syncProperties(values: Record<string, string>): Promise<string> {
+		return syncProperties(this.rest, `${this.owner}/${this.name}`, values);
+	}
+
+	async syncTopics(topics: string[]): Promise<string> {
+		return syncTopics(this.rest, `${this.owner}/${this.name}`, topics);
 	}
 }
 

--- a/packages/holocron-plugin-github/src/capabilities/topics.ts
+++ b/packages/holocron-plugin-github/src/capabilities/topics.ts
@@ -1,0 +1,19 @@
+import { parseRepo } from "../repo.js";
+import type { RestClient } from "@theholocron/cli";
+
+/**
+ * Replace a repo's topic set with the supplied list.
+ *
+ * Calls `PUT /repos/{owner}/{name}/topics` — GitHub replaces the full
+ * set atomically, so the config is always the source of truth.
+ */
+export async function syncTopics(rest: RestClient, repo: string, topics: string[]): Promise<string> {
+	const { owner, name } = parseRepo(repo);
+
+	await rest.request<void>(`/repos/${owner}/${name}/topics`, {
+		method: "PUT",
+		body: { names: topics },
+	});
+
+	return `${topics.length} topics set`;
+}


### PR DESCRIPTION
## Summary

Implements Steps 1–5 of the [tech-repo-metadata spec](.notes/tech-repo-metadata.spec.md).

- **Step 1** — `RepoConfig` union type in `config.ts`: `project.repo` now accepts `string | RepoConfig` (with `name`, `protection`, `requiredChecks`, `topics`, `properties`). `PluginLoader` extracts `repo.name` when the object form is used. `RepoPolicyConfig` fields are `@deprecated` — the migration shim is preserved for rollout.
- **Step 2** — `syncProperties` in `holocron-plugin-github`: calls `PATCH /repos/{owner}/{name}/properties/values`.
- **Step 3** — `syncTopics` in `holocron-plugin-github`: calls `PUT /repos/{owner}/{name}/topics`.
- **Step 4** — Optional `syncProperties?` and `syncTopics?` added to the `Source` interface. `GitHubSource` implements both.
- **Step 5** — `runSetup` derives and syncs properties (`branch_protection_level`, `monorepo`, plus manual fields from `repo.properties`) and topics after the labels step.

## Test plan

- [ ] All 251 existing tests pass (`pnpm test`)
- [ ] `pnpm typecheck` clean across `@theholocron/cli` and `@theholocron/holocron-plugin-github`
- [ ] Step 6 (migrate the five `holocron.config.ts` files) and Step 7 (drop `repoPolicy`) to follow in a subsequent PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->