### PR TITLE
feat(clerk): migrate plugin to @theholocron/clerk-client

### DIFF
--- a/packages/holocron-plugin-clerk/package.json
+++ b/packages/holocron-plugin-clerk/package.json
@@ -26,9 +26,11 @@
     "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
+    "@theholocron/clerk-client": "catalog:",
     "@theholocron/cli": "workspace:*"
   },
   "devDependencies": {
+    "@theholocron/clerk-client": "catalog:",
     "@theholocron/cli": "workspace:*",
     "@types/node": "catalog:",
     "@theholocron/eslint-config": "catalog:",

--- a/packages/holocron-plugin-clerk/src/__tests__/capability.test.ts
+++ b/packages/holocron-plugin-clerk/src/__tests__/capability.test.ts
@@ -2,14 +2,14 @@ import { ProviderApiError } from "@theholocron/cli";
 import { describe, expect, it } from "vitest";
 
 import { ClerkAuth } from "../capabilities/auth.js";
-import { createClerkRestClient } from "../rest.js";
+import { createClerkClient } from "../rest.js";
 
 import { stubFetch } from "./helpers.js";
 
 function makeAuth(responses: Parameters<typeof stubFetch>[0]) {
 	const { fetch, calls } = stubFetch(responses);
-	const rest = createClerkRestClient({ token: "sk_test_pat", fetch });
-	const auth = new ClerkAuth(rest);
+	const client = createClerkClient({ token: "sk_test_pat", fetch });
+	const auth = new ClerkAuth(client);
 	return { auth, calls };
 }
 

--- a/packages/holocron-plugin-clerk/src/__tests__/rest.test.ts
+++ b/packages/holocron-plugin-clerk/src/__tests__/rest.test.ts
@@ -1,48 +1,37 @@
 import { ProviderApiError } from "@theholocron/cli";
 import { describe, expect, it, vi } from "vitest";
 
-import { createClerkRestClient } from "../rest.js";
+import { createClerkClient } from "../rest.js";
 
 import { stubFetch } from "./helpers.js";
 
 const TOKEN = "sk_test_pat";
 
-describe("ClerkRestClient", () => {
+describe("createClerkClient", () => {
 	it("sends bearer + accept headers on every request", async () => {
 		const { fetch, calls } = stubFetch([{ status: 200, body: { total_count: 0 } }]);
-		const client = createClerkRestClient({ token: TOKEN, fetch });
-		await client.request("/users/count");
+		const client = createClerkClient({ token: TOKEN, fetch });
+		await client.users.count();
 		expect(calls[0]?.url).toBe("https://api.clerk.com/v1/users/count");
 		expect(calls[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
 		expect(calls[0]?.headers.accept).toBe("application/json");
 	});
 
 	it("serializes body on writes and sets content-type", async () => {
-		const { fetch, calls } = stubFetch([{ status: 200, body: { id: "user_x" } }]);
-		const client = createClerkRestClient({ token: TOKEN, fetch });
-		await client.request("/users", { method: "POST", body: { email_address: ["x@y.com"] } });
+		const { fetch, calls } = stubFetch([
+			{ status: 200, body: { id: "user_x", email_addresses: [], object: "user" } },
+		]);
+		const client = createClerkClient({ token: TOKEN, fetch });
+		await client.users.create({ email_address: ["x@y.com"] });
 		expect(calls[0]?.method).toBe("POST");
-		expect(calls[0]?.body).toEqual({ email_address: ["x@y.com"] });
+		expect(calls[0]?.body).toMatchObject({ email_address: ["x@y.com"] });
 		expect(calls[0]?.headers["content-type"]).toBe("application/json");
-	});
-
-	it("appends query params when supplied", async () => {
-		const { fetch, calls } = stubFetch([{ status: 200, body: [] }]);
-		const client = createClerkRestClient({ token: TOKEN, fetch });
-		await client.request("/users", { query: { limit: "10", order_by: "-created_at" } });
-		expect(calls[0]?.url).toBe("https://api.clerk.com/v1/users?limit=10&order_by=-created_at");
-	});
-
-	it("returns undefined on 204", async () => {
-		const { fetch } = stubFetch([{ status: 204 }]);
-		const client = createClerkRestClient({ token: TOKEN, fetch });
-		expect(await client.request("/users/user_x", { method: "DELETE" })).toBeUndefined();
 	});
 
 	it("throws ProviderApiError with status + path on non-2xx", async () => {
 		const { fetch } = stubFetch([{ status: 401, text: "invalid secret key" }]);
-		const client = createClerkRestClient({ token: TOKEN, fetch });
-		const err = await client.request("/users/count").catch((e: unknown) => e);
+		const client = createClerkClient({ token: TOKEN, fetch });
+		const err = await client.users.count().catch((e: unknown) => e);
 		expect(err).toBeInstanceOf(ProviderApiError);
 		const pae = err as ProviderApiError;
 		expect(pae.status).toBe(401);
@@ -53,8 +42,8 @@ describe("ClerkRestClient", () => {
 		const failingFetch: typeof fetch = vi.fn(async () => {
 			throw new TypeError("fetch failed");
 		});
-		const client = createClerkRestClient({ token: TOKEN, fetch: failingFetch });
-		const err = await client.request("/users/count").catch((e: unknown) => e);
+		const client = createClerkClient({ token: TOKEN, fetch: failingFetch });
+		const err = await client.users.count().catch((e: unknown) => e);
 		expect(err).toBeInstanceOf(ProviderApiError);
 		expect((err as ProviderApiError).status).toBe(0);
 		expect((err as ProviderApiError).message).toContain("Clerk GET /users/count failed");

--- a/packages/holocron-plugin-clerk/src/capabilities/auth.ts
+++ b/packages/holocron-plugin-clerk/src/capabilities/auth.ts
@@ -34,28 +34,16 @@ import type {
 	WebhookDashboardInfo,
 } from "@theholocron/cli";
 
-import type { RestClient } from "@theholocron/cli";
+import type { ClerkClient } from "../rest.js";
 
 export type ClerkAuthOptions = Record<string, never>;
-
-interface ClerkCreateUserResponse {
-	id: string;
-	email_addresses: Array<{ email_address: string }>;
-}
-
-interface ClerkSvixUrlResponse {
-	/** Older endpoint shape. */
-	url?: string;
-	/** Newer endpoint shape. */
-	svix_url?: string;
-}
 
 export class ClerkAuth implements Auth {
 	readonly key = "auth" as const;
 	readonly providerName = "clerk";
 
 	constructor(
-		private readonly rest: RestClient,
+		private readonly client: ClerkClient,
 		_opts: ClerkAuthOptions = {}
 	) {}
 
@@ -71,10 +59,10 @@ export class ClerkAuth implements Auth {
 	// ── whoami ──────────────────────────────────────────────────────────
 
 	async whoami(): Promise<AuthIdentity> {
-		const body = await this.rest.request<{ total_count: number }>("/users/count");
+		const result = await this.client.users.count();
 		return {
 			provider: "clerk",
-			details: { userCount: body.total_count },
+			details: { userCount: result.total_count },
 		};
 	}
 
@@ -82,7 +70,7 @@ export class ClerkAuth implements Auth {
 
 	async ensureWebhookApp(): Promise<{ alreadyExists: boolean }> {
 		try {
-			await this.rest.request<void>("/webhooks/svix", { method: "POST" });
+			await this.client.webhooks.ensureSvixApp();
 			return { alreadyExists: false };
 		} catch (err) {
 			if (err instanceof ProviderApiError && isAlreadyExistsError(err)) {
@@ -93,9 +81,7 @@ export class ClerkAuth implements Auth {
 	}
 
 	async getWebhookDashboardUrl(): Promise<WebhookDashboardInfo> {
-		const body = await this.rest.request<ClerkSvixUrlResponse>("/webhooks/svix_url", {
-			method: "POST",
-		});
+		const body = await this.client.webhooks.getSvixUrl();
 		const url = body.url ?? body.svix_url;
 		if (!url) {
 			throw new ProviderApiError("Clerk POST /webhooks/svix_url returned 200 but no `url` field", 500, undefined);
@@ -106,17 +92,14 @@ export class ClerkAuth implements Auth {
 	// ── users ───────────────────────────────────────────────────────────
 
 	async createUser(input: CreateAuthUserInput): Promise<AuthUser> {
-		const body = await this.rest.request<ClerkCreateUserResponse>("/users", {
-			method: "POST",
-			body: {
-				email_address: [input.email],
-				password: input.password,
-				...(input.firstName ? { first_name: input.firstName } : {}),
-				...(input.lastName ? { last_name: input.lastName } : {}),
-			},
+		const user = await this.client.users.create({
+			email_address: [input.email],
+			password: input.password,
+			...(input.firstName ? { first_name: input.firstName } : {}),
+			...(input.lastName ? { last_name: input.lastName } : {}),
 		});
-		const email = body.email_addresses[0]?.email_address ?? input.email;
-		return { id: body.id, email };
+		const email = user.email_addresses[0]?.email_address ?? input.email;
+		return { id: user.id, email };
 	}
 }
 

--- a/packages/holocron-plugin-clerk/src/index.ts
+++ b/packages/holocron-plugin-clerk/src/index.ts
@@ -5,11 +5,11 @@
  * See README for auth + config docs.
  */
 
-import type { Auth, RestClient } from "@theholocron/cli";
+import type { Auth } from "@theholocron/cli";
 
 import { resolveToken, type ResolveTokenInput } from "./auth.js";
 import { ClerkAuth } from "./capabilities/auth.js";
-import { createClerkRestClient } from "./rest.js";
+import { createClerkClient, type ClerkClient } from "./rest.js";
 
 export interface ClerkPluginOptions extends ResolveTokenInput {
 	/** Override base URL for tests. */
@@ -20,19 +20,19 @@ export interface ClerkPluginOptions extends ResolveTokenInput {
 
 export interface PluginContext {
 	options: ClerkPluginOptions;
-	rest: RestClient;
+	client: ClerkClient;
 }
 
 export function createContext(options: ClerkPluginOptions = {}): PluginContext {
 	const token = resolveToken(options);
 	return {
 		options,
-		rest: createClerkRestClient({ token, baseUrl: options.baseUrl, fetch: options.fetch }),
+		client: createClerkClient({ token, baseUrl: options.baseUrl, fetch: options.fetch }),
 	};
 }
 
 export function auth(ctx: PluginContext): Auth {
-	return new ClerkAuth(ctx.rest);
+	return new ClerkAuth(ctx.client);
 }
 
 export function createPlugin(options: ClerkPluginOptions = {}) {
@@ -58,7 +58,7 @@ export const AUTH_HINT =
 // ── Public re-exports ────────────────────────────────────────────────
 
 export * from "./auth.js";
-export { createClerkRestClient } from "./rest.js";
+export { createClerkClient } from "./rest.js";
 export { ClerkAuth } from "./capabilities/auth.js";
 export { parseWebhook } from "./parse-webhook.js";
 export { verifyToken } from "./verify-token.js";

--- a/packages/holocron-plugin-clerk/src/rest.ts
+++ b/packages/holocron-plugin-clerk/src/rest.ts
@@ -1,12 +1,5 @@
-import { createRestClient, type RequestOptions, type RestClient } from "@theholocron/cli";
-
-export type { RequestOptions, RestClient };
-
-export function createClerkRestClient(opts: { token: string; baseUrl?: string; fetch?: typeof fetch }): RestClient {
-	return createRestClient({
-		baseUrl: opts.baseUrl ?? "https://api.clerk.com/v1",
-		token: opts.token,
-		vendor: "Clerk",
-		fetch: opts.fetch,
-	});
-}
+export {
+	createClerkClient,
+	type ClerkClient,
+	type ClerkClientOptions,
+} from "@theholocron/clerk-client";

--- a/packages/holocron-plugin-clerk/src/verify-token.ts
+++ b/packages/holocron-plugin-clerk/src/verify-token.ts
@@ -9,7 +9,7 @@
  * canonical "is this secret key valid?" endpoint.
  */
 
-import { createClerkRestClient } from "./rest.js";
+import { createClerkClient } from "./rest.js";
 
 export interface VerifyTokenSuccess {
 	ok: true;
@@ -23,23 +23,17 @@ export interface VerifyTokenFailure {
 
 export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
 
-interface InstanceResponse {
-	id?: string;
-	environment_type?: string; // "development" | "production" | "staging"
-	object?: string;
-}
-
 export interface VerifyTokenOptions {
 	baseUrl?: string;
 	fetch?: typeof fetch;
 }
 
 export async function verifyToken(token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
-	const rest = createClerkRestClient({ token, baseUrl: opts.baseUrl, fetch: opts.fetch });
+	const client = createClerkClient({ token, baseUrl: opts.baseUrl, fetch: opts.fetch });
 	try {
-		const instance = await rest.request<InstanceResponse>("/instance");
-		const env = instance?.environment_type ?? "unknown";
-		const id = instance?.id ?? "unknown";
+		const inst = await client.instance.get();
+		const env = inst?.environment_type ?? "unknown";
+		const id = inst?.id ?? "unknown";
 		return { ok: true, subject: `${env} instance ${id}` };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@theholocron/clerk-client':
+      specifier: ^0.3.2
+      version: 0.3.2
     '@theholocron/commitlint-config':
       specifier: ^6.0.1
       version: 6.0.1
@@ -328,6 +331,9 @@ importers:
 
   packages/holocron-plugin-clerk:
     devDependencies:
+      '@theholocron/clerk-client':
+        specifier: 'catalog:'
+        version: 0.3.2
       '@theholocron/cli':
         specifier: workspace:*
         version: link:../cli
@@ -1637,6 +1643,10 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@theholocron/clerk-client@0.3.2':
+    resolution: {integrity: sha512-RP/XOqIzupxjRF/uao0eXa7OfBBqxoagxjBoihn1NSSB35oO6uS4y/G74VleQOV9DDac5oXa396diiMIJt9jsg==}
+    engines: {node: '>=22.0.0'}
 
   '@theholocron/commitlint-config@6.0.1':
     resolution: {integrity: sha512-t/wQNXpseoCYI5ngPP1B7KkH9Xkg3n13KKE2GN92c0BQSMSOnbZgxes9v+LKznXK9vaCxW3kN5Z+y7UTkOx3Zg==}
@@ -6395,6 +6405,10 @@ snapshots:
       text-hex: 1.0.0
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@theholocron/clerk-client@0.3.2':
+    dependencies:
+      '@theholocron/http-client': 0.3.2
 
   '@theholocron/commitlint-config@6.0.1(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@theholocron/clerk-client':
-      specifier: ^0.3.2
-      version: 0.3.2
+      specifier: ^0.5.0
+      version: 0.5.0
     '@theholocron/commitlint-config':
       specifier: ^6.0.1
       version: 6.0.1
@@ -333,7 +333,7 @@ importers:
     devDependencies:
       '@theholocron/clerk-client':
         specifier: 'catalog:'
-        version: 0.3.2
+        version: 0.5.0
       '@theholocron/cli':
         specifier: workspace:*
         version: link:../cli
@@ -1644,8 +1644,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@theholocron/clerk-client@0.3.2':
-    resolution: {integrity: sha512-RP/XOqIzupxjRF/uao0eXa7OfBBqxoagxjBoihn1NSSB35oO6uS4y/G74VleQOV9DDac5oXa396diiMIJt9jsg==}
+  '@theholocron/clerk-client@0.5.0':
+    resolution: {integrity: sha512-9HWbS3gbmMA3onCAOO7de9Vtv0Yt8Wxy1keDaKz0PntVAKCI3V0+p+CBRsGDfxR8SmDPNH3gBD6L7SooBoLjsw==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/commitlint-config@6.0.1':
@@ -6406,7 +6406,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@theholocron/clerk-client@0.3.2':
+  '@theholocron/clerk-client@0.5.0':
     dependencies:
       '@theholocron/http-client': 0.3.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ catalogs:
       specifier: ^5.2.0
       version: 5.2.0
     '@theholocron/github-client':
-      specifier: ^0.3.2
-      version: 0.3.2
+      specifier: ^0.5.0
+      version: 0.5.0
     '@theholocron/lint-staged-config':
       specifier: ^5.2.0
       version: 5.2.0
@@ -65,7 +65,7 @@ catalogs:
       version: 4.1.10
 
 overrides:
-  '@theholocron/http-client': ^0.3.2
+  '@theholocron/http-client': ^0.5.0
 
 importers:
 
@@ -178,10 +178,10 @@ importers:
         version: 1.3.0
       '@theholocron/github-client':
         specifier: 'catalog:'
-        version: 0.3.2
+        version: 0.5.0
       '@theholocron/http-client':
-        specifier: ^0.3.2
-        version: 0.3.2
+        specifier: ^0.5.0
+        version: 0.5.0
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
@@ -436,7 +436,7 @@ importers:
         version: 5.2.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/github-client':
         specifier: 'catalog:'
-        version: 0.3.2
+        version: 0.5.0
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 6.0.0(typescript@5.9.3)
@@ -1681,12 +1681,12 @@ packages:
       eslint-plugin-storybook:
         optional: true
 
-  '@theholocron/github-client@0.3.2':
-    resolution: {integrity: sha512-bNqZAjymMRA0TN2es4F++yzvYQSjVCURDw40CvSlchXLGZo1yEXMj51foKrypUEJkDi7pV8nnjAbX3rwfll7Tw==}
+  '@theholocron/github-client@0.5.0':
+    resolution: {integrity: sha512-/xHV6FytyMtLrz7h46uHVS+Neb0PkOSfWaLzkgTF4f7mDL7kfAfLVEFTfVSAdTfV+fwOoWlQdGsJg84hc+Vzpg==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/http-client@0.3.2':
-    resolution: {integrity: sha512-SYrAwP78Akjch0+dxCbkt870ck/OcpJyAgEZw5kfhmb22s1AtMPz6g6YrotzE4ZVyOVTiQpSBQUO/qUpCthHZw==}
+  '@theholocron/http-client@0.5.0':
+    resolution: {integrity: sha512-W1JO8JCsAXf/koPzxAPAZqdG1rkXrsEfW/TpRL0vW9lFYrbsUWkyEH850bR5wOiYUL2J0ZgjEB18rRn4BAPhPA==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/lint-staged-config@5.2.0':
@@ -6408,7 +6408,7 @@ snapshots:
 
   '@theholocron/clerk-client@0.5.0':
     dependencies:
-      '@theholocron/http-client': 0.3.2
+      '@theholocron/http-client': 0.5.0
 
   '@theholocron/commitlint-config@6.0.1(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)':
     dependencies:
@@ -6426,11 +6426,11 @@ snapshots:
       eslint-plugin-n: 18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-react: 7.37.5(eslint@10.7.0(jiti@2.6.1))
 
-  '@theholocron/github-client@0.3.2':
+  '@theholocron/github-client@0.5.0':
     dependencies:
-      '@theholocron/http-client': 0.3.2
+      '@theholocron/http-client': 0.5.0
 
-  '@theholocron/http-client@0.3.2': {}
+  '@theholocron/http-client@0.5.0': {}
 
   '@theholocron/lint-staged-config@5.2.0(husky@9.1.7)(imagemin-lint-staged@0.5.1)(lint-staged@16.4.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ catalog:
   '@theholocron/commitlint-config': ^6.0.1
   '@theholocron/semantic-release-config': ^6.1.0
   '@theholocron/eslint-config': ^5.2.0
+  '@theholocron/clerk-client': ^0.3.2
   '@theholocron/github-client': ^0.3.2
   '@theholocron/http-client': ^0.3.2
   '@theholocron/lint-staged-config': ^5.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,8 @@ catalog:
   '@theholocron/semantic-release-config': ^6.1.0
   '@theholocron/eslint-config': ^5.2.0
   '@theholocron/clerk-client': ^0.5.0
-  '@theholocron/github-client': ^0.3.2
-  '@theholocron/http-client': ^0.3.2
+  '@theholocron/github-client': ^0.5.0
+  '@theholocron/http-client': ^0.5.0
   '@theholocron/lint-staged-config': ^5.2.0
   '@theholocron/prettier-config': ^5.2.0
   '@theholocron/tsconfig': ^6.0.0
@@ -30,4 +30,4 @@ catalog:
 # same http-client instance — prevents instanceof ProviderApiError
 # dual-module hazard when github-client and cli both depend on it.
 overrides:
-  '@theholocron/http-client': ^0.3.2
+  '@theholocron/http-client': ^0.5.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ catalog:
   '@theholocron/commitlint-config': ^6.0.1
   '@theholocron/semantic-release-config': ^6.1.0
   '@theholocron/eslint-config': ^5.2.0
-  '@theholocron/clerk-client': ^0.3.2
+  '@theholocron/clerk-client': ^0.5.0
   '@theholocron/github-client': ^0.3.2
   '@theholocron/http-client': ^0.3.2
   '@theholocron/lint-staged-config': ^5.2.0


### PR DESCRIPTION
## Summary

Replaces the inline rest client in `holocron-plugin-clerk` with the typed `ClerkClient` from `@theholocron/clerk-client`, following the same pattern as the github plugin migration (#152).

- `rest.ts` — re-exports `createClerkClient` and `ClerkClient` from the package (was: inline `createRestClient` wrapper)
- `capabilities/auth.ts` — `ClerkAuth` takes `ClerkClient`; `whoami` uses `client.users.count()`, `createUser` uses `client.users.create()`, webhook methods use `client.webhooks.*`
- `verify-token.ts` — uses `client.instance.get()` instead of raw `rest.request("/instance")`
- `index.ts` — `PluginContext.client: ClerkClient` (was `rest: RestClient`)
- Tests updated: `createClerkClient` throughout; `rest.test.ts` covers transport behavior via the typed client

Workspace catalog bumped to `@theholocron/clerk-client: ^0.5.0` (adds `webhooks`, `instance`, `baseUrl` — clients #134).

## Test plan

- [x] `pnpm --filter @theholocron/holocron-plugin-clerk typecheck` — passes
- [x] `pnpm --filter @theholocron/holocron-plugin-clerk lint` — passes
- [x] `pnpm --filter @theholocron/holocron-plugin-clerk test` — 41 tests pass across 6 suites
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->