### PR TITLE
feat(cli): migrate plugin-github and sync-github to @theholocron/github-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
     "typescript": "catalog:",
     "typescript-eslint": "^8.62.1"
   },
+  "pnpm": {
+    "overrides": {
+      "@theholocron/http-client": "^0.3.2"
+    }
+  },
   "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": ">=22",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,8 @@
   },
   "dependencies": {
     "@napi-rs/keyring": "^1.3.0",
-    "@theholocron/http-client": "^0.1.0",
+    "@theholocron/github-client": "^0.3.2",
+    "@theholocron/http-client": "^0.3.2",
     "tsx": "catalog:",
     "yargs": "^18.0.0"
   },

--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -277,7 +277,7 @@ describe("runSyncGithub", () => {
 			fetch: fn,
 		});
 		expect(report.status).toBe("fail");
-		expect(report.message).toContain("Forbidden");
+		expect(report.message).toContain("403");
 		expect(blobCalls).toBe(1);
 	});
 
@@ -346,7 +346,7 @@ describe("runSyncGithub", () => {
 			fetch: fn,
 		});
 		expect(report.status).toBe("fail");
-		expect(report.message).toContain("not found");
+		expect(report.message).toContain("404");
 	});
 
 	it("fails when the tree creation returns an error", async () => {

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -238,9 +238,7 @@ export async function runSyncGithub(input: RunSyncGithubInput): Promise<SyncGith
 		const commit = await client.git.getCommit(repo, headSha);
 		baseTreeSha = commit.tree.sha;
 		const treeData = await client.git.getTree(repo, baseTreeSha, true);
-		existingBlobs = new Map(
-			treeData.tree.filter((i) => i.type === "blob").map((i) => [i.path, i.sha])
-		);
+		existingBlobs = new Map(treeData.tree.filter((i) => i.type === "blob").map((i) => [i.path, i.sha]));
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : `Branch ${baseBranch} not found`;
 		print(`  ✗ ${msg}`);
@@ -256,9 +254,9 @@ export async function runSyncGithub(input: RunSyncGithubInput): Promise<SyncGith
 
 			try {
 				const data = await client.git.getContents(repo, "holocron.config.json");
-				const raw = JSON.parse(
-					Buffer.from(data.content.replace(/\n/g, ""), "base64").toString("utf8")
-				) as { project?: { workflows?: Array<string | WorkflowEntry> } };
+				const raw = JSON.parse(Buffer.from(data.content.replace(/\n/g, ""), "base64").toString("utf8")) as {
+					project?: { workflows?: Array<string | WorkflowEntry> };
+				};
 				entries = (raw?.project?.workflows ?? []).map((w) => (typeof w === "string" ? { name: w } : w));
 			} catch (err) {
 				if (!(err instanceof ProviderApiError) || err.status !== 404) throw err;
@@ -384,9 +382,7 @@ export async function runSyncGithub(input: RunSyncGithubInput): Promise<SyncGith
 			print(`  → PR opened: ${prUrl}`);
 		} catch (err) {
 			const alreadyExists =
-				err instanceof ProviderApiError &&
-				err.status === 422 &&
-				String(err.details).includes("already exists");
+				err instanceof ProviderApiError && err.status === 422 && String(err.details).includes("already exists");
 			if (alreadyExists) {
 				print(`  → PR already open for ${branch} — branch updated, ready to merge`);
 			} else {

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -2,11 +2,13 @@ import { createHash } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
+import { createGitHubClient } from "@theholocron/github-client";
+import { ProviderApiError } from "@theholocron/http-client";
+
 import { ACTIONS, REUSABLE_WORKFLOWS, WORKFLOW_TEMPLATE_PROPERTIES } from "../templates/index.js";
 import { WORKFLOW_TEMPLATES, generateThinCallerContent } from "./setup-workflows.js";
 
 const DEFAULT_REPO = "theholocron/.github";
-const API_BASE = "https://api.github.com";
 
 export type SyncGithubStatus = "ok" | "fail" | "dry-run";
 
@@ -74,7 +76,6 @@ function parseWorkflowsFromTs(source: string): WorkflowEntry[] {
 	const objSpans: Array<[number, number]> = [];
 
 	// Pass 1: object entries — { name: "foo", with: { ... } }
-	// The `with` value must be a flat object (no nested braces) to keep the regex simple.
 	const objRe = /\{\s*name\s*:\s*"([^"]+)"(?:\s*,\s*with\s*:\s*(\{[^}]*\}))?\s*\}/g;
 	let m: RegExpExecArray | null;
 	while ((m = objRe.exec(body)) !== null) {
@@ -135,10 +136,6 @@ function buildBatch(
 	const files: FileBatch = [];
 	const isPrimaryGithubRepo = repo === DEFAULT_REPO;
 
-	// Composite actions → .github/actions/<name>/action.yml
-	// Only the primary .github repo needs these — reusable workflows reference
-	// them via the full path `theholocron/.github/.github/actions/setup@main`,
-	// so no other repo needs a local copy.
 	if (isPrimaryGithubRepo) {
 		for (const [name, content] of Object.entries(ACTIONS)) {
 			files.push({
@@ -149,8 +146,6 @@ function buildBatch(
 	}
 
 	if (isPrimaryGithubRepo) {
-		// Reusable workflow definitions → .github/workflows/<name>.yml
-		// Only .github hosts the implementations; all other repos call them via uses:.
 		for (const [name, content] of Object.entries(REUSABLE_WORKFLOWS)) {
 			files.push({
 				path: `.github/workflows/${name}.yml`,
@@ -158,8 +153,6 @@ function buildBatch(
 			});
 		}
 
-		// Workflow templates (starter templates for the Actions UI) → workflow-templates/
-		// Only the primary .github repo surfaces these in GitHub's "New workflow" picker.
 		for (const [name, content] of Object.entries(WORKFLOW_TEMPLATES)) {
 			files.push({
 				path: `workflow-templates/${name}.yml`,
@@ -174,9 +167,6 @@ function buildBatch(
 			}
 		}
 	} else {
-		// Secondary repos get thin callers in .github/workflows/ that delegate to
-		// .github's reusable implementations. The config may restrict which workflows
-		// a repo receives via project.workflows; undefined means all.
 		for (const name of Object.keys(REUSABLE_WORKFLOWS)) {
 			if (allowedWorkflows && !allowedWorkflows.has(name)) continue;
 			const content = generateThinCallerContent(name, withOverrides?.get(name));
@@ -200,17 +190,10 @@ export function gitBlobSha(content: string): string {
 export async function runSyncGithub(input: RunSyncGithubInput): Promise<SyncGithubReport> {
 	const print = input.print ?? ((line: string) => console.log(line));
 	const repo = input.repo ?? DEFAULT_REPO;
-	const [owner, repoName] = repo.split("/");
 	const { token, dryRun = false, branch, createPr = false } = input;
 	const message = input.message ?? `chore: sync from theholocron/holocron`;
-	const fetchFn = input.fetch ?? globalThis.fetch;
 
-	const headers = {
-		Authorization: `Bearer ${token}`,
-		Accept: "application/vnd.github+json",
-		"Content-Type": "application/json",
-		"X-GitHub-Api-Version": "2022-11-28",
-	};
+	const client = createGitHubClient({ token, fetch: input.fetch });
 
 	print(`holocron sync-github${dryRun ? " (dry-run)" : ""}`);
 	print(`  repo:   ${repo}`);
@@ -218,8 +201,6 @@ export async function runSyncGithub(input: RunSyncGithubInput): Promise<SyncGith
 	print("");
 
 	// ── output-dir: write all files to disk without any API calls ───────────
-	// Always generates the full unfiltered batch — used for local validation
-	// (actionlint smoke test) where we want to check every template.
 	if (input.outputDir) {
 		const batch = buildBatch(repo);
 		for (const file of batch) {
@@ -232,76 +213,62 @@ export async function runSyncGithub(input: RunSyncGithubInput): Promise<SyncGith
 	}
 
 	// ── 1. Resolve target branch ─────────────────────────────────────────────
-	// When opening a PR, the commit is based on the default branch and the
-	// PR branch (--branch) is created fresh. For direct pushes, --branch is
-	// used as-is (falls back to default if omitted).
 	let targetBranch = branch;
 	let defaultBranch: string | undefined;
 	if (!targetBranch || createPr) {
-		const repoRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}`, { headers });
-		if (!repoRes.ok) {
+		try {
+			const repoData = await client.repos.getRepo(repo);
+			defaultBranch = repoData.default_branch;
+			if (!targetBranch) targetBranch = defaultBranch;
+		} catch {
 			const msg = "failed to fetch repo metadata";
 			print(`  ✗ ${msg}`);
 			return { status: "fail", created: 0, updated: 0, unchanged: 0, message: msg };
 		}
-		const repoData = (await repoRes.json()) as { default_branch: string };
-		defaultBranch = repoData.default_branch;
-		if (!targetBranch) targetBranch = defaultBranch;
 	}
 
 	// ── 2. Get HEAD commit → base tree ───────────────────────────────────────
-	// Always read existing state from the default branch when creating a PR.
-	const baseBranch = createPr && defaultBranch ? defaultBranch : targetBranch;
-	const refRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/git/ref/heads/${baseBranch}`, { headers });
-	if (!refRes.ok) {
-		const msg = `Branch ${baseBranch} not found`;
+	const baseBranch = createPr && defaultBranch ? defaultBranch : targetBranch!;
+	let headSha: string;
+	let baseTreeSha: string;
+	let existingBlobs: Map<string, string>;
+	try {
+		const ref = await client.git.getRef(repo, baseBranch);
+		headSha = ref.object.sha;
+		const commit = await client.git.getCommit(repo, headSha);
+		baseTreeSha = commit.tree.sha;
+		const treeData = await client.git.getTree(repo, baseTreeSha, true);
+		existingBlobs = new Map(
+			treeData.tree.filter((i) => i.type === "blob").map((i) => [i.path, i.sha])
+		);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : `Branch ${baseBranch} not found`;
 		print(`  ✗ ${msg}`);
 		return { status: "fail", created: 0, updated: 0, unchanged: 0, message: msg };
 	}
-	const {
-		object: { sha: headSha },
-	} = (await refRes.json()) as { object: { sha: string } };
-
-	const commitRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/git/commits/${headSha}`, { headers });
-	const {
-		tree: { sha: baseTreeSha },
-	} = (await commitRes.json()) as { tree: { sha: string } };
-
-	const treeRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/git/trees/${baseTreeSha}?recursive=1`, {
-		headers,
-	});
-	const { tree: existingTree } = (await treeRes.json()) as {
-		tree: Array<{ path: string; sha: string; type: string }>;
-	};
-	const existingBlobs = new Map(existingTree.filter((i) => i.type === "blob").map((i) => [i.path, i.sha]));
 
 	// ── 3. Fetch workflow allowlist + per-workflow overrides from target repo ─
-	// Reads holocron.config.json first; falls back to holocron.config.ts.
-	// If present and non-empty, only listed workflows are synced.
-	// Object entries ({ name, with }) also carry per-caller with: overrides.
 	let allowedWorkflows: Set<string> | undefined;
 	let withOverrides: Map<string, Record<string, unknown>> | undefined;
 	if (repo !== DEFAULT_REPO) {
 		try {
 			let entries: WorkflowEntry[] = [];
 
-			const jsonRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/contents/holocron.config.json`, {
-				headers,
-			});
-			if (jsonRes.ok) {
-				const data = (await jsonRes.json()) as { content: string };
-				const raw = JSON.parse(Buffer.from(data.content.replace(/\n/g, ""), "base64").toString("utf8")) as {
-					project?: { workflows?: Array<string | WorkflowEntry> };
-				};
+			try {
+				const data = await client.git.getContents(repo, "holocron.config.json");
+				const raw = JSON.parse(
+					Buffer.from(data.content.replace(/\n/g, ""), "base64").toString("utf8")
+				) as { project?: { workflows?: Array<string | WorkflowEntry> } };
 				entries = (raw?.project?.workflows ?? []).map((w) => (typeof w === "string" ? { name: w } : w));
-			} else {
-				const tsRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/contents/holocron.config.ts`, {
-					headers,
-				});
-				if (tsRes.ok) {
-					const data = (await tsRes.json()) as { content: string };
+			} catch (err) {
+				if (!(err instanceof ProviderApiError) || err.status !== 404) throw err;
+				// Fall back to .ts config
+				try {
+					const data = await client.git.getContents(repo, "holocron.config.ts");
 					const source = Buffer.from(data.content.replace(/\n/g, ""), "base64").toString("utf8");
 					entries = parseWorkflowsFromTs(source);
+				} catch {
+					// No config — sync all workflows with no overrides
 				}
 			}
 
@@ -311,7 +278,7 @@ export async function runSyncGithub(input: RunSyncGithubInput): Promise<SyncGith
 				if (overrideEntries.length > 0) withOverrides = new Map(overrideEntries);
 			}
 		} catch {
-			// No config or parse error — sync all workflows with no overrides
+			// Parse error — sync all workflows with no overrides
 		}
 	}
 
@@ -352,77 +319,53 @@ export async function runSyncGithub(input: RunSyncGithubInput): Promise<SyncGith
 	// ── 6. Create blobs for changed files ────────────────────────────────────
 	const treeEntries: Array<{ path: string; mode: string; type: string; sha: string }> = [];
 	for (const file of changedFiles) {
-		const blobRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/git/blobs`, {
-			method: "POST",
-			headers,
-			body: JSON.stringify({ content: file.content, encoding: "utf-8" }),
-		});
-		if (!blobRes.ok) {
-			const err = (await blobRes.json()) as { message?: string };
-			const msg = `failed to create blob for ${file.path}: ${err.message ?? blobRes.status}`;
+		try {
+			const blob = await client.git.createBlob(repo, file.content);
+			treeEntries.push({ path: file.path, mode: "100644", type: "blob", sha: blob.sha });
+		} catch (err) {
+			const msg = `failed to create blob for ${file.path}: ${err instanceof Error ? err.message : String(err)}`;
 			print(`  ✗ ${msg}`);
 			return { status: "fail", created, updated, unchanged, message: msg };
 		}
-		const { sha: blobSha } = (await blobRes.json()) as { sha: string };
-		treeEntries.push({ path: file.path, mode: "100644", type: "blob", sha: blobSha });
 	}
 
 	// ── 7. Create tree ───────────────────────────────────────────────────────
-	const newTreeRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/git/trees`, {
-		method: "POST",
-		headers,
-		body: JSON.stringify({ base_tree: baseTreeSha, tree: treeEntries }),
-	});
-	if (!newTreeRes.ok) {
-		const err = (await newTreeRes.json()) as { message?: string };
-		const msg = `failed to create tree: ${err.message ?? newTreeRes.status}`;
+	let newTreeSha: string;
+	try {
+		const newTree = await client.git.createTree(repo, treeEntries, baseTreeSha);
+		newTreeSha = newTree.sha;
+	} catch (err) {
+		const msg = `failed to create tree: ${err instanceof Error ? err.message : String(err)}`;
 		print(`  ✗ ${msg}`);
 		return { status: "fail", created, updated, unchanged, message: msg };
 	}
-	const { sha: newTreeSha } = (await newTreeRes.json()) as { sha: string };
 
 	// ── 8. Create commit ─────────────────────────────────────────────────────
-	const newCommitRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/git/commits`, {
-		method: "POST",
-		headers,
-		body: JSON.stringify({ message, tree: newTreeSha, parents: [headSha] }),
-	});
-	if (!newCommitRes.ok) {
-		const err = (await newCommitRes.json()) as { message?: string };
-		const msg = `failed to create commit: ${err.message ?? newCommitRes.status}`;
+	let newCommitSha: string;
+	try {
+		const newCommit = await client.git.createCommit(repo, message, newTreeSha, [headSha]);
+		newCommitSha = newCommit.sha;
+	} catch (err) {
+		const msg = `failed to create commit: ${err instanceof Error ? err.message : String(err)}`;
 		print(`  ✗ ${msg}`);
 		return { status: "fail", created, updated, unchanged, message: msg };
 	}
-	const { sha: newCommitSha } = (await newCommitRes.json()) as { sha: string };
 
 	// ── 9. Update (or create) branch ref ────────────────────────────────────
-	// For PR mode: try to create the branch; if it already exists from a
-	// previous partial run, force-update it instead.
-	// For direct push: fast-forward the existing branch.
-	let refUpdateRes: Response;
-	if (createPr && branch) {
-		refUpdateRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/git/refs`, {
-			method: "POST",
-			headers,
-			body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: newCommitSha }),
-		});
-		if (refUpdateRes.status === 422) {
-			refUpdateRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/git/refs/heads/${branch}`, {
-				method: "PATCH",
-				headers,
-				body: JSON.stringify({ sha: newCommitSha, force: true }),
-			});
+	try {
+		if (createPr && branch) {
+			try {
+				await client.git.createRef(repo, `refs/heads/${branch}`, newCommitSha);
+			} catch (err) {
+				if (!(err instanceof ProviderApiError) || err.status !== 422) throw err;
+				// Branch already exists from a previous partial run — force-update it.
+				await client.git.updateRef(repo, `heads/${branch}`, newCommitSha, true);
+			}
+		} else {
+			await client.git.updateRef(repo, `heads/${targetBranch!}`, newCommitSha);
 		}
-	} else {
-		refUpdateRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/git/refs/heads/${targetBranch}`, {
-			method: "PATCH",
-			headers,
-			body: JSON.stringify({ sha: newCommitSha }),
-		});
-	}
-	if (!refUpdateRes.ok) {
-		const err = (await refUpdateRes.json()) as { message?: string };
-		const msg = `failed to update ref: ${err.message ?? refUpdateRes.status}`;
+	} catch (err) {
+		const msg = `failed to update ref: ${err instanceof Error ? err.message : String(err)}`;
 		print(`  ✗ ${msg}`);
 		return { status: "fail", created, updated, unchanged, message: msg };
 	}
@@ -430,28 +373,24 @@ export async function runSyncGithub(input: RunSyncGithubInput): Promise<SyncGith
 	// ── 10. Open PR if requested ─────────────────────────────────────────────
 	let prUrl: string | undefined;
 	if (branch && createPr && !dryRun) {
-		const prRes = await fetchFn(`${API_BASE}/repos/${owner}/${repoName}/pulls`, {
-			method: "POST",
-			headers,
-			body: JSON.stringify({
-				title: message.split("\n")[0],
+		try {
+			const pr = await client.git.createPull(repo, {
+				title: message.split("\n")[0]!,
 				head: branch,
 				base: "main",
 				body: "Auto-generated by `holocron sync-github`. Review and merge to apply template updates.",
-			}),
-		});
-
-		if (prRes.ok) {
-			const pr = (await prRes.json()) as { html_url: string };
+			});
 			prUrl = pr.html_url;
 			print(`  → PR opened: ${prUrl}`);
-		} else {
-			const err = (await prRes.json()) as { message?: string; errors?: Array<{ message: string }> };
-			const alreadyExists = err.errors?.some((e) => e.message.includes("already exists"));
+		} catch (err) {
+			const alreadyExists =
+				err instanceof ProviderApiError &&
+				err.status === 422 &&
+				String(err.details).includes("already exists");
 			if (alreadyExists) {
 				print(`  → PR already open for ${branch} — branch updated, ready to merge`);
 			} else {
-				print(`  ⚠ PR creation failed: ${err.message ?? prRes.status}`);
+				print(`  ⚠ PR creation failed: ${err instanceof Error ? err.message : String(err)}`);
 			}
 		}
 	}

--- a/packages/holocron-plugin-github/package.json
+++ b/packages/holocron-plugin-github/package.json
@@ -26,13 +26,15 @@
     "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
-    "@theholocron/cli": "workspace:*"
+    "@theholocron/cli": "workspace:*",
+    "@theholocron/github-client": "^0.3.2"
   },
   "dependencies": {
     "libsodium-wrappers": "^0.7.15"
   },
   "devDependencies": {
     "@theholocron/cli": "workspace:*",
+    "@theholocron/github-client": "^0.3.2",
     "@types/node": "catalog:",
     "@theholocron/eslint-config": "catalog:",
     "@theholocron/tsconfig": "catalog:",

--- a/packages/holocron-plugin-github/src/__tests__/ci.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/ci.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { GitHubCi } from "../capabilities/ci.js";
-import { createGitHubRestClient } from "../rest.js";
+import { createGitHubClient } from "../rest.js";
 
 import { stubFetch } from "./helpers.js";
 
@@ -9,7 +9,7 @@ const REPO = "theholocron/holocron";
 
 function makeCi(responses: Parameters<typeof stubFetch>[0]) {
 	const { fetch, calls } = stubFetch(responses);
-	const rest = createGitHubRestClient({ token: "pat", fetch });
+	const rest = createGitHubClient({ token: "pat", fetch });
 	const ci = new GitHubCi(rest, { repo: REPO });
 	return { ci, calls };
 }

--- a/packages/holocron-plugin-github/src/__tests__/environments.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/environments.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { GitHubEnvironments } from "../capabilities/environments.js";
-import { createGitHubRestClient } from "../rest.js";
+import { createGitHubClient } from "../rest.js";
 
 import { stubFetch } from "./helpers.js";
 
@@ -9,7 +9,7 @@ const REPO = "theholocron/holocron";
 
 function makeEnvs(responses: Parameters<typeof stubFetch>[0]) {
 	const { fetch, calls } = stubFetch(responses);
-	const rest = createGitHubRestClient({ token: "pat", fetch });
+	const rest = createGitHubClient({ token: "pat", fetch });
 	const envs = new GitHubEnvironments(rest, { repo: REPO });
 	return { envs, calls };
 }

--- a/packages/holocron-plugin-github/src/__tests__/issues.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/issues.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { GitHubIssues } from "../capabilities/issues.js";
-import { createGitHubRestClient } from "../rest.js";
+import { createGitHubClient } from "../rest.js";
 
 import { stubFetch } from "./helpers.js";
 
@@ -10,7 +10,7 @@ const LABELS = { inProgress: "status:in-progress", inReview: "status:in-review" 
 
 function makeIssues(responses: Parameters<typeof stubFetch>[0]) {
 	const { fetch, calls } = stubFetch(responses);
-	const rest = createGitHubRestClient({ token: "pat", fetch });
+	const rest = createGitHubClient({ token: "pat", fetch });
 	const issues = new GitHubIssues(rest, { repo: REPO, labels: LABELS });
 	return { issues, calls };
 }
@@ -227,7 +227,8 @@ describe("GitHubIssues.create", () => {
 			{ status: 201, body: rawIssue({ number: 101 }) },
 		]);
 		await issues.create({ summary: "x", milestone: "V0.1 — feature parity" });
-		expect(calls[0]?.url).toContain("/milestones?state=all");
+		expect(calls[0]?.url).toContain("/milestones")
+		expect(calls[0]?.url).toContain("state=all");
 		expect(calls[1]?.body).toMatchObject({ milestone: 12 });
 	});
 
@@ -377,7 +378,7 @@ describe("GitHubIssues.doctor", () => {
 
 function makeIssuesNoLabels(responses: Parameters<typeof stubFetch>[0]) {
 	const { fetch, calls } = stubFetch(responses);
-	const rest = createGitHubRestClient({ token: "pat", fetch });
+	const rest = createGitHubClient({ token: "pat", fetch });
 	const issues = new GitHubIssues(rest, { repo: REPO });
 	return { issues, calls };
 }

--- a/packages/holocron-plugin-github/src/__tests__/issues.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/issues.test.ts
@@ -227,7 +227,7 @@ describe("GitHubIssues.create", () => {
 			{ status: 201, body: rawIssue({ number: 101 }) },
 		]);
 		await issues.create({ summary: "x", milestone: "V0.1 — feature parity" });
-		expect(calls[0]?.url).toContain("/milestones")
+		expect(calls[0]?.url).toContain("/milestones");
 		expect(calls[0]?.url).toContain("state=all");
 		expect(calls[1]?.body).toMatchObject({ milestone: 12 });
 	});

--- a/packages/holocron-plugin-github/src/__tests__/labels.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/labels.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { syncLabels, type CanonicalLabel } from "../capabilities/labels.js";
-import { createGitHubRestClient } from "../rest.js";
+import { createGitHubClient } from "../rest.js";
 
 import { stubFetch } from "./helpers.js";
 
@@ -17,7 +17,7 @@ const STALE = ["github_actions", "javascript"];
 
 function makeRest(responses: Parameters<typeof stubFetch>[0]) {
 	const { fetch, calls } = stubFetch(responses);
-	const rest = createGitHubRestClient({ token: "pat", fetch });
+	const rest = createGitHubClient({ token: "pat", fetch });
 	return { rest, calls };
 }
 

--- a/packages/holocron-plugin-github/src/__tests__/properties.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/properties.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { syncProperties } from "../capabilities/properties.js";
-import { createGitHubRestClient } from "../rest.js";
+import { createGitHubClient } from "../rest.js";
 
 import { stubFetch } from "./helpers.js";
 
@@ -9,7 +9,7 @@ const REPO = "theholocron/holocron";
 
 function makeRest(responses: Parameters<typeof stubFetch>[0]) {
 	const { fetch, calls } = stubFetch(responses);
-	const rest = createGitHubRestClient({ token: "pat", fetch });
+	const rest = createGitHubClient({ token: "pat", fetch });
 	return { rest, calls };
 }
 

--- a/packages/holocron-plugin-github/src/__tests__/rest.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/rest.test.ts
@@ -1,18 +1,18 @@
 import { ProviderApiError } from "@theholocron/cli";
 import { describe, expect, it } from "vitest";
 
-import { createGitHubRestClient } from "../rest.js";
+import { createGitHubClient } from "../rest.js";
 
 import { stubFetch } from "./helpers.js";
 
 const TOKEN = "gh_pat_test";
 
-describe("GitHubRestClient", () => {
+describe("GitHubClient HTTP plumbing", () => {
 	it("sends the bearer token and api-version headers on GET", async () => {
-		const { fetch, calls } = stubFetch([{ status: 200, body: { login: "iamnewton" } }]);
-		const client = createGitHubRestClient({ token: TOKEN, fetch });
-		const result = await client.request<{ login: string }>("/user");
-		expect(result).toEqual({ login: "iamnewton" });
+		const { fetch, calls } = stubFetch([{ status: 200, body: { login: "iamnewton", name: null, email: null } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.user.getCurrentUser();
+		expect(result.login).toBe("iamnewton");
 		expect(calls[0]?.url).toBe("https://api.github.com/user");
 		expect(calls[0]?.method).toBe("GET");
 		expect(calls[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
@@ -21,32 +21,25 @@ describe("GitHubRestClient", () => {
 	});
 
 	it("serializes a body on POST and sets content-type", async () => {
-		const { fetch, calls } = stubFetch([{ status: 201, body: { id: 1 } }]);
-		const client = createGitHubRestClient({ token: TOKEN, fetch });
-		await client.request("/repos/x/y/issues", { method: "POST", body: { title: "hi" } });
+		const { fetch, calls } = stubFetch([{ status: 201, body: { name: "bug", color: "d73a4a", description: null } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		await client.labels.createLabel("x/y", { name: "bug", color: "d73a4a", description: "A bug" });
 		expect(calls[0]?.method).toBe("POST");
-		expect(calls[0]?.body).toEqual({ title: "hi" });
+		expect(calls[0]?.body).toMatchObject({ name: "bug", color: "d73a4a" });
 		expect(calls[0]?.headers["content-type"]).toBe("application/json");
 	});
 
 	it("returns undefined for 204 responses", async () => {
 		const { fetch } = stubFetch([{ status: 204 }]);
-		const client = createGitHubRestClient({ token: TOKEN, fetch });
-		const result = await client.request("/repos/x/y/secrets/PROD", { method: "PUT" });
-		expect(result).toBeUndefined();
-	});
-
-	it("returns undefined when expectNoContent is set even on 200", async () => {
-		const { fetch } = stubFetch([{ status: 200 }]);
-		const client = createGitHubRestClient({ token: TOKEN, fetch });
-		const result = await client.request("/repos/x/y/something", { expectNoContent: true });
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const result = await client.security.enableVulnerabilityAlerts("x/y");
 		expect(result).toBeUndefined();
 	});
 
 	it("throws ProviderApiError on non-2xx with status + details", async () => {
 		const { fetch } = stubFetch([{ status: 401, text: "bad creds" }]);
-		const client = createGitHubRestClient({ token: TOKEN, fetch });
-		const err = await client.request("/user").catch((e: unknown) => e);
+		const client = createGitHubClient({ token: TOKEN, fetch });
+		const err = await client.user.getCurrentUser().catch((e: unknown) => e);
 		expect(err).toBeInstanceOf(ProviderApiError);
 		const pae = err as ProviderApiError;
 		expect(pae.status).toBe(401);
@@ -55,13 +48,9 @@ describe("GitHubRestClient", () => {
 	});
 
 	it("strips trailing slashes from baseUrl override", async () => {
-		const { fetch, calls } = stubFetch([{ status: 200, body: {} }]);
-		const client = createGitHubRestClient({
-			token: TOKEN,
-			fetch,
-			baseUrl: "https://example.test/api/",
-		});
-		await client.request("/foo");
-		expect(calls[0]?.url).toBe("https://example.test/api/foo");
+		const { fetch, calls } = stubFetch([{ status: 200, body: { login: "x", name: null, email: null } }]);
+		const client = createGitHubClient({ token: TOKEN, fetch, baseUrl: "https://example.test/api/" });
+		await client.user.getCurrentUser();
+		expect(calls[0]?.url).toBe("https://example.test/api/user");
 	});
 });

--- a/packages/holocron-plugin-github/src/__tests__/rest.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/rest.test.ts
@@ -21,7 +21,9 @@ describe("GitHubClient HTTP plumbing", () => {
 	});
 
 	it("serializes a body on POST and sets content-type", async () => {
-		const { fetch, calls } = stubFetch([{ status: 201, body: { name: "bug", color: "d73a4a", description: null } }]);
+		const { fetch, calls } = stubFetch([
+			{ status: 201, body: { name: "bug", color: "d73a4a", description: null } },
+		]);
 		const client = createGitHubClient({ token: TOKEN, fetch });
 		await client.labels.createLabel("x/y", { name: "bug", color: "d73a4a", description: "A bug" });
 		expect(calls[0]?.method).toBe("POST");

--- a/packages/holocron-plugin-github/src/__tests__/secrets.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/secrets.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { GitHubSecrets } from "../capabilities/secrets.js";
-import { createGitHubRestClient } from "../rest.js";
+import { createGitHubClient } from "../rest.js";
 import { sodium } from "../sodium.js";
 
 import { stubFetch } from "./helpers.js";
@@ -20,7 +20,7 @@ async function makeKeypair() {
 
 function makeSecrets(responses: Parameters<typeof stubFetch>[0]) {
 	const { fetch, calls } = stubFetch(responses);
-	const rest = createGitHubRestClient({ token: "pat", fetch });
+	const rest = createGitHubClient({ token: "pat", fetch });
 	const secrets = new GitHubSecrets(rest, { repo: REPO });
 	return { secrets, calls };
 }

--- a/packages/holocron-plugin-github/src/__tests__/source.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/source.test.ts
@@ -6,7 +6,7 @@ import { ProviderApiError } from "@theholocron/cli";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { GitHubSource } from "../capabilities/source.js";
-import { createGitHubRestClient } from "../rest.js";
+import { createGitHubClient } from "../rest.js";
 
 import { stubFetch } from "./helpers.js";
 
@@ -14,7 +14,7 @@ const REPO = "theholocron/holocron";
 
 function makeSource(responses: Parameters<typeof stubFetch>[0], repoRoot: string = process.cwd()) {
 	const { fetch, calls } = stubFetch(responses);
-	const rest = createGitHubRestClient({ token: "pat", fetch });
+	const rest = createGitHubClient({ token: "pat", fetch });
 	const source = new GitHubSource(rest, { repo: REPO, repoRoot });
 	return { source, calls };
 }

--- a/packages/holocron-plugin-github/src/__tests__/topics.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/topics.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { syncTopics } from "../capabilities/topics.js";
-import { createGitHubRestClient } from "../rest.js";
+import { createGitHubClient } from "../rest.js";
 
 import { stubFetch } from "./helpers.js";
 
@@ -9,7 +9,7 @@ const REPO = "theholocron/holocron";
 
 function makeRest(responses: Parameters<typeof stubFetch>[0]) {
 	const { fetch, calls } = stubFetch(responses);
-	const rest = createGitHubRestClient({ token: "pat", fetch });
+	const rest = createGitHubClient({ token: "pat", fetch });
 	return { rest, calls };
 }
 

--- a/packages/holocron-plugin-github/src/capabilities/ci.ts
+++ b/packages/holocron-plugin-github/src/capabilities/ci.ts
@@ -1,78 +1,34 @@
-/**
- * `ci` capability for GitHub — workflow runs only.
- *
- * Reads `/repos/{owner}/{name}/actions/runs[?…]` for `listRuns` and
- * `/repos/{owner}/{name}/actions/runs/{run_id}` for `getRun`.
- * Workflow YAML files themselves live with the `source` capability
- * (see Phase 1 architectural decision).
- */
-
 import type { Ci, CiRun, CiRunFilter, CiRunStatus } from "@theholocron/cli";
-
-import { parseRepo } from "../repo.js";
-import type { RestClient } from "@theholocron/cli";
+import type { GitHubClient, GitHubWorkflowRun } from "@theholocron/github-client";
 
 export interface CiOptions {
 	repo: string;
-}
-
-interface RawRun {
-	id: number;
-	name: string | null;
-	display_title: string;
-	head_branch: string;
-	head_sha: string;
-	status: "queued" | "in_progress" | "completed" | string;
-	conclusion: "success" | "failure" | "cancelled" | "skipped" | string | null;
-	html_url: string;
-	created_at: string;
-	updated_at: string;
-}
-
-interface RawRunsResponse {
-	total_count: number;
-	workflow_runs: RawRun[];
 }
 
 export class GitHubCi implements Ci {
 	readonly key = "ci" as const;
 	readonly providerName = "github";
 
-	private readonly base: string;
-
 	constructor(
-		private readonly rest: RestClient,
-		opts: CiOptions
-	) {
-		const { owner, name } = parseRepo(opts.repo);
-		this.base = `/repos/${owner}/${name}/actions/runs`;
-	}
+		private readonly client: GitHubClient,
+		private readonly opts: CiOptions
+	) {}
 
 	async listRuns(filter?: CiRunFilter): Promise<CiRun[]> {
-		const params = new URLSearchParams();
-		if (filter?.branch) params.set("branch", filter.branch);
-		if (filter?.limit) params.set("per_page", String(filter.limit));
-		// Note: GitHub's `status` query param accepts `queued`/`in_progress`/
-		// `completed`/`success`/`failure`/etc. — we forward our enum 1:1.
-		if (filter?.status) params.set("status", filter.status);
-		const qs = params.toString();
-		const path = qs ? `${this.base}?${qs}` : this.base;
-		const res = await this.rest.request<RawRunsResponse>(path);
-		return res.workflow_runs.map((r) => this.mapRun(r));
+		const runs = await this.client.workflows.listRuns(this.opts.repo, {
+			branch: filter?.branch,
+			limit: filter?.limit,
+			status: filter?.status,
+		});
+		return runs.map((r) => this.mapRun(r));
 	}
 
 	async getRun(id: string | number): Promise<CiRun> {
-		const raw = await this.rest.request<RawRun>(`${this.base}/${id}`);
+		const raw = await this.client.workflows.getRun(this.opts.repo, id);
 		return this.mapRun(raw);
 	}
 
-	/**
-	 * GitHub reports run state as `status` plus `conclusion` (the latter
-	 * is set once `status === 'completed'`). Holocron's `CiRunStatus`
-	 * collapses these onto one axis — when complete, the conclusion is
-	 * the meaningful value.
-	 */
-	private mapRun(raw: RawRun): CiRun {
+	private mapRun(raw: GitHubWorkflowRun): CiRun {
 		const status: CiRunStatus =
 			raw.status === "completed" && raw.conclusion
 				? this.mapConclusion(raw.conclusion)

--- a/packages/holocron-plugin-github/src/capabilities/environments.ts
+++ b/packages/holocron-plugin-github/src/capabilities/environments.ts
@@ -1,54 +1,22 @@
-/**
- * `environments` capability for GitHub.
- *
- * Wraps `/repos/{owner}/{name}/environments`. PUT is idempotent —
- * creates if absent, updates if present. The reviewer API requires
- * numeric ids; logins are silently ignored (preserved from Rando's
- * gh-rest port).
- */
-
 import type { Environment, Environments } from "@theholocron/cli";
-
-import { parseRepo } from "../repo.js";
-import type { RestClient } from "@theholocron/cli";
+import type { GitHubClient, GitHubEnvironment } from "@theholocron/github-client";
 
 export interface EnvironmentsOptions {
 	repo: string;
-}
-
-interface ListResponse {
-	total_count: number;
-	environments: Array<{
-		name: string;
-		wait_timer?: number;
-		prevent_self_review?: boolean;
-		protection_rules?: Array<{
-			type: string;
-			reviewers?: Array<{
-				type: "User" | "Team";
-				reviewer: { id: number };
-			}>;
-		}>;
-	}>;
 }
 
 export class GitHubEnvironments implements Environments {
 	readonly key = "environments" as const;
 	readonly providerName = "github";
 
-	private readonly base: string;
-
 	constructor(
-		private readonly rest: RestClient,
-		opts: EnvironmentsOptions
-	) {
-		const { owner, name } = parseRepo(opts.repo);
-		this.base = `/repos/${owner}/${name}/environments`;
-	}
+		private readonly client: GitHubClient,
+		private readonly opts: EnvironmentsOptions
+	) {}
 
 	async listEnvironments(): Promise<Environment[]> {
-		const res = await this.rest.request<ListResponse>(this.base);
-		return res.environments.map((e) => ({
+		const raw = await this.client.environments.listEnvironments(this.opts.repo);
+		return raw.map((e) => ({
 			name: e.name,
 			waitTimer: e.wait_timer,
 			preventSelfReview: e.prevent_self_review,
@@ -61,26 +29,17 @@ export class GitHubEnvironments implements Environments {
 		if (env.waitTimer !== undefined) body.wait_timer = env.waitTimer;
 		if (env.preventSelfReview !== undefined) body.prevent_self_review = env.preventSelfReview;
 		if (env.reviewers !== undefined) {
-			// GitHub's reviewer API silently ignores `login`; the numeric id
-			// is what actually wires. Callers are expected to resolve logins
-			// to ids ahead of time.
 			body.reviewers = env.reviewers.map((r) => ({ type: r.type, id: r.id }));
 		}
-		await this.rest.request<void>(`${this.base}/${encodeURIComponent(env.name)}`, {
-			method: "PUT",
-			body,
-		});
+		await this.client.environments.upsertEnvironment(this.opts.repo, env.name, body);
 	}
 
 	async deleteEnvironment(name: string): Promise<void> {
-		await this.rest.request<void>(`${this.base}/${encodeURIComponent(name)}`, {
-			method: "DELETE",
-			expectNoContent: true,
-		});
+		await this.client.environments.deleteEnvironment(this.opts.repo, name);
 	}
 
 	private flattenReviewers(
-		rules: ListResponse["environments"][number]["protection_rules"]
+		rules: GitHubEnvironment["protection_rules"]
 	): Environment["reviewers"] {
 		if (!rules) return undefined;
 		const reviewersRule = rules.find((r) => r.type === "required_reviewers");

--- a/packages/holocron-plugin-github/src/capabilities/environments.ts
+++ b/packages/holocron-plugin-github/src/capabilities/environments.ts
@@ -38,9 +38,7 @@ export class GitHubEnvironments implements Environments {
 		await this.client.environments.deleteEnvironment(this.opts.repo, name);
 	}
 
-	private flattenReviewers(
-		rules: GitHubEnvironment["protection_rules"]
-	): Environment["reviewers"] {
+	private flattenReviewers(rules: GitHubEnvironment["protection_rules"]): Environment["reviewers"] {
 		if (!rules) return undefined;
 		const reviewersRule = rules.find((r) => r.type === "required_reviewers");
 		if (!reviewersRule?.reviewers) return undefined;

--- a/packages/holocron-plugin-github/src/capabilities/issues.ts
+++ b/packages/holocron-plugin-github/src/capabilities/issues.ts
@@ -1,9 +1,6 @@
 /**
  * `issues` capability for GitHub.
  *
- * Ported from rando-id/rando.id `packages/cli/src/adapters/github-issues.ts`
- * with the v2 shape adjustments captured in the architecture spec.
- *
  * Lifecycle model: GitHub Issues has no transitions like Jira does.
  * Holocron's three lifecycle slots map to (state, label) pairs:
  *   inProgress → open + label `status:in-progress`  (strip other status:*)
@@ -24,9 +21,7 @@ import type {
 	TrackerDoctorReport,
 	TrackerUser,
 } from "@theholocron/cli";
-
-import { parseRepo } from "../repo.js";
-import type { RestClient } from "@theholocron/cli";
+import type { GitHubClient, GitHubIssue } from "@theholocron/github-client";
 
 export interface IssuesOptions {
 	repo: string;
@@ -34,40 +29,9 @@ export interface IssuesOptions {
 	 * Lifecycle slot → status label name. Optional at construction; if
 	 * omitted, capability methods that need labels (`transition`,
 	 * `doctor`) degrade gracefully — `transition` throws a clear error,
-	 * `doctor` reports the two label-backed slots as unresolved. This
-	 * lets the plugin load in configs where the operator hasn't picked
-	 * labels yet without failing the whole runtime.
+	 * `doctor` reports the two label-backed slots as unresolved.
 	 */
 	labels?: { inProgress: string; inReview: string };
-}
-
-interface RawUser {
-	login: string;
-	name?: string | null;
-	email?: string | null;
-}
-
-interface RawIssue {
-	id: number;
-	number: number;
-	title: string;
-	body?: string | null;
-	state: "open" | "closed";
-	labels: Array<{ name: string }>;
-	assignee: RawUser | null;
-	updated_at: string;
-	html_url: string;
-	/** Present when the "issue" is actually a PR. We filter these out. */
-	pull_request?: unknown;
-}
-
-interface RawRepo {
-	full_name: string;
-}
-
-interface RawMilestone {
-	number: number;
-	title: string;
 }
 
 export class GitHubIssues implements Issues {
@@ -76,51 +40,57 @@ export class GitHubIssues implements Issues {
 
 	private readonly owner: string;
 	private readonly repoName: string;
-	private readonly base: string;
+	private readonly repo: string;
 	private readonly labels: { inProgress: string; inReview: string } | undefined;
 
 	constructor(
-		private readonly rest: RestClient,
+		private readonly client: GitHubClient,
 		opts: IssuesOptions
 	) {
-		const { owner, name } = parseRepo(opts.repo);
+		const [owner = "", repoName = ""] = opts.repo.split("/", 2);
 		this.owner = owner;
-		this.repoName = name;
-		this.base = `/repos/${owner}/${name}`;
+		this.repoName = repoName;
+		this.repo = opts.repo;
 		this.labels = opts.labels;
 	}
 
 	// ── identity ─────────────────────────────────────────────────────────
 
 	async getMyself(): Promise<TrackerUser> {
-		const raw = await this.rest.request<RawUser>("/user");
-		return mapUser(raw);
+		const raw = await this.client.user.getCurrentUser();
+		return { id: raw.login, displayName: raw.name ?? raw.login, ...(raw.email ? { emailAddress: raw.email } : {}) };
 	}
 
 	// ── search / get ─────────────────────────────────────────────────────
 
 	async search(filter: IssueSearchFilter): Promise<Issue[]> {
-		const params = new URLSearchParams({
+		const params: Record<string, string | number> = {
 			state: filter.openOnly ? "open" : "all",
 			sort: "updated",
 			direction: "desc",
-			per_page: String(filter.limit ?? 50),
+			per_page: filter.limit ?? 50,
 			filter: "all",
-		});
+		};
 		if (filter.assignee === "currentUser") {
 			const me = await this.getMyself();
-			params.set("assignee", me.id);
+			params.assignee = me.id;
 		} else if (filter.assignee) {
-			params.set("assignee", filter.assignee);
+			params.assignee = filter.assignee;
 		}
-		const raw = await this.rest.request<RawIssue[]>(`${this.base}/issues?${params.toString()}`);
-		// Filter out PRs — the issues endpoint includes them.
+		const raw = await this.client.issues.listIssues(this.repo, {
+			state: params.state as "open" | "closed" | "all",
+			sort: params.sort as string,
+			direction: params.direction as string,
+			per_page: Number(params.per_page),
+			filter: params.filter as string,
+			assignee: params.assignee as string | undefined,
+		});
 		return raw.filter((i) => !i.pull_request).map((i) => this.mapIssue(i));
 	}
 
 	async get(key: string): Promise<Issue> {
 		const number = parseIssueNumber(key, this.owner, this.repoName);
-		const raw = await this.rest.request<RawIssue>(`${this.base}/issues/${number}`);
+		const raw = await this.client.issues.getIssue(this.repo, number);
 		return this.mapIssue(raw);
 	}
 
@@ -136,16 +106,13 @@ export class GitHubIssues implements Issues {
 		if (input.body) body.body = input.body;
 		if (input.labels?.length) body.labels = input.labels;
 		if (input.milestone) body.milestone = await this.resolveMilestone(input.milestone);
-		const raw = await this.rest.request<RawIssue>(`${this.base}/issues`, {
-			method: "POST",
-			body,
-		});
+		const raw = await this.client.issues.createIssue(this.repo, body);
 		return { key: `#${raw.number}` };
 	}
 
 	async transition(key: string, slot: LifecycleSlot): Promise<LifecycleResult> {
 		const number = parseIssueNumber(key, this.owner, this.repoName);
-		const issue = await this.rest.request<RawIssue>(`${this.base}/issues/${number}`);
+		const issue = await this.client.issues.getIssue(this.repo, number);
 		const currentStatusLabels = issue.labels.map((l) => l.name).filter((n) => n.startsWith("status:"));
 
 		if (slot === "done") {
@@ -153,14 +120,10 @@ export class GitHubIssues implements Issues {
 				return { transitioned: false, status: "closed", via: "already closed" };
 			}
 			await this.removeStatusLabels(number, currentStatusLabels);
-			await this.rest.request(`${this.base}/issues/${number}`, {
-				method: "PATCH",
-				body: { state: "closed", state_reason: "completed" },
-			});
+			await this.client.issues.updateIssue(this.repo, number, { state: "closed", state_reason: "completed" });
 			return { transitioned: true, status: "closed", via: "closed (completed)" };
 		}
 
-		// inProgress / inReview: ensure open + set the right label.
 		if (!this.labels) {
 			throw new Error(
 				`transition to \`${slot}\` requires \`labels\` in plugin options: ` +
@@ -171,52 +134,31 @@ export class GitHubIssues implements Issues {
 		const alreadyOpen = issue.state === "open";
 		const alreadyLabeled = currentStatusLabels.includes(targetLabel);
 		if (alreadyOpen && alreadyLabeled && currentStatusLabels.length === 1) {
-			return {
-				transitioned: false,
-				status: `open + ${targetLabel}`,
-				via: "already there",
-			};
+			return { transitioned: false, status: `open + ${targetLabel}`, via: "already there" };
 		}
 
 		if (!alreadyOpen) {
-			await this.rest.request(`${this.base}/issues/${number}`, {
-				method: "PATCH",
-				body: { state: "open" },
-			});
+			await this.client.issues.updateIssue(this.repo, number, { state: "open" });
 		}
-		// Strip any other status:* labels but keep targetLabel if present.
 		const toRemove = currentStatusLabels.filter((n) => n !== targetLabel);
 		if (toRemove.length) await this.removeStatusLabels(number, toRemove);
 		if (!alreadyLabeled) {
-			await this.rest.request(`${this.base}/issues/${number}/labels`, {
-				method: "POST",
-				body: { labels: [targetLabel] },
-			});
+			await this.client.issues.addLabels(this.repo, number, [targetLabel]);
 		}
-		return {
-			transitioned: true,
-			status: `open + ${targetLabel}`,
-			via: `label set to ${targetLabel}`,
-		};
+		return { transitioned: true, status: `open + ${targetLabel}`, via: `label set to ${targetLabel}` };
 	}
 
 	async comment(key: string, body: string): Promise<void> {
 		const number = parseIssueNumber(key, this.owner, this.repoName);
-		await this.rest.request(`${this.base}/issues/${number}/comments`, {
-			method: "POST",
-			body: { body },
-		});
+		await this.client.issues.createComment(this.repo, number, body);
 	}
 
 	// ── doctor ───────────────────────────────────────────────────────────
 
 	async doctor(): Promise<TrackerDoctorReport> {
 		const me = await this.getMyself();
-		const repo = await this.rest.request<RawRepo>(this.base);
-		// List existing labels so doctor can lint whether the configured
-		// status labels are actually defined. GitHub auto-creates labels
-		// on first apply, so missing is just a warning, not an error.
-		const allLabels = await this.rest.request<Array<{ name: string }>>(`${this.base}/labels?per_page=100`);
+		const repo = await this.client.repos.getRepo(this.repo);
+		const allLabels = await this.client.labels.listLabels(this.repo);
 		const labelNames = new Set(allLabels.map((l) => l.name));
 
 		const statuses: TrackerDoctorReport["statuses"] = [
@@ -248,12 +190,7 @@ export class GitHubIssues implements Issues {
 							? `label exists in ${repo.full_name}`
 							: "(label not defined yet — auto-created on first apply)",
 					},
-					{
-						slot: "done",
-						value: "closed (state_reason=completed)",
-						resolved: true,
-						note: "(intrinsic — GitHub close-with-reason)",
-					},
+					{ slot: "done", value: "closed (state_reason=completed)", resolved: true, note: "(intrinsic — GitHub close-with-reason)" },
 				]
 			: [
 					{
@@ -268,12 +205,7 @@ export class GitHubIssues implements Issues {
 						resolved: false,
 						note: "no `labels` configured in plugin options — transitions to `inReview` will error",
 					},
-					{
-						slot: "done",
-						value: "closed (state_reason=completed)",
-						resolved: true,
-						note: "(intrinsic — GitHub close-with-reason)",
-					},
+					{ slot: "done", value: "closed (state_reason=completed)", resolved: true, note: "(intrinsic — GitHub close-with-reason)" },
 				];
 
 		return {
@@ -288,7 +220,7 @@ export class GitHubIssues implements Issues {
 
 	private async resolveMilestone(ref: string): Promise<number> {
 		if (/^\d+$/.test(ref)) return parseInt(ref, 10);
-		const milestones = await this.rest.request<RawMilestone[]>(`${this.base}/milestones?state=all&per_page=100`);
+		const milestones = await this.client.issues.listMilestones(this.repo, { state: "all" });
 		const match = milestones.find((m) => m.title.toLowerCase() === ref.toLowerCase());
 		if (!match) {
 			throw new Error(
@@ -299,16 +231,12 @@ export class GitHubIssues implements Issues {
 	}
 
 	private async removeStatusLabels(number: number, labels: string[]): Promise<void> {
-		// One DELETE per label — GitHub doesn't expose a bulk remove.
-		// Sequential so a rate-limit hit on one doesn't fan out failures.
 		for (const label of labels) {
-			await this.rest.request(`${this.base}/issues/${number}/labels/${encodeURIComponent(label)}`, {
-				method: "DELETE",
-			});
+			await this.client.issues.removeLabel(this.repo, number, label);
 		}
 	}
 
-	private mapIssue(raw: RawIssue): Issue {
+	private mapIssue(raw: GitHubIssue): Issue {
 		const statusLabels = raw.labels.map((l) => l.name).filter((n) => n.startsWith("status:"));
 		let category: StatusCategory = "open";
 		let statusName = raw.state === "closed" ? "closed" : "open";
@@ -328,23 +256,17 @@ export class GitHubIssues implements Issues {
 			...(raw.body ? { body: raw.body } : {}),
 			status: statusName,
 			statusCategory: category,
-			assignee: raw.assignee ? mapUser(raw.assignee) : null,
+			assignee: raw.assignee
+				? { id: raw.assignee.login, displayName: raw.assignee.name ?? raw.assignee.login, ...(raw.assignee.email ? { emailAddress: raw.assignee.email } : {}) }
+				: null,
 			updated: raw.updated_at,
 			url: raw.html_url,
 		};
 	}
 }
 
-// ── helpers ─────────────────────────────────────────────────────────────
-
-/**
- * Accept "#42", "42", or "owner/repo#42" and return the numeric id.
- * Cross-repo refs are allowed in input but the adapter is bound to one
- * repo — we error if the owner/repo doesn't match.
- */
 function parseIssueNumber(key: string, owner: string, repoName: string): number {
 	const trimmed = key.trim();
-	// owner/repo#N form
 	const crossMatch = trimmed.match(/^([^/]+)\/([^#]+)#(\d+)$/);
 	if (crossMatch) {
 		if (crossMatch[1] !== owner || crossMatch[2] !== repoName) {
@@ -354,18 +276,9 @@ function parseIssueNumber(key: string, owner: string, repoName: string): number 
 		}
 		return parseInt(crossMatch[3]!, 10);
 	}
-	// #N or plain N
 	const num = trimmed.replace(/^#/, "");
 	if (!/^\d+$/.test(num)) {
 		throw new Error(`Invalid GitHub issue key "${key}" — expected #N or N.`);
 	}
 	return parseInt(num, 10);
-}
-
-function mapUser(raw: RawUser): TrackerUser {
-	return {
-		id: raw.login,
-		displayName: raw.name ?? raw.login,
-		...(raw.email ? { emailAddress: raw.email } : {}),
-	};
 }

--- a/packages/holocron-plugin-github/src/capabilities/issues.ts
+++ b/packages/holocron-plugin-github/src/capabilities/issues.ts
@@ -190,7 +190,12 @@ export class GitHubIssues implements Issues {
 							? `label exists in ${repo.full_name}`
 							: "(label not defined yet — auto-created on first apply)",
 					},
-					{ slot: "done", value: "closed (state_reason=completed)", resolved: true, note: "(intrinsic — GitHub close-with-reason)" },
+					{
+						slot: "done",
+						value: "closed (state_reason=completed)",
+						resolved: true,
+						note: "(intrinsic — GitHub close-with-reason)",
+					},
 				]
 			: [
 					{
@@ -205,7 +210,12 @@ export class GitHubIssues implements Issues {
 						resolved: false,
 						note: "no `labels` configured in plugin options — transitions to `inReview` will error",
 					},
-					{ slot: "done", value: "closed (state_reason=completed)", resolved: true, note: "(intrinsic — GitHub close-with-reason)" },
+					{
+						slot: "done",
+						value: "closed (state_reason=completed)",
+						resolved: true,
+						note: "(intrinsic — GitHub close-with-reason)",
+					},
 				];
 
 		return {
@@ -257,7 +267,11 @@ export class GitHubIssues implements Issues {
 			status: statusName,
 			statusCategory: category,
 			assignee: raw.assignee
-				? { id: raw.assignee.login, displayName: raw.assignee.name ?? raw.assignee.login, ...(raw.assignee.email ? { emailAddress: raw.assignee.email } : {}) }
+				? {
+						id: raw.assignee.login,
+						displayName: raw.assignee.name ?? raw.assignee.login,
+						...(raw.assignee.email ? { emailAddress: raw.assignee.email } : {}),
+					}
 				: null,
 			updated: raw.updated_at,
 			url: raw.html_url,

--- a/packages/holocron-plugin-github/src/capabilities/labels.ts
+++ b/packages/holocron-plugin-github/src/capabilities/labels.ts
@@ -1,16 +1,9 @@
-import { parseRepo } from "../repo.js";
-import type { RestClient } from "@theholocron/cli";
+import type { GitHubClient, GitHubLabel } from "@theholocron/github-client";
 
 export interface CanonicalLabel {
 	readonly name: string;
 	readonly color: string;
 	readonly description: string;
-}
-
-interface RawLabel {
-	name: string;
-	color: string;
-	description: string | null;
 }
 
 /**
@@ -22,15 +15,12 @@ interface RawLabel {
  * - Leaves unrecognised labels that aren't in `stale` untouched.
  */
 export async function syncLabels(
-	rest: RestClient,
+	client: GitHubClient,
 	repo: string,
 	canonical: ReadonlyArray<CanonicalLabel>,
 	stale: ReadonlyArray<string>
 ): Promise<string> {
-	const { owner, name } = parseRepo(repo);
-	const base = `/repos/${owner}/${name}`;
-
-	const existing = await rest.request<RawLabel[]>(`${base}/labels?per_page=100`);
+	const existing: GitHubLabel[] = await client.labels.listLabels(repo);
 	const existingMap = new Map(existing.map((l) => [l.name.toLowerCase(), l]));
 
 	let created = 0;
@@ -40,15 +30,16 @@ export async function syncLabels(
 	for (const label of canonical) {
 		const current = existingMap.get(label.name);
 		if (!current) {
-			await rest.request(`${base}/labels`, {
-				method: "POST",
-				body: { name: label.name, color: label.color, description: label.description },
+			await client.labels.createLabel(repo, {
+				name: label.name,
+				color: label.color,
+				description: label.description,
 			});
 			created++;
 		} else if (current.color !== label.color || (current.description ?? "") !== label.description) {
-			await rest.request(`${base}/labels/${encodeURIComponent(label.name)}`, {
-				method: "PATCH",
-				body: { color: label.color, description: label.description },
+			await client.labels.updateLabel(repo, label.name, {
+				color: label.color,
+				description: label.description,
 			});
 			updated++;
 		}
@@ -56,9 +47,7 @@ export async function syncLabels(
 
 	for (const staleName of stale) {
 		if (existingMap.has(staleName)) {
-			await rest.request(`${base}/labels/${encodeURIComponent(staleName)}`, {
-				method: "DELETE",
-			});
+			await client.labels.deleteLabel(repo, staleName);
 			deleted++;
 		}
 	}

--- a/packages/holocron-plugin-github/src/capabilities/properties.ts
+++ b/packages/holocron-plugin-github/src/capabilities/properties.ts
@@ -1,21 +1,6 @@
-import { parseRepo } from "../repo.js";
-import type { RestClient } from "@theholocron/cli";
+import type { GitHubClient } from "@theholocron/github-client";
 
-/**
- * Sync custom property values for a repo to the org-defined schema.
- *
- * Calls `PATCH /repos/{owner}/{name}/properties/values` with the full
- * map — GitHub replaces only the supplied keys, leaving others untouched.
- */
-export async function syncProperties(rest: RestClient, repo: string, values: Record<string, string>): Promise<string> {
-	const { owner, name } = parseRepo(repo);
-
-	const properties = Object.entries(values).map(([property_name, value]) => ({ property_name, value }));
-
-	await rest.request<void>(`/repos/${owner}/${name}/properties/values`, {
-		method: "PATCH",
-		body: { properties },
-	});
-
-	return `${properties.length} properties set`;
+export async function syncProperties(client: GitHubClient, repo: string, values: Record<string, string>): Promise<string> {
+	await client.properties.setProperties(repo, values);
+	return `${Object.keys(values).length} properties set`;
 }

--- a/packages/holocron-plugin-github/src/capabilities/properties.ts
+++ b/packages/holocron-plugin-github/src/capabilities/properties.ts
@@ -1,6 +1,10 @@
 import type { GitHubClient } from "@theholocron/github-client";
 
-export async function syncProperties(client: GitHubClient, repo: string, values: Record<string, string>): Promise<string> {
+export async function syncProperties(
+	client: GitHubClient,
+	repo: string,
+	values: Record<string, string>
+): Promise<string> {
 	await client.properties.setProperties(repo, values);
 	return `${Object.keys(values).length} properties set`;
 }

--- a/packages/holocron-plugin-github/src/capabilities/secrets.ts
+++ b/packages/holocron-plugin-github/src/capabilities/secrets.ts
@@ -1,94 +1,40 @@
-/**
- * `secrets` capability for GitHub.
- *
- * Multi-scope wrapper over GitHub Actions secrets:
- *   - `{ kind: 'repo' }`         → `/repos/{owner}/{name}/actions/secrets`
- *   - `{ kind: 'environment' }`  → `/repos/{owner}/{name}/environments/{env}/secrets`
- *   - `{ kind: 'organization' }` → `/orgs/{org}/actions/secrets`
- *
- * Each scope has its own public key (via `…/secrets/public-key`).
- * Values are encrypted with libsodium sealed-box before PUT.
- *
- * Org secrets get a default `visibility: 'all'`. The caller can
- * override via a `setOrgSecretVisibility` follow-up if a different
- * policy is needed (rare for v1; we don't expose it as a method yet).
- */
-
 import type { Secrets, SecretScope } from "@theholocron/cli";
+import type { GitHubClient, SecretScope as GHSecretScope } from "@theholocron/github-client";
 
-import { parseRepo } from "../repo.js";
-import type { RestClient } from "@theholocron/cli";
 import { encryptSecret } from "../sodium.js";
 
 export interface SecretsOptions {
 	repo: string;
 }
 
-interface PublicKey {
-	key_id: string;
-	key: string;
-}
-
-interface ListResponse {
-	total_count: number;
-	secrets: Array<{ name: string }>;
-}
-
 export class GitHubSecrets implements Secrets {
 	readonly key = "secrets" as const;
 	readonly providerName = "github";
 
-	private readonly repoBase: string;
-
 	constructor(
-		private readonly rest: RestClient,
-		opts: SecretsOptions
-	) {
-		const { owner, name } = parseRepo(opts.repo);
-		this.repoBase = `/repos/${owner}/${name}`;
-	}
+		private readonly client: GitHubClient,
+		private readonly opts: SecretsOptions
+	) {}
 
 	async listSecrets(scope: SecretScope): Promise<string[]> {
-		const base = this.scopeBase(scope);
-		const res = await this.rest.request<ListResponse>(`${base}/secrets`);
-		return res.secrets.map((s) => s.name);
+		return this.client.secrets.listSecrets(this.opts.repo, toGHScope(scope));
 	}
 
 	async setSecret(scope: SecretScope, name: string, value: string): Promise<void> {
-		const base = this.scopeBase(scope);
-		const pk = await this.rest.request<PublicKey>(`${base}/secrets/public-key`);
+		const ghScope = toGHScope(scope);
+		const pk = await this.client.secrets.getPublicKey(this.opts.repo, ghScope);
 		const encryptedValue = await encryptSecret(pk.key, value);
 		const body: Record<string, unknown> = { encrypted_value: encryptedValue, key_id: pk.key_id };
-		// Org secrets require a `visibility` field; default to 'all' (every
-		// repo in the org). Callers can swap later via direct REST if a
-		// narrower policy is needed.
-		if (scope.kind === "organization") {
-			body.visibility = "all";
-		}
-		await this.rest.request<void>(`${base}/secrets/${name}`, {
-			method: "PUT",
-			body,
-			expectNoContent: true,
-		});
+		if (scope.kind === "organization") body.visibility = "all";
+		await this.client.secrets.putSecret(this.opts.repo, ghScope, name, body);
 	}
 
 	async deleteSecret(scope: SecretScope, name: string): Promise<void> {
-		const base = this.scopeBase(scope);
-		await this.rest.request<void>(`${base}/secrets/${name}`, {
-			method: "DELETE",
-			expectNoContent: true,
-		});
+		await this.client.secrets.deleteSecret(this.opts.repo, toGHScope(scope), name);
 	}
+}
 
-	/** Endpoint root for the given scope. */
-	private scopeBase(scope: SecretScope): string {
-		switch (scope.kind) {
-			case "repo":
-				return `${this.repoBase}/actions`;
-			case "environment":
-				return `${this.repoBase}/environments/${scope.name}`;
-			case "organization":
-				return `/orgs/${scope.name}/actions`;
-		}
-	}
+function toGHScope(scope: SecretScope): GHSecretScope {
+	if (scope.kind === "organization") return { kind: "organization", org: scope.name };
+	return scope;
 }

--- a/packages/holocron-plugin-github/src/capabilities/source.ts
+++ b/packages/holocron-plugin-github/src/capabilities/source.ts
@@ -1,28 +1,15 @@
-/**
- * `source` capability for GitHub.
- *
- * Ported from rando-id/rando.id `packages/cli/src/adapters/gh-rest.ts`
- * with two changes for v2:
- *
- *  - Repo coords are bound at construction time (not passed per call)
- *  - Workflow files are local-fs operations (not GH API) — they live
- *    in the consumer's `.github/workflows/` directory
- */
-
 import { readdir, readFile, rm, writeFile, mkdir, stat } from "node:fs/promises";
 import { join, dirname } from "node:path";
 
 import type { LabelDef, RepoRef, RepoSettings, Ruleset, Source } from "@theholocron/cli";
+import type { GitHubClient } from "@theholocron/github-client";
 
-import { parseRepo } from "../repo.js";
-import type { RestClient } from "@theholocron/cli";
 import { syncLabels } from "./labels.js";
 import { syncProperties } from "./properties.js";
 import { syncTopics } from "./topics.js";
 
 export interface SourceOptions {
 	repo: string;
-	/** Absolute path to the repo root. Workflow file ops are scoped here. */
 	repoRoot: string;
 }
 
@@ -32,141 +19,81 @@ export class GitHubSource implements Source {
 
 	private readonly owner: string;
 	private readonly name: string;
-	private readonly repoPath: string;
+	private readonly repo: string;
 	private readonly repoRoot: string;
 	private readonly workflowDir: string;
 
 	constructor(
-		private readonly rest: RestClient,
+		private readonly client: GitHubClient,
 		opts: SourceOptions
 	) {
-		const { owner, name } = parseRepo(opts.repo);
+		const [owner = "", name = ""] = opts.repo.split("/", 2);
 		this.owner = owner;
 		this.name = name;
-		this.repoPath = `/repos/${owner}/${name}`;
+		this.repo = opts.repo;
 		this.repoRoot = opts.repoRoot;
 		this.workflowDir = join(opts.repoRoot, ".github", "workflows");
 	}
 
-	// ── auth + repo identity ────────────────────────────────────────────
-
 	async whoami(): Promise<{ login: string }> {
-		const data = await this.rest.request<{ login: string }>("/user");
+		const data = await this.client.user.getCurrentUser();
 		return { login: data.login };
 	}
 
 	async getRepo(): Promise<RepoRef> {
-		const data = await this.rest.request<{ default_branch: string }>(this.repoPath);
+		const data = await this.client.repos.getRepo(this.repo);
 		return { owner: this.owner, name: this.name, defaultBranch: data.default_branch };
 	}
 
-	// ── rulesets ────────────────────────────────────────────────────────
-
 	async listRulesets(): Promise<Ruleset[]> {
-		return this.rest.request<Ruleset[]>(`${this.repoPath}/rulesets`);
+		// GitHubRuleset.enforcement is string; Ruleset.enforcement is a narrower
+		// union — safe at runtime since GitHub only returns the three known values.
+		return this.client.rulesets.listRulesets(this.repo) as unknown as Promise<Ruleset[]>;
 	}
 
 	async createRuleset(payload: Record<string, unknown>): Promise<Ruleset> {
-		return this.rest.request<Ruleset>(`${this.repoPath}/rulesets`, {
-			method: "POST",
-			body: payload,
-		});
+		return this.client.rulesets.createRuleset(this.repo, payload) as unknown as Promise<Ruleset>;
 	}
 
 	async updateRuleset(id: number, payload: Record<string, unknown>): Promise<Ruleset> {
-		return this.rest.request<Ruleset>(`${this.repoPath}/rulesets/${id}`, {
-			method: "PUT",
-			body: payload,
-		});
+		return this.client.rulesets.updateRuleset(this.repo, id, payload) as unknown as Promise<Ruleset>;
 	}
 
-	// ── repo settings ───────────────────────────────────────────────────
-
 	async updateRepoSettings(settings: RepoSettings): Promise<void> {
-		await this.rest.request<void>(this.repoPath, { method: "PATCH", body: settings });
+		await this.client.repos.updateRepo(this.repo, settings as Record<string, unknown>);
 	}
 
 	async protectBranch(branch: string, payload: Record<string, unknown>): Promise<void> {
-		await this.rest.request<void>(`${this.repoPath}/branches/${encodeURIComponent(branch)}/protection`, {
-			method: "PUT",
-			body: payload,
-		});
+		await this.client.branches.protectBranch(this.repo, branch, payload);
 	}
 
-	// ── security toggles (idempotent flip-or-noop) ──────────────────────
-
 	async enableVulnerabilityAlerts(): Promise<void> {
-		await this.rest.request<void>(`${this.repoPath}/vulnerability-alerts`, {
-			method: "PUT",
-			expectNoContent: true,
-		});
+		await this.client.security.enableVulnerabilityAlerts(this.repo);
 	}
 
 	async enableAutomatedSecurityFixes(): Promise<void> {
-		await this.rest.request<void>(`${this.repoPath}/automated-security-fixes`, {
-			method: "PUT",
-			expectNoContent: true,
-		});
+		await this.client.security.enableAutomatedSecurityFixes(this.repo);
 	}
 
 	async enableSecretScanning(): Promise<void> {
-		await this.rest.request<void>(this.repoPath, {
-			method: "PATCH",
-			body: {
-				security_and_analysis: {
-					secret_scanning: { status: "enabled" },
-					secret_scanning_push_protection: { status: "enabled" },
-					// Validity checks confirm found secrets are still active (reduces
-					// false positives). Non-provider patterns catches secrets outside
-					// known provider formats. Both require org-level GHAS — accepted
-					// as a no-op until that is enabled.
-					secret_scanning_validity_checks: { status: "enabled" },
-					secret_scanning_non_provider_patterns: { status: "enabled" },
-				},
-			},
-		});
+		await this.client.security.enableSecretScanning(this.repo);
 	}
 
 	async enableCodeScanning(): Promise<string> {
-		const result = await this.rest.request<{ run_id: number; run_url: string }>(
-			`${this.repoPath}/code-scanning/default-setup`,
-			{
-				method: "PATCH",
-				// remote_and_local covers both remote exploits AND local paths
-				// (path traversal, injection via local input, etc.) — this is what
-				// GitHub surfaces as "code quality" alongside the security queries.
-				body: { state: "configured", query_suite: "extended", threat_model: "remote_and_local" },
-			}
-		);
+		const result = await this.client.security.enableCodeScanning(this.repo);
 		return `run ${result.run_id}`;
 	}
 
 	async disableDefaultCodeScanning(): Promise<void> {
-		await this.rest.request<void>(`${this.repoPath}/code-scanning/default-setup`, {
-			method: "PATCH",
-			body: { state: "not-configured" },
-		});
+		await this.client.security.disableDefaultCodeScanning(this.repo);
 	}
 
 	async enableDependencyGraph(): Promise<void> {
-		await this.rest.request<void>(this.repoPath, {
-			method: "PATCH",
-			body: {
-				security_and_analysis: {
-					// Auto-on for public repos; explicit for private repos.
-					dependency_graph: { status: "enabled" },
-					// Automatically submits dependency snapshots via GitHub Actions.
-					dependency_graph_autosubmit_action: { status: "enabled" },
-				},
-			},
-		});
+		await this.client.security.enableDependencyGraph(this.repo);
 	}
 
 	async enablePrivateVulnerabilityReporting(): Promise<void> {
-		await this.rest.request<void>(`${this.repoPath}/private-vulnerability-reporting`, {
-			method: "PUT",
-			expectNoContent: true,
-		});
+		await this.client.security.enablePrivateVulnerabilityReporting(this.repo);
 	}
 
 	// ── workflow files (local fs) ───────────────────────────────────────
@@ -211,15 +138,15 @@ export class GitHubSource implements Source {
 	}
 
 	async syncLabels(canonical: ReadonlyArray<LabelDef>, stale: ReadonlyArray<string>): Promise<string> {
-		return syncLabels(this.rest, `${this.owner}/${this.name}`, canonical, stale);
+		return syncLabels(this.client, this.repo, canonical, stale);
 	}
 
 	async syncProperties(values: Record<string, string>): Promise<string> {
-		return syncProperties(this.rest, `${this.owner}/${this.name}`, values);
+		return syncProperties(this.client, this.repo, values);
 	}
 
 	async syncTopics(topics: string[]): Promise<string> {
-		return syncTopics(this.rest, `${this.owner}/${this.name}`, topics);
+		return syncTopics(this.client, this.repo, topics);
 	}
 }
 

--- a/packages/holocron-plugin-github/src/capabilities/topics.ts
+++ b/packages/holocron-plugin-github/src/capabilities/topics.ts
@@ -1,19 +1,6 @@
-import { parseRepo } from "../repo.js";
-import type { RestClient } from "@theholocron/cli";
+import type { GitHubClient } from "@theholocron/github-client";
 
-/**
- * Replace a repo's topic set with the supplied list.
- *
- * Calls `PUT /repos/{owner}/{name}/topics` — GitHub replaces the full
- * set atomically, so the config is always the source of truth.
- */
-export async function syncTopics(rest: RestClient, repo: string, topics: string[]): Promise<string> {
-	const { owner, name } = parseRepo(repo);
-
-	await rest.request<void>(`/repos/${owner}/${name}/topics`, {
-		method: "PUT",
-		body: { names: topics },
-	});
-
+export async function syncTopics(client: GitHubClient, repo: string, topics: string[]): Promise<string> {
+	await client.topics.setTopics(repo, topics);
 	return `${topics.length} topics set`;
 }

--- a/packages/holocron-plugin-github/src/index.ts
+++ b/packages/holocron-plugin-github/src/index.ts
@@ -8,7 +8,8 @@
  * returns the bound implementation.
  */
 
-import type { Auth, Ci, Environments, Issues, RestClient, Secrets, Source } from "@theholocron/cli";
+import type { Auth, Ci, Environments, Issues, Secrets, Source } from "@theholocron/cli";
+import { createGitHubClient, type GitHubClient } from "@theholocron/github-client";
 
 import { resolveToken, type ResolveTokenInput } from "./auth.js";
 import { GitHubCi } from "./capabilities/ci.js";
@@ -16,7 +17,6 @@ import { GitHubEnvironments } from "./capabilities/environments.js";
 import { GitHubIssues, type IssuesOptions } from "./capabilities/issues.js";
 import { GitHubSecrets } from "./capabilities/secrets.js";
 import { GitHubSource } from "./capabilities/source.js";
-import { createGitHubRestClient } from "./rest.js";
 
 export interface GitHubPluginOptions extends ResolveTokenInput {
 	/** "owner/name" — e.g., "theholocron/holocron". Required. */
@@ -34,21 +34,21 @@ export interface GitHubPluginOptions extends ResolveTokenInput {
 
 export interface PluginContext {
 	options: GitHubPluginOptions;
-	rest: RestClient;
+	client: GitHubClient;
 	repo: string;
 	repoRoot: string;
 }
 
 export function createContext(options: GitHubPluginOptions): PluginContext {
 	const token = resolveToken(options);
-	const rest = createGitHubRestClient({
+	const client = createGitHubClient({
 		token,
 		baseUrl: options.baseUrl,
 		fetch: options.fetch,
 	});
 	return {
 		options,
-		rest,
+		client,
 		repo: options.repo,
 		repoRoot: options.repoRoot ?? process.cwd(),
 	};
@@ -57,25 +57,25 @@ export function createContext(options: GitHubPluginOptions): PluginContext {
 // ── Capability factories ──────────────────────────────────────────────
 
 export function source(ctx: PluginContext): Source {
-	return new GitHubSource(ctx.rest, { repo: ctx.repo, repoRoot: ctx.repoRoot });
+	return new GitHubSource(ctx.client, { repo: ctx.repo, repoRoot: ctx.repoRoot });
 }
 
 export function secrets(ctx: PluginContext): Secrets {
-	return new GitHubSecrets(ctx.rest, { repo: ctx.repo });
+	return new GitHubSecrets(ctx.client, { repo: ctx.repo });
 }
 
 export function environments(ctx: PluginContext): Environments {
-	return new GitHubEnvironments(ctx.rest, { repo: ctx.repo });
+	return new GitHubEnvironments(ctx.client, { repo: ctx.repo });
 }
 
 export function ci(ctx: PluginContext): Ci {
-	return new GitHubCi(ctx.rest, { repo: ctx.repo });
+	return new GitHubCi(ctx.client, { repo: ctx.repo });
 }
 
 export function issues(ctx: PluginContext): Issues {
 	const opts: IssuesOptions = { repo: ctx.repo };
 	if (ctx.options.labels !== undefined) opts.labels = ctx.options.labels;
-	return new GitHubIssues(ctx.rest, opts);
+	return new GitHubIssues(ctx.client, opts);
 }
 
 // ── Plugin barrel for the core loader ─────────────────────────────────
@@ -109,7 +109,7 @@ export const AUTH_HINT =
 
 export type { Auth };
 export * from "./auth.js";
-export { createGitHubRestClient } from "./rest.js";
+export { createGitHubClient } from "./rest.js";
 export { encryptSecret } from "./sodium.js";
 export { GitHubSource } from "./capabilities/source.js";
 export { GitHubSecrets } from "./capabilities/secrets.js";

--- a/packages/holocron-plugin-github/src/rest.ts
+++ b/packages/holocron-plugin-github/src/rest.ts
@@ -1,16 +1,1 @@
-import { createRestClient, type RequestOptions, type RestClient } from "@theholocron/cli";
-
-export type { RequestOptions, RestClient };
-
-export function createGitHubRestClient(opts: { token: string; baseUrl?: string; fetch?: typeof fetch }): RestClient {
-	return createRestClient({
-		baseUrl: opts.baseUrl ?? "https://api.github.com",
-		token: opts.token,
-		extraHeaders: {
-			accept: "application/vnd.github+json",
-			"x-github-api-version": "2022-11-28",
-		},
-		vendor: "GitHub",
-		fetch: opts.fetch,
-	});
-}
+export { createGitHubClient, type GitHubClientOptions } from "@theholocron/github-client";

--- a/packages/holocron-plugin-github/src/verify-token.ts
+++ b/packages/holocron-plugin-github/src/verify-token.ts
@@ -9,7 +9,7 @@
  * what we don't have yet at bootstrap time.
  */
 
-import { createGitHubRestClient } from "./rest.js";
+import { createGitHubClient } from "./rest.js";
 
 export interface VerifyTokenSuccess {
 	ok: true;
@@ -23,21 +23,15 @@ export interface VerifyTokenFailure {
 
 export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
 
-interface UserResponse {
-	login?: string;
-	name?: string | null;
-	email?: string | null;
-}
-
 export interface VerifyTokenOptions {
 	baseUrl?: string;
 	fetch?: typeof fetch;
 }
 
 export async function verifyToken(token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
-	const rest = createGitHubRestClient({ token, baseUrl: opts.baseUrl, fetch: opts.fetch });
+	const client = createGitHubClient({ token, baseUrl: opts.baseUrl, fetch: opts.fetch });
 	try {
-		const me = await rest.request<UserResponse>("/user");
+		const me = await client.user.getCurrentUser();
 		const subject = me.login ?? me.email ?? "unknown";
 		return { ok: true, subject: `user @ ${subject}` };
 	} catch (err) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ catalogs:
       specifier: ^4.1.10
       version: 4.1.10
 
+overrides:
+  '@theholocron/http-client': ^0.3.2
+
 importers:
 
   .:
@@ -161,9 +164,12 @@ importers:
       '@napi-rs/keyring':
         specifier: ^1.3.0
         version: 1.3.0
+      '@theholocron/github-client':
+        specifier: ^0.3.2
+        version: 0.3.2
       '@theholocron/http-client':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.3.2
+        version: 0.3.2
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
@@ -413,6 +419,9 @@ importers:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
         version: 5.2.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+      '@theholocron/github-client':
+        specifier: ^0.3.2
+        version: 0.3.2
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 6.0.0(typescript@5.9.3)
@@ -1653,8 +1662,13 @@ packages:
       eslint-plugin-storybook:
         optional: true
 
-  '@theholocron/http-client@0.1.0':
-    resolution: {integrity: sha512-ul45D9F1nQmfbQ5x6Q4zQT20mBnmCZ7HmpSpXWvQPAf0kI8pZfd7rvpuc2fkXBI7w5uDfH+KFoaCGpzL+HDyoA==}
+  '@theholocron/github-client@0.3.2':
+    resolution: {integrity: sha512-bNqZAjymMRA0TN2es4F++yzvYQSjVCURDw40CvSlchXLGZo1yEXMj51foKrypUEJkDi7pV8nnjAbX3rwfll7Tw==}
+    engines: {node: '>=22.0.0'}
+
+  '@theholocron/http-client@0.3.2':
+    resolution: {integrity: sha512-SYrAwP78Akjch0+dxCbkt870ck/OcpJyAgEZw5kfhmb22s1AtMPz6g6YrotzE4ZVyOVTiQpSBQUO/qUpCthHZw==}
+    engines: {node: '>=22.0.0'}
 
   '@theholocron/lint-staged-config@5.2.0':
     resolution: {integrity: sha512-O74y4rxxSnryP/JSPILZy6Hgi3paL4vGEBaovjm0QgkJEEjF334mO04KWy8OgfxprM1KvAYAD7lEiKj6JL38bQ==}
@@ -2046,8 +2060,8 @@ packages:
     resolution: {integrity: sha512-8OG92q3R35qjC/4i6BLBMg8IB+fClWu/1PEwg2Z9Rn+BuNaiEgJzpzn+pxWOdHJWDCAwu2JP0wCDTozAM4QirQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
-  ast-v8-to-istanbul@1.0.4:
-    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -4108,6 +4122,10 @@ packages:
 
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
 
   once@1.4.0:
@@ -6370,7 +6388,11 @@ snapshots:
       eslint-plugin-n: 18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-react: 7.37.5(eslint@10.7.0(jiti@2.6.1))
 
-  '@theholocron/http-client@0.1.0': {}
+  '@theholocron/github-client@0.3.2':
+    dependencies:
+      '@theholocron/http-client': 0.3.2
+
+  '@theholocron/http-client@0.3.2': {}
 
   '@theholocron/lint-staged-config@5.2.0(husky@9.1.7)(imagemin-lint-staged@0.5.1)(lint-staged@16.4.0)':
     dependencies:
@@ -6572,12 +6594,12 @@ snapshots:
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.10
-      ast-v8-to-istanbul: 1.0.4
+      ast-v8-to-istanbul: 1.0.5
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.3
-      obug: 2.1.3
+      obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
       vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
@@ -6825,7 +6847,7 @@ snapshots:
       estree-walker: 3.0.3
       pathe: 2.0.3
 
-  ast-v8-to-istanbul@1.0.4:
+  ast-v8-to-istanbul@1.0.5:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -9271,6 +9293,9 @@ snapshots:
     optional: true
 
   obug@2.1.3: {}
+
+  obug@2.1.4:
+    optional: true
 
   once@1.4.0:
     dependencies:


### PR DESCRIPTION
## Summary

PR 2 of 2 — consumes `@theholocron/github-client` (published in theholocron/clients). Removes all raw HTTP knowledge from `holocron-plugin-github` and the raw `fetch()` calls from `sync-github.ts`.

### `packages/holocron-plugin-github`

- Each capability class (`GitHubSource`, `GitHubCi`, `GitHubSecrets`, `GitHubEnvironments`, `GitHubIssues`) now takes `GitHubClient` instead of `RestClient`
- `src/rest.ts` re-exports `createGitHubClient` from `@theholocron/github-client`
- `labels.ts`, `properties.ts`, `topics.ts` helpers updated to use typed `client.labels.*` / `client.properties.*` / `client.topics.*` methods
- `verify-token.ts` uses `client.user.getCurrentUser()` instead of `rest.request()`
- All test files: `createGitHubRestClient` → `createGitHubClient`, constructors take `GitHubClient`

### `packages/cli`

- `sync-github.ts`: ~80 lines of manual `fetch()` replaced with `createGitHubClient().git.*` calls; error handling changed from `res.ok` checks to `ProviderApiError` catch
- `@theholocron/github-client: ^0.3.2` added as dependency
- `@theholocron/http-client` bumped to `^0.3.2` + root `pnpm.overrides` to deduplicate both `cli` and `github-client` to the same `http-client` instance (prevents `instanceof ProviderApiError` dual-module hazard)

## Test plan

- [x] 111 plugin tests passing
- [x] 274 CLI tests passing  
- [x] Typecheck clean on both packages
- [x] Lint clean on both packages
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->