### PR TITLE
fix(ci): tell codecov test-results-action where to find JUnit XML files

### DIFF
--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -733,6 +733,7 @@ jobs:
         if: \${{ !cancelled() }}
         with:
           token: \${{ secrets.CODECOV_TOKEN }}
+          files: '**/test-report.junit.xml'
 `,
 
 	"sync-github": `\


### PR DESCRIPTION
## Summary

- Adds `files: '**/test-report.junit.xml'` to the `codecov/test-results-action` step in the reusable `test` workflow template
- Without this, the action can't locate the per-package JUnit XML reports vitest writes in monorepos

## Test plan

- [ ] Merge to `alpha`, let `sync-workflow-templates` push the updated workflow to `.github`
- [ ] Confirm the next CI run on a downstream repo no longer warns "JUnit XML file not found"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->