### PR TITLE
chore: move overrides to pnpm-workspace.yaml and catalog external deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,11 +55,6 @@
     "typescript": "catalog:",
     "typescript-eslint": "^8.62.1"
   },
-  "pnpm": {
-    "overrides": {
-      "@theholocron/http-client": "^0.3.2"
-    }
-  },
   "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": ">=22",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@napi-rs/keyring": "^1.3.0",
-    "@theholocron/github-client": "^0.3.2",
-    "@theholocron/http-client": "^0.3.2",
+    "@theholocron/github-client": "catalog:",
+    "@theholocron/http-client": "catalog:",
     "tsx": "catalog:",
     "yargs": "^18.0.0"
   },

--- a/packages/holocron-plugin-github/package.json
+++ b/packages/holocron-plugin-github/package.json
@@ -27,14 +27,14 @@
   },
   "peerDependencies": {
     "@theholocron/cli": "workspace:*",
-    "@theholocron/github-client": "^0.3.2"
+    "@theholocron/github-client": "catalog:"
   },
   "dependencies": {
     "libsodium-wrappers": "^0.7.15"
   },
   "devDependencies": {
     "@theholocron/cli": "workspace:*",
-    "@theholocron/github-client": "^0.3.2",
+    "@theholocron/github-client": "catalog:",
     "@types/node": "catalog:",
     "@theholocron/eslint-config": "catalog:",
     "@theholocron/tsconfig": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@theholocron/eslint-config':
       specifier: ^5.2.0
       version: 5.2.0
+    '@theholocron/github-client':
+      specifier: ^0.3.2
+      version: 0.3.2
     '@theholocron/lint-staged-config':
       specifier: ^5.2.0
       version: 5.2.0
@@ -165,7 +168,7 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       '@theholocron/github-client':
-        specifier: ^0.3.2
+        specifier: 'catalog:'
         version: 0.3.2
       '@theholocron/http-client':
         specifier: ^0.3.2
@@ -420,7 +423,7 @@ importers:
         specifier: 'catalog:'
         version: 5.2.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/github-client':
-        specifier: ^0.3.2
+        specifier: 'catalog:'
         version: 0.3.2
       '@theholocron/tsconfig':
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,8 @@ packages:
 catalog:
   '@theholocron/commitlint-config': ^6.0.1
   '@theholocron/eslint-config': ^5.2.0
+  '@theholocron/github-client': ^0.3.2
+  '@theholocron/http-client': ^0.3.2
   '@theholocron/lint-staged-config': ^5.2.0
   '@theholocron/prettier-config': ^5.2.0
   '@theholocron/tsconfig': ^6.0.0
@@ -21,3 +23,9 @@ catalog:
   '@vitest/coverage-v8': ^4.1.10
   typescript: ^5.9.3
   '@types/node': ^26
+
+# Force all packages (including external transitive deps) to use the
+# same http-client instance — prevents instanceof ProviderApiError
+# dual-module hazard when github-client and cli both depend on it.
+overrides:
+  '@theholocron/http-client': ^0.3.2


### PR DESCRIPTION
## Summary

- Adds `@theholocron/github-client` and `@theholocron/http-client` to the workspace `catalog:` in `pnpm-workspace.yaml` — packages now reference them via `catalog:` instead of hardcoded `^0.3.2`
- Moves `pnpm.overrides` from root `package.json` into `overrides:` in `pnpm-workspace.yaml`, which is the canonical home for workspace-level config
- Cleans up root `package.json` accordingly

## Test plan

- [x] 111 plugin tests passing
- [x] 274 CLI tests passing
- [x] Single `@theholocron/http-client@0.3.2` in lockfile (no dual-module split)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->