### PR TITLE
fix(ci): tell codecov test-results-action where to find JUnit XML files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,25 @@ name: Release
 # main  = stable releases (v2.0.0, v2.0.1, …) → npm `latest` dist-tag
 # alpha = prereleases (v2.0.0-alpha.N)       → npm `alpha` dist-tag
 #
-# workflow_dispatch is kept alongside push so alpha/stable releases can
-# also be triggered by hand for recovery / re-runs. The `dry_run` input
-# defaults to true — safe for iterating on release-config changes
-# without accidentally publishing.
+# Push trigger is ALPHA-ONLY until stable v2.0.0 is intentionally cut.
+# The v2 monorepo was squash-merged onto main as a `feat:` commit
+# (d9211ad) before the alpha branch existed, so semantic-release on
+# main will compute `v1.0.0 → v1.1.0` (feat = minor bump) on the very
+# next release-triggering push — accidentally publishing v2 alpha code
+# to npm's `latest` dist-tag as if it were stable v1.1.0. Which is
+# exactly what happened during PR #93's merge; recovery required
+# resetting the `latest` dist-tag + unpublishing v1.1.0. See the
+# `main-channel-prerelease-gotcha` memory for context.
+#
+# When stable v2.0.0 IS ready: dispatch manually first to verify the
+# computed version, then re-add `main` to the push branches list.
+#
+# workflow_dispatch is kept alongside push so alpha releases can be
+# triggered by hand for recovery / re-runs. The `dry_run` input defaults
+# to true — safe for iterating on release-config changes.
 on:
   push:
     branches:
-      - main
       - alpha
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,24 @@
 name: Release
 
-# PAUSED (push trigger disabled). Trigger manually via workflow_dispatch
-# until Trusted Publishing (OIDC) is verified end-to-end.
+# main  = stable releases (v2.0.0, v2.0.1, …) → npm `latest` dist-tag
+# alpha = prereleases (v2.0.0-alpha.N)       → npm `alpha` dist-tag
 #
-# Every previous push-triggered run has failed at pnpm publish AFTER
-# @semantic-release/git had already auto-committed a CHANGELOG bump +
-# tagged the next version, leaving main / alpha polluted with runaway
-# state and forcing multiple rewinds.
-#
-# Re-enable the push trigger via a follow-up PR once a dry-run dispatch
-# confirms:
-#   1. semantic-release recognizes v2.0.0-alpha.0 as the last alpha
-#      release (via refs/notes/semantic-release-v2.0.0-alpha.0)
-#   2. pnpm publish successfully exchanges an OIDC id-token with npm
-#      instead of falling back to `npm adduser` prompt (ENEEDAUTH)
+# workflow_dispatch is kept alongside push so alpha/stable releases can
+# also be triggered by hand for recovery / re-runs. The `dry_run` input
+# defaults to true — safe for iterating on release-config changes
+# without accidentally publishing.
 on:
+  push:
+    branches:
+      - main
+      - alpha
   workflow_dispatch:
     inputs:
       dry_run:
         description: |
           Run semantic-release --dry-run. True = analyze + preview only, no
-          git writes, no publish. Set to false ONLY once dry-run reports
-          clean.
+          git writes, no publish. Only meaningful for workflow_dispatch runs;
+          push-triggered runs always run fully.
         required: false
         default: 'true'
         type: choice


### PR DESCRIPTION
## Summary

- Adds `files: '**/test-report.junit.xml'` to the `codecov/test-results-action` step in the reusable `test` workflow template
- Without this, the action couldn't locate the per-package JUnit XML reports vitest writes in monorepos

## Test plan

- [ ] Merge to `alpha`, let `sync-workflow-templates` push the updated workflow to `.github`
- [ ] Confirm the next CI run on a downstream repo (`clients`) no longer warns "JUnit XML file not found"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->