### PR TITLE
feat(doppler): migrate plugin to @theholocron/doppler-client

### DIFF
--- a/packages/holocron-plugin-clerk/src/rest.ts
+++ b/packages/holocron-plugin-clerk/src/rest.ts
@@ -1,5 +1,1 @@
-export {
-	createClerkClient,
-	type ClerkClient,
-	type ClerkClientOptions,
-} from "@theholocron/clerk-client";
+export { createClerkClient, type ClerkClient, type ClerkClientOptions } from "@theholocron/clerk-client";

--- a/packages/holocron-plugin-doppler/package.json
+++ b/packages/holocron-plugin-doppler/package.json
@@ -26,10 +26,12 @@
     "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
-    "@theholocron/cli": "workspace:*"
+    "@theholocron/cli": "workspace:*",
+    "@theholocron/doppler-client": "catalog:"
   },
   "devDependencies": {
     "@theholocron/cli": "workspace:*",
+    "@theholocron/doppler-client": "catalog:",
     "@types/node": "catalog:",
     "@theholocron/eslint-config": "catalog:",
     "@theholocron/tsconfig": "catalog:",

--- a/packages/holocron-plugin-doppler/src/__tests__/rest.test.ts
+++ b/packages/holocron-plugin-doppler/src/__tests__/rest.test.ts
@@ -1,57 +1,41 @@
 import { ProviderApiError } from "@theholocron/cli";
 import { describe, expect, it } from "vitest";
 
-import { createDopplerRestClient } from "../rest.js";
+import { createDopplerClient } from "../rest.js";
 import { stubFetch } from "./helpers.js";
 
-describe("DopplerRestClient", () => {
+describe("createDopplerClient", () => {
 	it("sends bearer + accept headers and returns the parsed body", async () => {
 		const stub = stubFetch([{ status: 200, body: { workplace: { name: "acme" } } }]);
-		const client = createDopplerRestClient({ token: "dp.pt.abc", fetch: stub.fetch });
-		const res = await client.request<{ workplace: { name: string } }>("/me");
-		expect(res.workplace.name).toBe("acme");
+		const client = createDopplerClient({ token: "dp.pt.abc", fetch: stub.fetch });
+		const res = await client.me.get();
+		expect(res.workplace?.name).toBe("acme");
 		expect(stub.calls[0]?.headers["authorization"]).toBe("Bearer dp.pt.abc");
 		expect(stub.calls[0]?.headers["accept"]).toBe("application/json");
 	});
 
 	it("serializes body as JSON and sets content-type when present", async () => {
-		const stub = stubFetch([{ status: 200, body: {} }]);
-		const client = createDopplerRestClient({ token: "t", fetch: stub.fetch });
-		await client.request<unknown>("/projects", { method: "POST", body: { name: "demo" } });
+		const stub = stubFetch([{ status: 200, body: { project: {} } }]);
+		const client = createDopplerClient({ token: "t", fetch: stub.fetch });
+		await client.projects.create("demo");
 		expect(stub.calls[0]?.method).toBe("POST");
 		expect(stub.calls[0]?.headers["content-type"]).toBe("application/json");
-		expect(stub.calls[0]?.body).toEqual({ name: "demo" });
+		expect(stub.calls[0]?.body).toMatchObject({ name: "demo" });
 	});
 
 	it("appends query params to the URL", async () => {
-		const stub = stubFetch([{ status: 200, body: {} }]);
-		const client = createDopplerRestClient({ token: "t", fetch: stub.fetch });
-		await client.request<unknown>("/configs/config/secret", {
-			query: { project: "demo", config: "dev", name: "API_KEY" },
-		});
+		const stub = stubFetch([{ status: 200, body: { name: "API_KEY", value: {} } }]);
+		const client = createDopplerClient({ token: "t", fetch: stub.fetch });
+		await client.secrets.get("demo", "dev", "API_KEY");
 		expect(stub.calls[0]?.url).toMatch(/project=demo/);
 		expect(stub.calls[0]?.url).toMatch(/config=dev/);
 		expect(stub.calls[0]?.url).toMatch(/name=API_KEY/);
 	});
 
-	it("returns undefined on 204", async () => {
-		const stub = stubFetch([{ status: 204 }]);
-		const client = createDopplerRestClient({ token: "t", fetch: stub.fetch });
-		const res = await client.request<unknown>("/whatever");
-		expect(res).toBeUndefined();
-	});
-
-	it("returns undefined on expectNoContent even with 200", async () => {
-		const stub = stubFetch([{ status: 200, body: { ignored: true } }]);
-		const client = createDopplerRestClient({ token: "t", fetch: stub.fetch });
-		const res = await client.request<unknown>("/whatever", { expectNoContent: true });
-		expect(res).toBeUndefined();
-	});
-
 	it("throws ProviderApiError with the HTTP status on non-2xx", async () => {
 		const stub = stubFetch([{ status: 401, body: { messages: ["invalid token"] } }]);
-		const client = createDopplerRestClient({ token: "bad", fetch: stub.fetch });
-		const err = await client.request<unknown>("/me").catch((e: unknown) => e);
+		const client = createDopplerClient({ token: "bad", fetch: stub.fetch });
+		const err = await client.me.get().catch((e: unknown) => e);
 		expect(err).toBeInstanceOf(ProviderApiError);
 		expect((err as ProviderApiError).status).toBe(401);
 		expect((err as ProviderApiError).message).toMatch(/→ 401/);
@@ -61,15 +45,10 @@ describe("DopplerRestClient", () => {
 		const throwing: typeof fetch = async () => {
 			throw new TypeError("fetch failed");
 		};
-		const client = createDopplerRestClient({ token: "t", fetch: throwing });
-		const err = await client.request<unknown>("/me").catch((e: unknown) => e);
+		const client = createDopplerClient({ token: "t", fetch: throwing });
+		const err = await client.me.get().catch((e: unknown) => e);
 		expect(err).toBeInstanceOf(ProviderApiError);
 		expect((err as ProviderApiError).status).toBe(0);
 		expect((err as ProviderApiError).message).toMatch(/TypeError: fetch failed/);
-	});
-
-	it("trims trailing slashes from the base URL", () => {
-		const client = createDopplerRestClient({ token: "t", baseUrl: "https://api.doppler.com/v3///" });
-		expect(client.baseUrl).toBe("https://api.doppler.com/v3");
 	});
 });

--- a/packages/holocron-plugin-doppler/src/__tests__/vault.test.ts
+++ b/packages/holocron-plugin-doppler/src/__tests__/vault.test.ts
@@ -2,12 +2,12 @@ import { ProviderApiError } from "@theholocron/cli";
 import { describe, expect, it } from "vitest";
 
 import { DopplerVault } from "../capabilities/vault.js";
-import { createDopplerRestClient } from "../rest.js";
+import { createDopplerClient } from "../rest.js";
 import { stubFetch } from "./helpers.js";
 
 function makeClient(responses: Array<{ status?: number; body?: unknown }>) {
 	const stub = stubFetch(responses);
-	const client = createDopplerRestClient({ token: "t", fetch: stub.fetch });
+	const client = createDopplerClient({ token: "t", fetch: stub.fetch });
 	return { client, stub };
 }
 

--- a/packages/holocron-plugin-doppler/src/capabilities/vault.ts
+++ b/packages/holocron-plugin-doppler/src/capabilities/vault.ts
@@ -26,31 +26,13 @@
 import { ProviderApiError } from "@theholocron/cli";
 import type { EnsureResult, Vault } from "@theholocron/cli";
 
-import type { RestClient } from "@theholocron/cli";
+import type { DopplerClient } from "../rest.js";
 
 export interface DopplerVaultOptions {
 	/** Default project — read/list/etc. operate here unless overridden. */
 	project: string;
 	/** Default config name — dev / stg / prd, etc. */
 	config: string;
-}
-
-interface SecretsListResponse {
-	secrets?: Record<string, { raw?: string; computed?: string } | null>;
-}
-
-interface SecretReadResponse {
-	name?: string;
-	value?: { raw?: string; computed?: string } | null;
-}
-
-interface SecretsDownloadResponse {
-	// `format=json` returns `{NAME: "value", ...}` at the top level.
-	[key: string]: string;
-}
-
-interface EnvironmentsListResponse {
-	environments?: Array<{ id?: string; name?: string; slug?: string }>;
 }
 
 export class DopplerVault implements Vault {
@@ -61,7 +43,7 @@ export class DopplerVault implements Vault {
 	private readonly config: string;
 
 	constructor(
-		private readonly rest: RestClient,
+		private readonly client: DopplerClient,
 		opts: DopplerVaultOptions
 	) {
 		if (!opts.project) {
@@ -78,44 +60,29 @@ export class DopplerVault implements Vault {
 
 	async read(reference: string): Promise<string> {
 		const parsed = parseReference(reference);
-		const res = await this.rest.request<SecretReadResponse>("/configs/config/secret", {
-			query: { project: parsed.project, config: parsed.config, name: parsed.name },
-		});
+		const res = await this.client.secrets.get(parsed.project, parsed.config, parsed.name);
 		return res.value?.computed ?? res.value?.raw ?? "";
 	}
 
 	async write(reference: string, value: string): Promise<void> {
 		const parsed = parseReference(reference);
-		await this.rest.request<unknown>("/configs/config/secrets", {
-			method: "POST",
-			body: {
-				project: parsed.project,
-				config: parsed.config,
-				secrets: { [parsed.name]: value },
-			},
-		});
+		await this.client.secrets.update(parsed.project, parsed.config, { [parsed.name]: value });
 	}
 
 	async list(): Promise<string[]> {
-		const res = await this.rest.request<SecretsListResponse>("/configs/config/secrets", {
-			query: { project: this.project, config: this.config },
-		});
+		const res = await this.client.secrets.list(this.project, this.config);
 		return Object.keys(res.secrets ?? {});
 	}
 
 	// ── environments ────────────────────────────────────────────────────
 
 	async environments(): Promise<string[]> {
-		const res = await this.rest.request<EnvironmentsListResponse>("/environments", {
-			query: { project: this.project },
-		});
+		const res = await this.client.environments.list(this.project);
 		return (res.environments ?? []).map((e) => e.slug ?? e.name ?? "").filter(Boolean);
 	}
 
 	async readEnvironment(environmentId: string): Promise<Record<string, string>> {
-		const res = await this.rest.request<SecretsDownloadResponse>("/configs/config/secrets/download", {
-			query: { project: this.project, config: environmentId, format: "json" },
-		});
+		const res = await this.client.secrets.download(this.project, environmentId);
 		// Filter out any non-string entries defensively.
 		const out: Record<string, string> = {};
 		for (const [k, v] of Object.entries(res)) {
@@ -128,10 +95,7 @@ export class DopplerVault implements Vault {
 
 	async ensureProject(name: string): Promise<EnsureResult> {
 		try {
-			await this.rest.request<unknown>("/projects", {
-				method: "POST",
-				body: { name, description: `Managed by holocron` },
-			});
+			await this.client.projects.create(name, "Managed by holocron");
 			return { alreadyExists: false };
 		} catch (err) {
 			if (isConflict(err)) return { alreadyExists: true };
@@ -141,10 +105,7 @@ export class DopplerVault implements Vault {
 
 	async ensureEnvironment(project: string, name: string): Promise<EnsureResult> {
 		try {
-			await this.rest.request<unknown>("/environments", {
-				method: "POST",
-				body: { project, name, slug: name },
-			});
+			await this.client.environments.create(project, name, name);
 			return { alreadyExists: false };
 		} catch (err) {
 			if (isConflict(err)) return { alreadyExists: true };

--- a/packages/holocron-plugin-doppler/src/index.ts
+++ b/packages/holocron-plugin-doppler/src/index.ts
@@ -6,11 +6,11 @@
  * for auth + config docs.
  */
 
-import type { RestClient, Vault } from "@theholocron/cli";
+import type { Vault } from "@theholocron/cli";
 
 import { resolveToken, type ResolveTokenInput } from "./auth.js";
 import { DopplerVault, type DopplerVaultOptions } from "./capabilities/vault.js";
-import { createDopplerRestClient } from "./rest.js";
+import { createDopplerClient, type DopplerClient } from "./rest.js";
 
 export interface DopplerPluginOptions extends ResolveTokenInput, DopplerVaultOptions {
 	/** Override base URL for tests. */
@@ -21,19 +21,19 @@ export interface DopplerPluginOptions extends ResolveTokenInput, DopplerVaultOpt
 
 export interface PluginContext {
 	options: DopplerPluginOptions;
-	rest: RestClient;
+	client: DopplerClient;
 }
 
 export function createContext(options: DopplerPluginOptions): PluginContext {
 	const token = resolveToken(options);
 	return {
 		options,
-		rest: createDopplerRestClient({ token, baseUrl: options.baseUrl, fetch: options.fetch }),
+		client: createDopplerClient({ token, baseUrl: options.baseUrl, fetch: options.fetch }),
 	};
 }
 
 export function vault(ctx: PluginContext): Vault {
-	return new DopplerVault(ctx.rest, { project: ctx.options.project, config: ctx.options.config });
+	return new DopplerVault(ctx.client, { project: ctx.options.project, config: ctx.options.config });
 }
 
 export function createPlugin(options: DopplerPluginOptions) {
@@ -57,7 +57,7 @@ export const AUTH_HINT =
 // ── Public re-exports ────────────────────────────────────────────────
 
 export * from "./auth.js";
-export { createDopplerRestClient } from "./rest.js";
+export { createDopplerClient } from "./rest.js";
 export { DopplerVault } from "./capabilities/vault.js";
 export { verifyToken } from "./verify-token.js";
 export type { VerifyTokenResult, VerifyTokenSuccess, VerifyTokenFailure } from "./verify-token.js";

--- a/packages/holocron-plugin-doppler/src/rest.ts
+++ b/packages/holocron-plugin-doppler/src/rest.ts
@@ -1,12 +1,5 @@
-import { createRestClient, type RequestOptions, type RestClient } from "@theholocron/cli";
-
-export type { RequestOptions, RestClient };
-
-export function createDopplerRestClient(opts: { token: string; baseUrl?: string; fetch?: typeof fetch }): RestClient {
-	return createRestClient({
-		baseUrl: opts.baseUrl ?? "https://api.doppler.com/v3",
-		token: opts.token,
-		vendor: "Doppler",
-		fetch: opts.fetch,
-	});
-}
+export {
+	createDopplerClient,
+	type DopplerClient,
+	type DopplerClientOptions,
+} from "@theholocron/doppler-client";

--- a/packages/holocron-plugin-doppler/src/rest.ts
+++ b/packages/holocron-plugin-doppler/src/rest.ts
@@ -1,5 +1,1 @@
-export {
-	createDopplerClient,
-	type DopplerClient,
-	type DopplerClientOptions,
-} from "@theholocron/doppler-client";
+export { createDopplerClient, type DopplerClient, type DopplerClientOptions } from "@theholocron/doppler-client";

--- a/packages/holocron-plugin-doppler/src/verify-token.ts
+++ b/packages/holocron-plugin-doppler/src/verify-token.ts
@@ -9,7 +9,7 @@
  * what we don't have yet at bootstrap time.
  */
 
-import { createDopplerRestClient } from "./rest.js";
+import { createDopplerClient } from "./rest.js";
 
 export interface VerifyTokenSuccess {
 	ok: true;
@@ -23,26 +23,15 @@ export interface VerifyTokenFailure {
 
 export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
 
-interface MeResponse {
-	/** Token type: "cli", "personal", "service", "service_account". */
-	type?: string;
-	/** Workplace-level identifier. */
-	slug?: string;
-	/** Workplace object (present on account-level tokens). */
-	workplace?: { name?: string; slug?: string };
-	/** Present on user tokens. */
-	name?: string;
-}
-
 export interface VerifyTokenOptions {
 	baseUrl?: string;
 	fetch?: typeof fetch;
 }
 
 export async function verifyToken(token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
-	const rest = createDopplerRestClient({ token, baseUrl: opts.baseUrl, fetch: opts.fetch });
+	const client = createDopplerClient({ token, baseUrl: opts.baseUrl, fetch: opts.fetch });
 	try {
-		const me = await rest.request<MeResponse>("/me");
+		const me = await client.me.get();
 		const workplace = me.workplace?.name ?? me.slug ?? "unknown";
 		const kind = me.type ?? "token";
 		return { ok: true, subject: `${kind} @ ${workplace}` };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,17 +7,20 @@ settings:
 catalogs:
   default:
     '@theholocron/clerk-client':
-      specifier: ^0.5.0
-      version: 0.5.0
+      specifier: ^0.6.2
+      version: 0.6.2
     '@theholocron/commitlint-config':
       specifier: ^6.0.1
       version: 6.0.1
+    '@theholocron/doppler-client':
+      specifier: ^0.6.2
+      version: 0.6.2
     '@theholocron/eslint-config':
       specifier: ^5.2.0
       version: 5.2.0
     '@theholocron/github-client':
-      specifier: ^0.5.0
-      version: 0.5.0
+      specifier: ^0.6.2
+      version: 0.6.2
     '@theholocron/lint-staged-config':
       specifier: ^5.2.0
       version: 5.2.0
@@ -65,7 +68,7 @@ catalogs:
       version: 4.1.10
 
 overrides:
-  '@theholocron/http-client': ^0.5.0
+  '@theholocron/http-client': ^0.6.2
 
 importers:
 
@@ -178,10 +181,10 @@ importers:
         version: 1.3.0
       '@theholocron/github-client':
         specifier: 'catalog:'
-        version: 0.5.0
+        version: 0.6.2
       '@theholocron/http-client':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.2
+        version: 0.6.2
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
@@ -333,7 +336,7 @@ importers:
     devDependencies:
       '@theholocron/clerk-client':
         specifier: 'catalog:'
-        version: 0.5.0
+        version: 0.6.2
       '@theholocron/cli':
         specifier: workspace:*
         version: link:../cli
@@ -382,6 +385,9 @@ importers:
       '@theholocron/cli':
         specifier: workspace:*
         version: link:../cli
+      '@theholocron/doppler-client':
+        specifier: 'catalog:'
+        version: 0.6.2
       '@theholocron/eslint-config':
         specifier: 'catalog:'
         version: 5.2.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
@@ -436,7 +442,7 @@ importers:
         version: 5.2.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/github-client':
         specifier: 'catalog:'
-        version: 0.5.0
+        version: 0.6.2
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 6.0.0(typescript@5.9.3)
@@ -1644,8 +1650,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@theholocron/clerk-client@0.5.0':
-    resolution: {integrity: sha512-9HWbS3gbmMA3onCAOO7de9Vtv0Yt8Wxy1keDaKz0PntVAKCI3V0+p+CBRsGDfxR8SmDPNH3gBD6L7SooBoLjsw==}
+  '@theholocron/clerk-client@0.6.2':
+    resolution: {integrity: sha512-cxQXi7XVwZTd+ZN8FIkzNt4dEZGJHEUVcZaUSA8wkD7ZpRHGjTrjQcQurUnh5nodqxba/am3KHwqGn0LU/Ey/Q==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/commitlint-config@6.0.1':
@@ -1653,6 +1659,10 @@ packages:
     peerDependencies:
       '@commitlint/cli': ^19
       '@commitlint/config-conventional': ^19
+
+  '@theholocron/doppler-client@0.6.2':
+    resolution: {integrity: sha512-uim+x1t7e5Hu6oci1irtzTnqjhwZjVfb1qrAu049cDgOBqfNwXpyNyS5/5JKdAF/9im+YZ9ZPaYCA0uhn4b3aw==}
+    engines: {node: '>=22.0.0'}
 
   '@theholocron/eslint-config@5.2.0':
     resolution: {integrity: sha512-qmqXqPvBwPUyL2V6KrkiyYW+QAq5YURtoui0IKZ1J5cFI+F7iYiZZISq1570qFbtSfH0dvw2J+d9y7DElh1uTg==}
@@ -1681,12 +1691,12 @@ packages:
       eslint-plugin-storybook:
         optional: true
 
-  '@theholocron/github-client@0.5.0':
-    resolution: {integrity: sha512-/xHV6FytyMtLrz7h46uHVS+Neb0PkOSfWaLzkgTF4f7mDL7kfAfLVEFTfVSAdTfV+fwOoWlQdGsJg84hc+Vzpg==}
+  '@theholocron/github-client@0.6.2':
+    resolution: {integrity: sha512-WE/niZ+15SZfalXtn/fpIptmVtWHWBwmWmRX0/uVF7dxn/mVNj8em0EogSG1b3KosOB6dNFPNwqoJJRNFy9Sgg==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/http-client@0.5.0':
-    resolution: {integrity: sha512-W1JO8JCsAXf/koPzxAPAZqdG1rkXrsEfW/TpRL0vW9lFYrbsUWkyEH850bR5wOiYUL2J0ZgjEB18rRn4BAPhPA==}
+  '@theholocron/http-client@0.6.2':
+    resolution: {integrity: sha512-NOYWFX16/9Hei5vo3Ev3QyqSAgPW5ro4vTZewGBmLgL9KsgCEwiLK0hQufF9XZq+W2G/lMzlz9uJNKPxcTq4HQ==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/lint-staged-config@5.2.0':
@@ -6406,14 +6416,18 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@theholocron/clerk-client@0.5.0':
+  '@theholocron/clerk-client@0.6.2':
     dependencies:
-      '@theholocron/http-client': 0.5.0
+      '@theholocron/http-client': 0.6.2
 
   '@theholocron/commitlint-config@6.0.1(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)':
     dependencies:
       '@commitlint/cli': 19.8.1(@types/node@26.1.1)(typescript@5.9.3)
       '@commitlint/config-conventional': 19.8.1
+
+  '@theholocron/doppler-client@0.6.2':
+    dependencies:
+      '@theholocron/http-client': 0.6.2
 
   '@theholocron/eslint-config@5.2.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))':
     dependencies:
@@ -6426,11 +6440,11 @@ snapshots:
       eslint-plugin-n: 18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-react: 7.37.5(eslint@10.7.0(jiti@2.6.1))
 
-  '@theholocron/github-client@0.5.0':
+  '@theholocron/github-client@0.6.2':
     dependencies:
-      '@theholocron/http-client': 0.5.0
+      '@theholocron/http-client': 0.6.2
 
-  '@theholocron/http-client@0.5.0': {}
+  '@theholocron/http-client@0.6.2': {}
 
   '@theholocron/lint-staged-config@5.2.0(husky@9.1.7)(imagemin-lint-staged@0.5.1)(lint-staged@16.4.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,10 @@ catalog:
   '@theholocron/commitlint-config': ^6.0.1
   '@theholocron/semantic-release-config': ^6.1.0
   '@theholocron/eslint-config': ^5.2.0
-  '@theholocron/clerk-client': ^0.5.0
-  '@theholocron/github-client': ^0.5.0
-  '@theholocron/http-client': ^0.5.0
+  '@theholocron/clerk-client': ^0.6.2
+  '@theholocron/doppler-client': ^0.6.2
+  '@theholocron/github-client': ^0.6.2
+  '@theholocron/http-client': ^0.6.2
   '@theholocron/lint-staged-config': ^5.2.0
   '@theholocron/prettier-config': ^5.2.0
   '@theholocron/tsconfig': ^6.0.0
@@ -30,4 +31,4 @@ catalog:
 # same http-client instance — prevents instanceof ProviderApiError
 # dual-module hazard when github-client and cli both depend on it.
 overrides:
-  '@theholocron/http-client': ^0.5.0
+  '@theholocron/http-client': ^0.6.2


### PR DESCRIPTION
## Summary

Replaces the inline rest client in `holocron-plugin-doppler` with the typed `DopplerClient` from `@theholocron/doppler-client`, following the same pattern as the clerk and github plugin migrations.

- `rest.ts` — re-exports `createDopplerClient` and `DopplerClient` from the package
- `capabilities/vault.ts` — `DopplerVault` takes `DopplerClient`; all raw `rest.request()` calls replaced with typed methods (`client.secrets.*`, `client.environments.*`, `client.projects.create`, `client.me.get`)
- `verify-token.ts` — uses `client.me.get()` instead of raw rest
- `index.ts` — `PluginContext.client: DopplerClient` (was `rest: RestClient`)
- Tests updated to use `createDopplerClient` throughout
- Workspace catalog bumped to `@theholocron/doppler-client: ^0.6.2`

## Test plan

- [x] `pnpm --filter @theholocron/holocron-plugin-doppler typecheck` — passes
- [x] `pnpm --filter @theholocron/holocron-plugin-doppler test` — 39 tests pass across 5 suites
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->