### PR TITLE
feat(neon-plugin): migrate to @theholocron/neon-client

### DIFF
--- a/packages/holocron-plugin-neon/package.json
+++ b/packages/holocron-plugin-neon/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@theholocron/cli": "workspace:*",
-    "@theholocron/neon-client": "^0.7.0"
+    "@theholocron/neon-client": "catalog:"
   },
   "peerDependenciesMeta": {
     "@theholocron/neon-client": {

--- a/packages/holocron-plugin-neon/package.json
+++ b/packages/holocron-plugin-neon/package.json
@@ -26,10 +26,17 @@
     "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
-    "@theholocron/cli": "workspace:*"
+    "@theholocron/cli": "workspace:*",
+    "@theholocron/neon-client": "^0.7.0"
+  },
+  "peerDependenciesMeta": {
+    "@theholocron/neon-client": {
+      "optional": false
+    }
   },
   "devDependencies": {
     "@theholocron/cli": "workspace:*",
+    "@theholocron/neon-client": "catalog:",
     "@types/node": "catalog:",
     "@theholocron/eslint-config": "catalog:",
     "@theholocron/tsconfig": "catalog:",

--- a/packages/holocron-plugin-neon/src/__tests__/rest.test.ts
+++ b/packages/holocron-plugin-neon/src/__tests__/rest.test.ts
@@ -1,68 +1,50 @@
 import { ProviderApiError } from "@theholocron/cli";
 import { describe, expect, it, vi } from "vitest";
 
-import { createNeonRestClient } from "../rest.js";
+import { createNeonClient } from "../rest.js";
 
 import { stubFetch } from "./helpers.js";
 
-const TOKEN = "neon-pat";
+const TOKEN = "neon-test-pat";
 
-describe("NeonRestClient", () => {
+describe("createNeonClient", () => {
 	it("sends bearer + accept headers on every request", async () => {
-		const { fetch, calls } = stubFetch([{ status: 200, body: { projects: [] } }]);
-		const client = createNeonRestClient({ token: TOKEN, fetch });
-		await client.request("/projects");
+		const { fetch, calls } = stubFetch([{ status: 200, body: {} }]);
+		const client = createNeonClient({ token: TOKEN, fetch });
+		await client.users.me();
+		expect(calls[0]?.url).toBe("https://console.neon.tech/api/v2/users/me");
 		expect(calls[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
 		expect(calls[0]?.headers.accept).toBe("application/json");
 	});
 
 	it("serializes body on writes and sets content-type", async () => {
-		const { fetch, calls } = stubFetch([{ status: 200, body: { branch: {} } }]);
-		const client = createNeonRestClient({ token: TOKEN, fetch });
-		await client.request("/projects/p1/branches", {
-			method: "POST",
-			body: { branch: { name: "feat" } },
-		});
+		const { fetch, calls } = stubFetch([
+			{ status: 201, body: { branch: { id: "br_new", name: "feat", created_at: "t" } } },
+		]);
+		const client = createNeonClient({ token: TOKEN, fetch });
+		await client.branches.create("p1", { name: "feat", endpoints: [{ type: "read_write" }] });
 		expect(calls[0]?.method).toBe("POST");
-		expect(calls[0]?.body).toEqual({ branch: { name: "feat" } });
+		expect(calls[0]?.body).toMatchObject({ branch: { name: "feat" } });
 		expect(calls[0]?.headers["content-type"]).toBe("application/json");
-	});
-
-	it("appends query params when supplied", async () => {
-		const { fetch, calls } = stubFetch([{ status: 200, body: { uri: "..." } }]);
-		const client = createNeonRestClient({ token: TOKEN, fetch });
-		await client.request("/projects/p1/connection_uri", {
-			query: { branch_id: "br-1", pooled: "true" },
-		});
-		expect(calls[0]?.url).toBe(
-			"https://console.neon.tech/api/v2/projects/p1/connection_uri?branch_id=br-1&pooled=true"
-		);
-	});
-
-	it("returns undefined on 204", async () => {
-		const { fetch } = stubFetch([{ status: 204 }]);
-		const client = createNeonRestClient({ token: TOKEN, fetch });
-		expect(await client.request("/projects/p1/branches/b1", { method: "DELETE" })).toBeUndefined();
 	});
 
 	it("throws ProviderApiError with status + path on non-2xx", async () => {
 		const { fetch } = stubFetch([{ status: 403, text: "managed by vercel" }]);
-		const client = createNeonRestClient({ token: TOKEN, fetch });
-		const err = await client.request("/projects", { method: "POST", body: {} }).catch((e: unknown) => e);
+		const client = createNeonClient({ token: TOKEN, fetch });
+		const err = await client.branches.list("p1").catch((e: unknown) => e);
 		expect(err).toBeInstanceOf(ProviderApiError);
-		const pae = err as ProviderApiError;
-		expect(pae.status).toBe(403);
-		expect(pae.message).toContain("/projects");
+		expect((err as ProviderApiError).status).toBe(403);
+		expect((err as ProviderApiError).message).toContain("/projects/p1/branches");
 	});
 
 	it("wraps transport-level failures with status 0", async () => {
 		const failingFetch: typeof fetch = vi.fn(async () => {
 			throw new TypeError("fetch failed");
 		});
-		const client = createNeonRestClient({ token: TOKEN, fetch: failingFetch });
-		const err = await client.request("/projects").catch((e: unknown) => e);
+		const client = createNeonClient({ token: TOKEN, fetch: failingFetch });
+		const err = await client.users.me().catch((e: unknown) => e);
 		expect(err).toBeInstanceOf(ProviderApiError);
 		expect((err as ProviderApiError).status).toBe(0);
-		expect((err as ProviderApiError).message).toContain("Neon GET /projects failed");
+		expect((err as ProviderApiError).message).toContain("Neon GET /users/me failed");
 	});
 });

--- a/packages/holocron-plugin-neon/src/__tests__/storage.test.ts
+++ b/packages/holocron-plugin-neon/src/__tests__/storage.test.ts
@@ -2,7 +2,7 @@ import { ProviderApiError } from "@theholocron/cli";
 import { describe, expect, it } from "vitest";
 
 import { NeonStorage } from "../capabilities/storage.js";
-import { createNeonRestClient } from "../rest.js";
+import { createNeonClient } from "../rest.js";
 
 import { stubFetch } from "./helpers.js";
 
@@ -11,8 +11,8 @@ const BASE = `https://console.neon.tech/api/v2/projects/${PROJECT_ID}`;
 
 function makeStorage(responses: Parameters<typeof stubFetch>[0]) {
 	const { fetch, calls } = stubFetch(responses);
-	const rest = createNeonRestClient({ token: "pat", fetch });
-	const storage = new NeonStorage(rest, { projectId: PROJECT_ID });
+	const client = createNeonClient({ token: "neon-test-pat", fetch });
+	const storage = new NeonStorage(client, { projectId: PROJECT_ID });
 	return { storage, calls };
 }
 
@@ -180,7 +180,7 @@ describe("NeonStorage.enableExtension", () => {
 
 describe("NeonStorage construction", () => {
 	it("throws when projectId is missing", () => {
-		const rest = createNeonRestClient({ token: "t" });
-		expect(() => new NeonStorage(rest, { projectId: "" })).toThrow(/projectId/);
+		const client = createNeonClient({ token: "neon-test-pat" });
+		expect(() => new NeonStorage(client, { projectId: "" })).toThrow(/projectId/);
 	});
 });

--- a/packages/holocron-plugin-neon/src/capabilities/storage.ts
+++ b/packages/holocron-plugin-neon/src/capabilities/storage.ts
@@ -19,108 +19,73 @@
 
 import { ProviderApiError } from "@theholocron/cli";
 import type { ConnectionStringOptions, Storage, StorageBranch } from "@theholocron/cli";
-
-import type { RestClient } from "@theholocron/cli";
+import type { NeonBranch, NeonClient, NeonDatabase } from "@theholocron/neon-client";
 
 export interface StorageOptions {
 	projectId: string;
-}
-
-interface NeonBranchShape {
-	id: string;
-	name: string;
-	parent_id?: string;
-	created_at: string;
-}
-
-interface NeonDbShape {
-	id: number;
-	name: string;
-	owner_name: string;
 }
 
 export class NeonStorage implements Storage {
 	readonly key = "storage" as const;
 	readonly providerName = "neon";
 
-	private readonly base: string;
-
 	constructor(
-		private readonly rest: RestClient,
-		opts: StorageOptions
+		private readonly client: NeonClient,
+		private readonly opts: StorageOptions
 	) {
 		if (!opts.projectId) {
 			throw new Error("NeonStorage requires `projectId` in options");
 		}
-		this.base = `/projects/${opts.projectId}`;
 	}
 
 	// ── connection string ───────────────────────────────────────────────
 
 	async getConnectionString(scope: string, options: ConnectionStringOptions = {}): Promise<string> {
-		// Neon's /connection_uri needs the default db name + role name. Look
-		// up the branch's databases first; first one is the default.
 		const db = await this.firstDatabase(scope);
-		const params = {
+		const { uri } = await this.client.connection.uri(this.opts.projectId, {
 			branch_id: scope,
 			database_name: db.name,
 			role_name: db.owner_name,
 			pooled: options.pooled ? "true" : "false",
-		};
-		const body = await this.rest.request<{ uri: string }>(`${this.base}/connection_uri`, {
-			query: params,
 		});
-		return body.uri;
+		return uri;
 	}
 
 	// ── branch ops ──────────────────────────────────────────────────────
 
 	async listBranches(): Promise<StorageBranch[]> {
-		const body = await this.rest.request<{ branches: NeonBranchShape[] }>(`${this.base}/branches`);
-		return body.branches.map(mapBranch);
+		const { branches } = await this.client.branches.list(this.opts.projectId);
+		return branches.map(mapBranch);
 	}
 
 	async createBranch(input: { name: string; from?: string }): Promise<StorageBranch> {
 		// Provision a read_write endpoint inline. Without it, /connection_uri
 		// returns "endpoint not found" on a freshly-created branch.
-		const body = await this.rest.request<{ branch: NeonBranchShape }>(`${this.base}/branches`, {
-			method: "POST",
-			body: {
-				branch: {
-					name: input.name,
-					...(input.from ? { parent_id: input.from } : {}),
-				},
-				endpoints: [{ type: "read_write" }],
-			},
+		const { branch } = await this.client.branches.create(this.opts.projectId, {
+			name: input.name,
+			...(input.from ? { parent_id: input.from } : {}),
+			endpoints: [{ type: "read_write" }],
 		});
-		return mapBranch(body.branch);
+		return mapBranch(branch);
 	}
 
 	async destroyBranch(branch: string): Promise<void> {
-		await this.rest.request<void>(`${this.base}/branches/${encodeURIComponent(branch)}`, {
-			method: "DELETE",
-		});
+		await this.client.branches.destroy(this.opts.projectId, branch);
 	}
 
 	async resetBranch(input: { branch: string; from: string }): Promise<void> {
 		// Neon's "Restore branch" endpoint resets the target branch to match
 		// the state of another branch. Reversible via Neon's auto-backup.
-		await this.rest.request<void>(`${this.base}/branches/${encodeURIComponent(input.branch)}/restore`, {
-			method: "POST",
-			body: { source_branch_id: input.from },
-		});
+		await this.client.branches.restore(this.opts.projectId, input.branch, input.from);
 	}
 
 	async enableExtension(input: { branch: string; extension: string }): Promise<void> {
 		const db = await this.firstDatabase(input.branch);
-		await this.rest.request<void>(
-			`${this.base}/branches/${encodeURIComponent(
-				input.branch
-			)}/databases/${encodeURIComponent(db.name)}/run_sql`,
-			{
-				method: "POST",
-				body: { query: `CREATE EXTENSION IF NOT EXISTS "${input.extension}"` },
-			}
+		await this.client.databases.runSql(
+			this.opts.projectId,
+			input.branch,
+			db.name,
+			`CREATE EXTENSION IF NOT EXISTS "${input.extension}"`
 		);
 	}
 
@@ -131,11 +96,9 @@ export class NeonStorage implements Storage {
 	 * and extension purposes. Throws if the branch has no databases (which
 	 * means it was created without an endpoint and needs initialization).
 	 */
-	private async firstDatabase(branchId: string): Promise<NeonDbShape> {
-		const body = await this.rest.request<{ databases: NeonDbShape[] }>(
-			`${this.base}/branches/${encodeURIComponent(branchId)}/databases`
-		);
-		const db = body.databases[0];
+	private async firstDatabase(branchId: string): Promise<NeonDatabase> {
+		const { databases } = await this.client.databases.list(this.opts.projectId, branchId);
+		const db = databases[0];
 		if (!db) {
 			throw new ProviderApiError(
 				`Neon branch ${branchId} has no databases — initialize the branch first`,
@@ -147,7 +110,7 @@ export class NeonStorage implements Storage {
 	}
 }
 
-function mapBranch(raw: NeonBranchShape): StorageBranch {
+function mapBranch(raw: NeonBranch): StorageBranch {
 	return {
 		id: raw.id,
 		name: raw.name,

--- a/packages/holocron-plugin-neon/src/index.ts
+++ b/packages/holocron-plugin-neon/src/index.ts
@@ -5,11 +5,11 @@
  * README for auth + config docs.
  */
 
-import type { RestClient, Storage } from "@theholocron/cli";
+import type { Storage } from "@theholocron/cli";
 
 import { resolveToken, type ResolveTokenInput } from "./auth.js";
 import { NeonStorage } from "./capabilities/storage.js";
-import { createNeonRestClient } from "./rest.js";
+import { createNeonClient, type NeonClient } from "./rest.js";
 
 export interface NeonPluginOptions extends ResolveTokenInput {
 	/** Neon project id this plugin is bound to. Required. */
@@ -22,7 +22,7 @@ export interface NeonPluginOptions extends ResolveTokenInput {
 
 export interface PluginContext {
 	options: NeonPluginOptions;
-	rest: RestClient;
+	client: NeonClient;
 }
 
 export function createContext(options: NeonPluginOptions): PluginContext {
@@ -32,12 +32,12 @@ export function createContext(options: NeonPluginOptions): PluginContext {
 	const token = resolveToken(options);
 	return {
 		options,
-		rest: createNeonRestClient({ token, baseUrl: options.baseUrl, fetch: options.fetch }),
+		client: createNeonClient({ token, baseUrl: options.baseUrl, fetch: options.fetch }),
 	};
 }
 
 export function storage(ctx: PluginContext): Storage {
-	return new NeonStorage(ctx.rest, { projectId: ctx.options.projectId });
+	return new NeonStorage(ctx.client, { projectId: ctx.options.projectId });
 }
 
 export function createPlugin(options: NeonPluginOptions) {
@@ -63,7 +63,8 @@ export const AUTH_HINT =
 // ── Public re-exports ────────────────────────────────────────────────
 
 export * from "./auth.js";
-export { createNeonRestClient } from "./rest.js";
+export { createNeonClient } from "./rest.js";
+export type { NeonClient } from "./rest.js";
 export { NeonStorage } from "./capabilities/storage.js";
 export { verifyToken } from "./verify-token.js";
 export type { VerifyTokenResult, VerifyTokenSuccess, VerifyTokenFailure } from "./verify-token.js";

--- a/packages/holocron-plugin-neon/src/rest.ts
+++ b/packages/holocron-plugin-neon/src/rest.ts
@@ -1,12 +1,1 @@
-import { createRestClient, type RequestOptions, type RestClient } from "@theholocron/cli";
-
-export type { RequestOptions, RestClient };
-
-export function createNeonRestClient(opts: { token: string; baseUrl?: string; fetch?: typeof fetch }): RestClient {
-	return createRestClient({
-		baseUrl: opts.baseUrl ?? "https://console.neon.tech/api/v2",
-		token: opts.token,
-		vendor: "Neon",
-		fetch: opts.fetch,
-	});
-}
+export { createNeonClient, type NeonClient, type NeonClientOptions } from "@theholocron/neon-client";

--- a/packages/holocron-plugin-neon/src/verify-token.ts
+++ b/packages/holocron-plugin-neon/src/verify-token.ts
@@ -5,7 +5,7 @@
  * shape.
  */
 
-import { createNeonRestClient } from "./rest.js";
+import { createNeonClient } from "./rest.js";
 
 export interface VerifyTokenSuccess {
 	ok: true;
@@ -19,22 +19,15 @@ export interface VerifyTokenFailure {
 
 export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
 
-interface MeResponse {
-	id?: string;
-	email?: string;
-	name?: string;
-	login?: string;
-}
-
 export interface VerifyTokenOptions {
 	baseUrl?: string;
 	fetch?: typeof fetch;
 }
 
 export async function verifyToken(token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
-	const rest = createNeonRestClient({ token, baseUrl: opts.baseUrl, fetch: opts.fetch });
+	const client = createNeonClient({ token, baseUrl: opts.baseUrl, fetch: opts.fetch });
 	try {
-		const me = await rest.request<MeResponse>("/users/me");
+		const me = await client.users.me();
 		const subject = me?.email ?? me?.login ?? me?.name ?? me?.id ?? "unknown";
 		return { ok: true, subject: `user @ ${subject}` };
 	} catch (err) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     '@theholocron/lint-staged-config':
       specifier: ^5.2.0
       version: 5.2.0
+    '@theholocron/neon-client':
+      specifier: ^0.7.0
+      version: 0.7.0
     '@theholocron/prettier-config':
       specifier: ^5.2.0
       version: 5.2.0
@@ -536,6 +539,9 @@ importers:
       '@theholocron/eslint-config':
         specifier: 'catalog:'
         version: 5.2.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+      '@theholocron/neon-client':
+        specifier: 'catalog:'
+        version: 0.7.0
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 6.0.0(typescript@5.9.3)
@@ -1711,6 +1717,10 @@ packages:
         optional: true
       sort-package-json:
         optional: true
+
+  '@theholocron/neon-client@0.7.0':
+    resolution: {integrity: sha512-Zw9aHyHaOgXHb69LLx2bMGfhafOAFYQ74NP048Gv+fYP8o8gSlkxvLfNV+tY3vsUfFziVC9NhorvH/hnfYnyBA==}
+    engines: {node: '>=22.0.0'}
 
   '@theholocron/prettier-config@5.2.0':
     resolution: {integrity: sha512-oPtdM/8chfXOHx3ECtK0bMukC2cRBLqyUZQfJCr5rom33PYNZp7QuON2pzLHBKyGJ3s3m95HQXjqa2BvgsA73g==}
@@ -6453,6 +6463,10 @@ snapshots:
     optionalDependencies:
       imagemin-lint-staged: 0.5.1
 
+  '@theholocron/neon-client@0.7.0':
+    dependencies:
+      '@theholocron/http-client': 0.6.2
+
   '@theholocron/prettier-config@5.2.0(prettier@3.9.3)':
     dependencies:
       prettier: 3.9.3
@@ -6666,7 +6680,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     optional: true
 
   '@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10)':
@@ -6677,7 +6691,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -6697,15 +6711,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.6(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
-
-  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
-    optional: true
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -10702,22 +10707,6 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.28.1
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
-      postcss: 8.5.19
-      rollup: 4.62.2
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 26.1.1
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      tsx: 4.22.4
-      yaml: 2.9.0
-    optional: true
-
   vitest@4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
@@ -10745,35 +10734,6 @@ snapshots:
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
-
-  vitest@4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 26.1.1
-      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
-    transitivePeerDependencies:
-      - msw
-    optional: true
 
   web-worker@1.5.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,20 +7,20 @@ settings:
 catalogs:
   default:
     '@theholocron/clerk-client':
-      specifier: ^0.6.2
-      version: 0.6.2
+      specifier: ^0.7.0
+      version: 0.7.0
     '@theholocron/commitlint-config':
       specifier: ^6.0.1
       version: 6.0.1
     '@theholocron/doppler-client':
-      specifier: ^0.6.2
-      version: 0.6.2
+      specifier: ^0.7.0
+      version: 0.7.0
     '@theholocron/eslint-config':
       specifier: ^5.2.0
       version: 5.2.0
     '@theholocron/github-client':
-      specifier: ^0.6.2
-      version: 0.6.2
+      specifier: ^0.7.0
+      version: 0.7.0
     '@theholocron/lint-staged-config':
       specifier: ^5.2.0
       version: 5.2.0
@@ -71,7 +71,7 @@ catalogs:
       version: 4.1.10
 
 overrides:
-  '@theholocron/http-client': ^0.6.2
+  '@theholocron/http-client': ^0.7.0
 
 importers:
 
@@ -184,10 +184,10 @@ importers:
         version: 1.3.0
       '@theholocron/github-client':
         specifier: 'catalog:'
-        version: 0.6.2
+        version: 0.7.0
       '@theholocron/http-client':
-        specifier: ^0.6.2
-        version: 0.6.2
+        specifier: ^0.7.0
+        version: 0.7.0
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
@@ -339,7 +339,7 @@ importers:
     devDependencies:
       '@theholocron/clerk-client':
         specifier: 'catalog:'
-        version: 0.6.2
+        version: 0.7.0
       '@theholocron/cli':
         specifier: workspace:*
         version: link:../cli
@@ -390,7 +390,7 @@ importers:
         version: link:../cli
       '@theholocron/doppler-client':
         specifier: 'catalog:'
-        version: 0.6.2
+        version: 0.7.0
       '@theholocron/eslint-config':
         specifier: 'catalog:'
         version: 5.2.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
@@ -445,7 +445,7 @@ importers:
         version: 5.2.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/github-client':
         specifier: 'catalog:'
-        version: 0.6.2
+        version: 0.7.0
       '@theholocron/tsconfig':
         specifier: 'catalog:'
         version: 6.0.0(typescript@5.9.3)
@@ -1656,8 +1656,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@theholocron/clerk-client@0.6.2':
-    resolution: {integrity: sha512-cxQXi7XVwZTd+ZN8FIkzNt4dEZGJHEUVcZaUSA8wkD7ZpRHGjTrjQcQurUnh5nodqxba/am3KHwqGn0LU/Ey/Q==}
+  '@theholocron/clerk-client@0.7.0':
+    resolution: {integrity: sha512-tRlFeDc1DKGTW2C7cwKynUKQ4oPBNTJPqPNq8Rdo7B5S9/rZCkklz4eMGQNTjSzBUFVu+t/N6uTVfh3EULvPlA==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/commitlint-config@6.0.1':
@@ -1666,8 +1666,8 @@ packages:
       '@commitlint/cli': ^19
       '@commitlint/config-conventional': ^19
 
-  '@theholocron/doppler-client@0.6.2':
-    resolution: {integrity: sha512-uim+x1t7e5Hu6oci1irtzTnqjhwZjVfb1qrAu049cDgOBqfNwXpyNyS5/5JKdAF/9im+YZ9ZPaYCA0uhn4b3aw==}
+  '@theholocron/doppler-client@0.7.0':
+    resolution: {integrity: sha512-E2LKVQ7MHV4IiEP3kivB4uHUxtFkG4eV4JcNrNsS0RXpkQw9OnHTNNzPGGD8d+9pJRP4vltlEPlPZtXh+wU+WQ==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/eslint-config@5.2.0':
@@ -1697,12 +1697,12 @@ packages:
       eslint-plugin-storybook:
         optional: true
 
-  '@theholocron/github-client@0.6.2':
-    resolution: {integrity: sha512-WE/niZ+15SZfalXtn/fpIptmVtWHWBwmWmRX0/uVF7dxn/mVNj8em0EogSG1b3KosOB6dNFPNwqoJJRNFy9Sgg==}
+  '@theholocron/github-client@0.7.0':
+    resolution: {integrity: sha512-7fQ1AY0ZUh95cS7HARBfTWMyYnP56aBMJ0TfT6XKCzQEgSUc4VvsCzUsBW0gnBF/BrqgBHNWQXfK0Fs1kFXUVw==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/http-client@0.6.2':
-    resolution: {integrity: sha512-NOYWFX16/9Hei5vo3Ev3QyqSAgPW5ro4vTZewGBmLgL9KsgCEwiLK0hQufF9XZq+W2G/lMzlz9uJNKPxcTq4HQ==}
+  '@theholocron/http-client@0.7.0':
+    resolution: {integrity: sha512-D2zC97WwBtMSrfKFtZM3GPVHxbuTJeMDjBH/JxlcB5YYSUzWX+LXrN8GrcHgm9heOPcwEf2GOGN6K9+DBq8Ntg==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/lint-staged-config@5.2.0':
@@ -6426,18 +6426,18 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@theholocron/clerk-client@0.6.2':
+  '@theholocron/clerk-client@0.7.0':
     dependencies:
-      '@theholocron/http-client': 0.6.2
+      '@theholocron/http-client': 0.7.0
 
   '@theholocron/commitlint-config@6.0.1(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)':
     dependencies:
       '@commitlint/cli': 19.8.1(@types/node@26.1.1)(typescript@5.9.3)
       '@commitlint/config-conventional': 19.8.1
 
-  '@theholocron/doppler-client@0.6.2':
+  '@theholocron/doppler-client@0.7.0':
     dependencies:
-      '@theholocron/http-client': 0.6.2
+      '@theholocron/http-client': 0.7.0
 
   '@theholocron/eslint-config@5.2.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))':
     dependencies:
@@ -6450,11 +6450,11 @@ snapshots:
       eslint-plugin-n: 18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-react: 7.37.5(eslint@10.7.0(jiti@2.6.1))
 
-  '@theholocron/github-client@0.6.2':
+  '@theholocron/github-client@0.7.0':
     dependencies:
-      '@theholocron/http-client': 0.6.2
+      '@theholocron/http-client': 0.7.0
 
-  '@theholocron/http-client@0.6.2': {}
+  '@theholocron/http-client@0.7.0': {}
 
   '@theholocron/lint-staged-config@5.2.0(husky@9.1.7)(imagemin-lint-staged@0.5.1)(lint-staged@16.4.0)':
     dependencies:
@@ -6465,7 +6465,7 @@ snapshots:
 
   '@theholocron/neon-client@0.7.0':
     dependencies:
-      '@theholocron/http-client': 0.6.2
+      '@theholocron/http-client': 0.7.0
 
   '@theholocron/prettier-config@5.2.0(prettier@3.9.3)':
     dependencies:
@@ -6680,7 +6680,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     optional: true
 
   '@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10)':
@@ -6691,7 +6691,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -6711,6 +6711,15 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.6(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+    optional: true
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -10707,6 +10716,22 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
+  vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.1
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.22.4
+      yaml: 2.9.0
+    optional: true
+
   vitest@4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
@@ -10734,6 +10759,35 @@ snapshots:
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw
+
+  vitest@4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.1
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+    transitivePeerDependencies:
+      - msw
+    optional: true
 
   web-worker@1.5.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,11 +7,11 @@ catalog:
   '@theholocron/commitlint-config': ^6.0.1
   '@theholocron/semantic-release-config': ^6.1.0
   '@theholocron/eslint-config': ^5.2.0
-  '@theholocron/clerk-client': ^0.6.2
-  '@theholocron/doppler-client': ^0.6.2
+  '@theholocron/clerk-client': ^0.7.0
+  '@theholocron/doppler-client': ^0.7.0
   '@theholocron/neon-client': ^0.7.0
-  '@theholocron/github-client': ^0.6.2
-  '@theholocron/http-client': ^0.6.2
+  '@theholocron/github-client': ^0.7.0
+  '@theholocron/http-client': ^0.7.0
   '@theholocron/lint-staged-config': ^5.2.0
   '@theholocron/prettier-config': ^5.2.0
   '@theholocron/tsconfig': ^6.0.0
@@ -32,4 +32,4 @@ catalog:
 # same http-client instance — prevents instanceof ProviderApiError
 # dual-module hazard when github-client and cli both depend on it.
 overrides:
-  '@theholocron/http-client': ^0.6.2
+  '@theholocron/http-client': ^0.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ catalog:
   '@theholocron/eslint-config': ^5.2.0
   '@theholocron/clerk-client': ^0.6.2
   '@theholocron/doppler-client': ^0.6.2
+  '@theholocron/neon-client': ^0.7.0
   '@theholocron/github-client': ^0.6.2
   '@theholocron/http-client': ^0.6.2
   '@theholocron/lint-staged-config': ^5.2.0


### PR DESCRIPTION
## Summary

- Migrates `holocron-plugin-neon` from the inline `createNeonRestClient` + raw `rest.request()` calls to the typed `@theholocron/neon-client`
- `rest.ts` now re-exports `createNeonClient` / `NeonClient` from the client package
- `PluginContext.client` is typed as `NeonClient` instead of `RestClient`
- `NeonStorage` uses typed methods (`client.branches.*`, `client.databases.*`, `client.connection.uri()`) instead of `rest.request()` with manual URL construction
- `verifyToken` uses `client.users.me()` instead of `rest.request("/users/me")`
- `rest.test.ts` and `storage.test.ts` updated to create `NeonClient` via `createNeonClient`

## Test plan

- [x] `pnpm --filter @theholocron/holocron-plugin-neon typecheck` — clean
- [x] `pnpm --filter @theholocron/holocron-plugin-neon test` — 30 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->