### PR TITLE
chore(config): add HolocronConfig type to self-hosted config

### DIFF
--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "@theholocron/cli";
+import type { HolocronConfig } from "@theholocron/cli";
 
 export default defineConfig({
 	project: {
@@ -36,4 +37,4 @@ export default defineConfig({
 		environments: "github",
 		issues: ["github", { labels: { inProgress: "status:in-progress", inReview: "status:in-review" } }],
 	},
-});
+} satisfies HolocronConfig);


### PR DESCRIPTION
## Summary

Adds `import type { HolocronConfig }` and `satisfies HolocronConfig` to the repo's own `holocron.config.ts` for explicit in-file typing, consistent with the configs and clients repos.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->