### PR TITLE
chore(config): drop repoPolicy (Step 7)

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -488,11 +488,11 @@ describe("runSetup", () => {
 		expect(defaultSetupEnabled).toBe(true);
 	});
 
-	it("applies balanced repo settings + creates a ruleset when repoPolicy.preset is 'balanced'", async () => {
+	it("applies balanced repo settings + creates a ruleset when repo.protection is 'balanced'", async () => {
 		let settingsApplied: Record<string, unknown> | null = null;
 		let rulesetCreated: Record<string, unknown> | null = null;
 		const loaded = loadedFrom({
-			project: { name: "demo", repoPolicy: { preset: "balanced" } },
+			project: { name: "demo", repo: { name: "theholocron/demo", protection: "balanced" } },
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -535,12 +535,12 @@ describe("runSetup", () => {
 		expect(policySteps[0]?.status).toBe("ok");
 	});
 
-	it("derives required_status_checks from configured workflows when preset is 'strict'", async () => {
+	it("derives required_status_checks from configured workflows when repo.protection is 'strict'", async () => {
 		let rulesetPayload: Record<string, unknown> | null = null;
 		const loaded = loadedFrom({
 			project: {
 				name: "demo",
-				repoPolicy: { preset: "strict" },
+				repo: { name: "theholocron/demo", protection: "strict" },
 				workflows: ["lint", "test", "typecheck"],
 			},
 			providers: { vault: "1password", source: "github" },
@@ -587,7 +587,7 @@ describe("runSetup", () => {
 		const loaded = loadedFrom({
 			project: {
 				name: "demo",
-				repoPolicy: { preset: "strict", requiredChecks: ["some-extra-check"] },
+				repo: { name: "theholocron/demo", protection: "strict", requiredChecks: ["some-extra-check"] },
 				workflows: ["lint"],
 			},
 			providers: { vault: "1password", source: "github" },
@@ -630,7 +630,7 @@ describe("runSetup", () => {
 		const created: unknown[] = [];
 		const updated: unknown[] = [];
 		const loaded = loadedFrom({
-			project: { name: "demo", repoPolicy: { preset: "balanced" } },
+			project: { name: "demo", repo: { name: "theholocron/demo", protection: "balanced" } },
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -671,10 +671,10 @@ describe("runSetup", () => {
 		expect(rulesetStep?.message).toBe("updated");
 	});
 
-	it("skips repo policy steps when preset is 'none'", async () => {
+	it("skips repo policy steps when repo.protection is 'none'", async () => {
 		let settingsCalled = false;
 		const loaded = loadedFrom({
-			project: { name: "demo", repoPolicy: { preset: "none" } },
+			project: { name: "demo", repo: { name: "theholocron/demo", protection: "none" } },
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -706,7 +706,7 @@ describe("runSetup", () => {
 		expect(report.steps.some((s) => s.step.includes("ruleset"))).toBe(false);
 	});
 
-	it("skips repo policy steps when no repoPolicy in config", async () => {
+	it("skips repo policy steps when no protection in config", async () => {
 		let settingsCalled = false;
 		const loaded = loadedFrom({
 			project: { name: "demo" },

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -374,7 +374,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	const dryRun = input.context.dryRun ?? false;
 	const steps: SetupStepResult[] = [];
 	const repo = config.project.repo;
-	const effectivePreset = repo?.protection ?? config.project.repoPolicy?.preset;
+	const effectivePreset = repo?.protection;
 
 	print(`Holocron setup — ${config.project.name}${dryRun ? " (dry-run)" : ""}`);
 	print(`  config: ${input.loaded.filepath}`);
@@ -437,7 +437,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 								const ctx = WORKFLOW_CHECK_CONTEXTS[name];
 								return ctx ? [ctx] : [];
 							}),
-							...(repo?.requiredChecks ?? config.project.repoPolicy?.requiredChecks ?? []),
+							...(repo?.requiredChecks ?? []),
 						]
 					: [];
 			steps.push(await upsertBranchProtection(source, dryRun, requiredChecks));
@@ -501,7 +501,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	}
 
 	// ── source: alex config ───────────────────────────────────────────────
-	// Always written — not gated on repoPolicy since all prose benefits from
+	// Always written — not gated on protection since all prose benefits from
 	// a consistent allow-list. Update ALEX_CONFIG above to propagate changes.
 	if (loader.has("source")) {
 		const source = loader.get("source") as Source;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -58,26 +58,6 @@ export type RawProviderEntry = SingleEntry | MultiEntry;
 
 export type RawProvidersConfig = Partial<Record<CapabilityKey, RawProviderEntry>>;
 
-export interface RepoPolicyConfig {
-	/**
-	 * "balanced" — squash-only merges, delete-branch-on-merge, issues/discussions/projects
-	 * enabled, auto-merge enabled, web sign-off required, always suggest updating, no wiki;
-	 * plus a ruleset that blocks force-push + deletion and requires a pull request (0 reviews).
-	 *
-	 * "strict" — everything in "balanced" plus required status checks from `requiredChecks`.
-	 *
-	 * "none" — skips repo settings + ruleset entirely.
-	 *
-	 * @default "balanced"
-	 * @deprecated Use `project.repo.protection` instead.
-	 */
-	preset?: "balanced" | "strict" | "none";
-	/**
-	 * CI check context names required on the default branch (used by "strict").
-	 * @deprecated Use `project.repo.requiredChecks` instead.
-	 */
-	requiredChecks?: string[];
-}
 
 export type RepoProtection = "balanced" | "strict" | "none";
 
@@ -125,12 +105,6 @@ export interface HolocronConfig {
 		 * `--repo` on the command line still overrides.
 		 */
 		repo?: RepoConfig;
-		/**
-		 * Repo-level policy applied by `holocron setup`. Defines merge
-		 * strategy, branch protection rulesets, and security defaults.
-		 * Requires `source` capability to be configured.
-		 */
-		repoPolicy?: RepoPolicyConfig;
 		/**
 		 * CI workflow names to install as thin wrappers during `holocron setup`.
 		 * Each name maps to a reusable workflow in `theholocron/.github`.

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -58,7 +58,6 @@ export type RawProviderEntry = SingleEntry | MultiEntry;
 
 export type RawProvidersConfig = Partial<Record<CapabilityKey, RawProviderEntry>>;
 
-
 export type RepoProtection = "balanced" | "strict" | "none";
 
 export interface RepoProperties {

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -183,9 +183,7 @@ export class PluginLoader {
 	 */
 	private projectDefaults(): Partial<RuntimeContext> {
 		const defaults: Partial<RuntimeContext> = {};
-		const repo = this.config.project.repo;
-		// Runtime guard: JSON configs may still carry the old string form during rollout.
-		if (repo) defaults.repo = typeof repo === "string" ? repo : repo.name;
+		if (this.config.project.repo) defaults.repo = this.config.project.repo.name;
 		return defaults;
 	}
 }

--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -235,7 +235,7 @@ jobs:
         id: metadata
 
       - run: gh pr merge --auto --squash "$PR_URL"
-        # --squash is intentional: repoPolicy sets allow_merge_commit: false,
+        # --squash is intentional: repo protection sets allow_merge_commit: false,
         # so --merge would fail on any repo using the standard preset.
         name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'


### PR DESCRIPTION
## Summary

Final step of the unified repo metadata spec. All five repos have migrated to `project.repo` object form (`holocron` + `configs` + `clients` in #145; `.github` and `.github-private` in their own PRs), so the migration shim can be removed.

- Deletes `RepoPolicyConfig` interface and `project.repoPolicy` field from `HolocronConfig`
- Removes the runtime `typeof repo === "string"` guard in `loader.ts`
- `effectivePreset` now reads `repo?.protection` only (no `repoPolicy` fallback)
- `requiredChecks` now reads `repo?.requiredChecks` only
- Updates all `setup.test.ts` tests from `repoPolicy` to `repo.protection` form
- Cleans up stale comment in `templates/index.ts`

## Depends on

#145 (merged)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->