### PR TITLE
docs(claude): document clients package consumption pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,9 @@ When a plugin or the CLI gains a dependency on a `@theholocron/*`
 package published from the clients repo:
 
 1. **Add to catalog** in `pnpm-workspace.yaml` under `catalog:`, e.g.:
-   ```yaml
-   '@theholocron/github-client': ^0.3.2
-   ```
+    ```yaml
+    "@theholocron/github-client": ^0.3.2
+    ```
 2. **Reference via `catalog:`** in the consuming `package.json`
    instead of hardcoding a version.
 3. **The `overrides:` block** in `pnpm-workspace.yaml` already forces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,35 @@ Three repos, one rule per concern:
       (NOT a capability method). Swap auth providers without rewriting
       handlers.
 
+## Consuming packages from `theholocron/clients`
+
+When a plugin or the CLI gains a dependency on a `@theholocron/*`
+package published from the clients repo:
+
+1. **Add to catalog** in `pnpm-workspace.yaml` under `catalog:`, e.g.:
+   ```yaml
+   '@theholocron/github-client': ^0.3.2
+   ```
+2. **Reference via `catalog:`** in the consuming `package.json`
+   instead of hardcoding a version.
+3. **The `overrides:` block** in `pnpm-workspace.yaml` already forces
+   `@theholocron/http-client` to a single version. Any new clients
+   package that transitively depends on `http-client` is covered
+   automatically — no extra override needed unless the new client
+   introduces a different shared dep that could split.
+
+**Why overrides matter:** `@theholocron/github-client` and
+`@theholocron/cli` both depend on `@theholocron/http-client`. Without
+the override, pnpm can resolve them to different versions, creating two
+separate module instances. `instanceof ProviderApiError` then silently
+returns `false` — the same class from different instances is never
+equal. The `overrides:` block in `pnpm-workspace.yaml` collapses all
+resolutions to one version.
+
+**`ProviderApiError.details` is a raw string**, not parsed JSON.
+When checking error body content use `String(err.details).includes(...)`,
+not object destructuring.
+
 ## Code patterns
 
 - **Package manager: pnpm only.** Never use `npm` or `yarn`. Run workspace-wide tasks through Turbo (`pnpm test`, `pnpm build`, etc.); run single-package tasks with `pnpm --filter <name> <script>`.


### PR DESCRIPTION
Adds a new section to CLAUDE.md explaining the three-step pattern for consuming `@theholocron/clients` packages in this workspace: add to catalog, reference via `catalog:`, and why the `overrides:` block is critical for preventing `instanceof ProviderApiError` failures. Also documents that `ProviderApiError.details` is a raw string.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->