### PR TITLE
chore: drop explicit name from holocron.config (derived from package.json)

### DIFF
--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -3,7 +3,6 @@ import { node } from "@theholocron/holocron-config";
 
 const { repo, workflows, providers } = node();
 export default defineConfig({
-	name: "holocron",
 	description:
 		"The Holocron CLI — pluggable, capability-based infrastructure orchestrator. This file makes the repo self-hosted: holocron commands work inside it.",
 	repo: {

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -3,17 +3,15 @@ import { node } from "@theholocron/holocron-config";
 
 const { repo, workflows, providers } = node();
 export default defineConfig({
-	project: {
-		name: "holocron",
-		description:
-			"The Holocron CLI — pluggable, capability-based infrastructure orchestrator. This file makes the repo self-hosted: holocron commands work inside it.",
-		repo: {
-			name: "theholocron/holocron",
-			topics: ["automation", "cli", "developer-tools", "holocron", "nodejs", "typescript"],
-			...repo,
-		},
-		workflows,
+	name: "holocron",
+	description:
+		"The Holocron CLI — pluggable, capability-based infrastructure orchestrator. This file makes the repo self-hosted: holocron commands work inside it.",
+	repo: {
+		name: "theholocron/holocron",
+		topics: ["automation", "cli", "developer-tools", "holocron", "nodejs", "typescript"],
+		...repo,
 	},
+	workflows,
 	providers: {
 		...providers,
 		vault: ["doppler", { project: "holocron", config: "dev" }],

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,7 +25,7 @@ Holocron reads `holocron.config.{json,js,ts}` from the project root
 ```jsonc
 // holocron.config.json
 {
-  "project": { "name": "my-app" },
+  "name": "my-app",
   "providers": {
     "vault": ["1password", { "vault": "my-app" }],
     "source": "github",
@@ -42,7 +42,7 @@ Holocron reads `holocron.config.{json,js,ts}` from the project root
 import { defineConfig } from "@theholocron/cli";
 
 export default defineConfig({
-  project: { name: "my-app" },
+  name: "my-app",
   providers: {
     vault: ["1password", { vault: "my-app" }],
     source: "github",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -51,6 +51,29 @@ export default defineConfig({
 
 ```
 
+### Auto-derived fields
+
+`name` and `repo.name` are optional. When absent, Holocron fills them
+in at load time:
+
+| Field | Derived from | Fallback |
+|---|---|---|
+| `name` | `package.json` → `name` field (scope stripped) | directory basename |
+| `repo.name` | `git remote get-url origin` (parsed to `owner/repo`) | not set |
+
+A minimal config — for repos with a `package.json` and a GitHub remote
+— only needs `providers`:
+
+<!-- prettier-ignore -->
+```jsonc
+{ "providers": { "source": "github" } }
+```
+
+Set `name` explicitly whenever the derived value would be wrong: content
+repos without a `package.json` (e.g. `.github`) will fall back to the
+directory basename, which may not match what your vault or deployment
+provider expects as a project identifier.
+
 ### Shareable configs
 
 **Level 1 — per-capability config packages.** Reference a published

--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -93,28 +93,28 @@ describe("resolveEntry — many-cardinality capabilities", () => {
 
 describe("resolveConfig", () => {
 	const minimal = {
-		project: { name: "demo" },
+		name: "demo",
 		providers: {
 			vault: "1password" as const,
 		},
 	};
 
-	it("requires project.name", () => {
-		expect(() => resolveConfig({ ...minimal, project: { name: "" } })).toThrow(ConfigError);
+	it("requires name", () => {
+		expect(() => resolveConfig({ ...minimal, name: "" })).toThrow(ConfigError);
 	});
 
 	it("requires the providers block", () => {
 		// @ts-expect-error — deliberately omitting required field
-		expect(() => resolveConfig({ project: { name: "x" } })).toThrow(ConfigError);
+		expect(() => resolveConfig({ name: "x" })).toThrow(ConfigError);
 	});
 
 	it("accepts config without vault (vault is no longer required)", () => {
-		expect(() => resolveConfig({ project: { name: "demo" }, providers: { source: "github" } })).not.toThrow();
+		expect(() => resolveConfig({ name: "demo", providers: { source: "github" } })).not.toThrow();
 	});
 
 	it("returns a normalized config with defaults filled in", () => {
 		const resolved = resolveConfig(minimal);
-		expect(resolved.project.name).toBe("demo");
+		expect(resolved.name).toBe("demo");
 		expect(resolved.providers.vault?.cardinality).toBe("single");
 		expect(resolved.apps).toEqual([]);
 		expect(resolved.doctor).toEqual({});

--- a/packages/cli/src/__tests__/define-config.test.ts
+++ b/packages/cli/src/__tests__/define-config.test.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "../define-config.js";
 describe("defineConfig", () => {
 	it("returns the config object unchanged", () => {
 		const config = {
-			project: { name: "my-app" },
+			name: "my-app",
 			providers: { source: "github" as const },
 		};
 		expect(defineConfig(config)).toBe(config);
@@ -13,7 +13,8 @@ describe("defineConfig", () => {
 
 	it("preserves nested options", () => {
 		const config = {
-			project: { name: "my-app", repo: { name: "org/my-app" } },
+			name: "my-app",
+			repo: { name: "org/my-app" },
 			providers: {
 				vault: ["1password", { vault: "my-app" }] as [string, Record<string, unknown>],
 				source: "github" as const,

--- a/packages/cli/src/__tests__/deploy.test.ts
+++ b/packages/cli/src/__tests__/deploy.test.ts
@@ -37,7 +37,7 @@ describe("runDeploy", () => {
 	it("triggers a deployment via the configured provider", async () => {
 		const triggerCalls: Array<{ projectId: string; branch: string; target?: string }> = [];
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", deployment: "vercel" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -81,7 +81,7 @@ describe("runDeploy", () => {
 	it("passes named target through (production / staging)", async () => {
 		const triggerCalls: Array<{ target?: string }> = [];
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", deployment: "vercel" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -117,7 +117,7 @@ describe("runDeploy", () => {
 
 	it("errors when deployment capability is not configured", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -139,7 +139,7 @@ describe("runDeploy", () => {
 	it("dry-run skips the actual triggerDeployment call", async () => {
 		let called = false;
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", deployment: "vercel" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -172,7 +172,7 @@ describe("runDeploy", () => {
 
 	it("dry-run includes target in message when target is provided", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", deployment: "vercel" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -201,7 +201,7 @@ describe("runDeploy", () => {
 
 	it("returns status=fail with the error message when the provider throws", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", deployment: "vercel" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -231,7 +231,7 @@ describe("runDeploy", () => {
 
 	it("returns status=fail with string coercion when a non-Error is thrown", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", deployment: "vercel" },
 		});
 		const loader = makeLoaderWith(loaded, {

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -38,7 +38,7 @@ describe("runDoctor", () => {
 	it("reports ok for source.whoami succeeding", async () => {
 		const lines: string[] = [];
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -71,7 +71,7 @@ describe("runDoctor", () => {
 
 	it("reports fail when a smoke check throws", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -102,7 +102,7 @@ describe("runDoctor", () => {
 
 	it("reports skip for many-cardinality capabilities (no smoke endpoint yet)", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: {
 				vault: "1password",
 				notifications: ["slack", "discord"],
@@ -131,7 +131,7 @@ describe("runDoctor", () => {
 
 	it("issues smoke check reports resolved lifecycle slot count", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", issues: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -167,7 +167,7 @@ describe("runDoctor", () => {
 
 	it("secrets smoke check reports configured secret count", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { secrets: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -190,7 +190,7 @@ describe("runDoctor", () => {
 
 	it("ci smoke check reports most recent run", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { ci: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -216,7 +216,7 @@ describe("runDoctor", () => {
 
 	it("ci smoke check reports no recent runs when list is empty", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { ci: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -239,7 +239,7 @@ describe("runDoctor", () => {
 
 	it("auth smoke check reports provider and env keys", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { auth: "clerk" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -265,7 +265,7 @@ describe("runDoctor", () => {
 
 	it("single-cardinality capability without a smoke check falls through to skip", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { deployment: "vercel" },
 		});
 		const loader = makeLoaderWith(loaded, {

--- a/packages/cli/src/__tests__/load-config.test.ts
+++ b/packages/cli/src/__tests__/load-config.test.ts
@@ -1,6 +1,7 @@
+import { execSync } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -112,6 +113,91 @@ describe("loadConfig", () => {
 		const err = await loadConfig(cwd).catch((e: unknown) => e);
 		expect(err).toBeInstanceOf(ConfigFileError);
 		expect((err as Error).message).toMatch(/default export/);
+	});
+
+	// ── name derivation ───────────────────────────────────────────────────
+
+	it("derives name from package.json when absent from config", async () => {
+		await writeFile(join(cwd, "package.json"), JSON.stringify({ name: "my-package" }));
+		await writeFile(
+			join(cwd, "holocron.config.json"),
+			JSON.stringify({ providers: { source: "github" } })
+		);
+		const { resolved } = await loadConfig(cwd);
+		expect(resolved.name).toBe("my-package");
+	});
+
+	it("strips @scope/ prefix from scoped package names", async () => {
+		await writeFile(join(cwd, "package.json"), JSON.stringify({ name: "@theholocron/my-package" }));
+		await writeFile(
+			join(cwd, "holocron.config.json"),
+			JSON.stringify({ providers: { source: "github" } })
+		);
+		const { resolved } = await loadConfig(cwd);
+		expect(resolved.name).toBe("my-package");
+	});
+
+	it("falls back to directory basename when no package.json exists", async () => {
+		await writeFile(
+			join(cwd, "holocron.config.json"),
+			JSON.stringify({ providers: { source: "github" } })
+		);
+		const { resolved } = await loadConfig(cwd);
+		expect(resolved.name).toBe(basename(cwd));
+	});
+
+	it("does not override name when explicitly set in config", async () => {
+		await writeFile(join(cwd, "package.json"), JSON.stringify({ name: "from-package-json" }));
+		await writeFile(
+			join(cwd, "holocron.config.json"),
+			JSON.stringify({ name: "from-config", providers: { source: "github" } })
+		);
+		const { resolved } = await loadConfig(cwd);
+		expect(resolved.name).toBe("from-config");
+	});
+
+	// ── repo.name derivation ──────────────────────────────────────────────
+
+	it("leaves repo.name absent when no git remote is configured", async () => {
+		await writeFile(
+			join(cwd, "holocron.config.json"),
+			JSON.stringify({ name: "demo", repo: {}, providers: { source: "github" } })
+		);
+		const { resolved } = await loadConfig(cwd);
+		expect(resolved.repo?.name).toBeUndefined();
+	});
+
+	it("derives repo.name from an HTTPS git remote", async () => {
+		execSync("git init", { cwd });
+		execSync("git remote add origin https://github.com/theholocron/my-app.git", { cwd });
+		await writeFile(
+			join(cwd, "holocron.config.json"),
+			JSON.stringify({ name: "demo", repo: {}, providers: { source: "github" } })
+		);
+		const { resolved } = await loadConfig(cwd);
+		expect(resolved.repo?.name).toBe("theholocron/my-app");
+	});
+
+	it("derives repo.name from an SSH git remote", async () => {
+		execSync("git init", { cwd });
+		execSync("git remote add origin git@github.com:theholocron/my-app.git", { cwd });
+		await writeFile(
+			join(cwd, "holocron.config.json"),
+			JSON.stringify({ name: "demo", repo: {}, providers: { source: "github" } })
+		);
+		const { resolved } = await loadConfig(cwd);
+		expect(resolved.repo?.name).toBe("theholocron/my-app");
+	});
+
+	it("does not override repo.name when explicitly set in config", async () => {
+		execSync("git init", { cwd });
+		execSync("git remote add origin https://github.com/theholocron/ignored.git", { cwd });
+		await writeFile(
+			join(cwd, "holocron.config.json"),
+			JSON.stringify({ name: "demo", repo: { name: "theholocron/explicit" }, providers: { source: "github" } })
+		);
+		const { resolved } = await loadConfig(cwd);
+		expect(resolved.repo?.name).toBe("theholocron/explicit");
 	});
 
 	// ── Priority ──────────────────────────────────────────────────────────

--- a/packages/cli/src/__tests__/load-config.test.ts
+++ b/packages/cli/src/__tests__/load-config.test.ts
@@ -39,13 +39,13 @@ describe("loadConfig", () => {
 		await writeFile(
 			join(cwd, "holocron.config.json"),
 			JSON.stringify({
-				project: { name: "demo" },
+				name: "demo",
 				providers: { vault: "1password", source: "github" },
 			})
 		);
 		const { resolved, filepath } = await loadConfig(cwd);
 		expect(filepath).toBe(join(cwd, "holocron.config.json"));
-		expect(resolved.project.name).toBe("demo");
+		expect(resolved.name).toBe("demo");
 		expect(resolved.providers.vault?.cardinality).toBe("single");
 	});
 
@@ -63,10 +63,10 @@ describe("loadConfig", () => {
 	it("loads valid config without vault (vault is no longer required)", async () => {
 		await writeFile(
 			join(cwd, "holocron.config.json"),
-			JSON.stringify({ project: { name: "demo" }, providers: { source: "github" } })
+			JSON.stringify({ name: "demo", providers: { source: "github" } })
 		);
 		const result = await loadConfig(cwd);
-		expect(result.resolved.project.name).toBe("demo");
+		expect(result.resolved.name).toBe("demo");
 		expect(result.resolved.providers.vault).toBeUndefined();
 	});
 
@@ -75,11 +75,11 @@ describe("loadConfig", () => {
 	it("reads + resolves a valid holocron.config.js", async () => {
 		await writeFile(
 			join(cwd, "holocron.config.js"),
-			`export default { project: { name: "js-demo" }, providers: { source: "github" } };`
+			`export default { name: "js-demo", providers: { source: "github" } };`
 		);
 		const { resolved, filepath } = await loadConfig(cwd);
 		expect(filepath).toBe(join(cwd, "holocron.config.js"));
-		expect(resolved.project.name).toBe("js-demo");
+		expect(resolved.name).toBe("js-demo");
 	});
 
 	it("errors when holocron.config.js has no default export", async () => {
@@ -89,8 +89,8 @@ describe("loadConfig", () => {
 		expect((err as Error).message).toMatch(/default export/);
 	});
 
-	it("errors when the JS config is invalid (missing project.name)", async () => {
-		await writeFile(join(cwd, "holocron.config.js"), `export default { project: {}, providers: {} };`);
+	it("errors when the JS config is invalid (missing providers)", async () => {
+		await writeFile(join(cwd, "holocron.config.js"), `export default { name: "demo" };`);
 		const err = await loadConfig(cwd).catch((e: unknown) => e);
 		expect(err).toBeInstanceOf(ConfigError);
 	});
@@ -100,11 +100,11 @@ describe("loadConfig", () => {
 	it("reads + resolves a valid holocron.config.ts (via tsImport)", async () => {
 		await writeFile(
 			join(cwd, "holocron.config.ts"),
-			`export default { project: { name: "ts-demo" }, providers: { source: "github" } } as const;`
+			`export default { name: "ts-demo", providers: { source: "github" } } as const;`
 		);
 		const { resolved, filepath } = await loadConfig(cwd);
 		expect(filepath).toBe(join(cwd, "holocron.config.ts"));
-		expect(resolved.project.name).toBe("ts-demo");
+		expect(resolved.name).toBe("ts-demo");
 	});
 
 	it("errors when holocron.config.ts has no default export", async () => {
@@ -119,26 +119,26 @@ describe("loadConfig", () => {
 	it("prefers .json over .js when both exist", async () => {
 		await writeFile(
 			join(cwd, "holocron.config.json"),
-			JSON.stringify({ project: { name: "json-wins" }, providers: {} })
+			JSON.stringify({ name: "json-wins", providers: {} })
 		);
 		await writeFile(
 			join(cwd, "holocron.config.js"),
-			`export default { project: { name: "js-loses" }, providers: {} };`
+			`export default { name: "js-loses", providers: {} };`
 		);
 		const { resolved } = await loadConfig(cwd);
-		expect(resolved.project.name).toBe("json-wins");
+		expect(resolved.name).toBe("json-wins");
 	});
 
 	it("prefers .js over .ts when both exist (no .json)", async () => {
 		await writeFile(
 			join(cwd, "holocron.config.js"),
-			`export default { project: { name: "js-wins" }, providers: { source: "github" } };`
+			`export default { name: "js-wins", providers: { source: "github" } };`
 		);
 		await writeFile(
 			join(cwd, "holocron.config.ts"),
-			`export default { project: { name: "ts-loses" }, providers: { source: "github" } } as const;`
+			`export default { name: "ts-loses", providers: { source: "github" } } as const;`
 		);
 		const { resolved } = await loadConfig(cwd);
-		expect(resolved.project.name).toBe("js-wins");
+		expect(resolved.name).toBe("js-wins");
 	});
 });

--- a/packages/cli/src/__tests__/loader.test.ts
+++ b/packages/cli/src/__tests__/loader.test.ts
@@ -32,7 +32,7 @@ describe("PluginLoader — single cardinality", () => {
 		const sourceImpl = { key: "source", providerName: "github" };
 		const { loader } = loaderWith(
 			{
-				project: { name: "demo" },
+				name: "demo",
 				providers: { vault: "1password", source: "github" },
 			},
 			{
@@ -48,7 +48,7 @@ describe("PluginLoader — single cardinality", () => {
 
 	it("throws LoaderError when accessing a non-loaded capability", async () => {
 		const { loader } = loaderWith(
-			{ project: { name: "demo" }, providers: { vault: "1password" } },
+			{ name: "demo", providers: { vault: "1password" } },
 			{ "@theholocron/holocron-plugin-1password": makePlugin("1password", { vault: {} }) }
 		);
 		await loader.load();
@@ -59,7 +59,7 @@ describe("PluginLoader — single cardinality", () => {
 	it("throws LoaderError when the package cannot be imported", async () => {
 		const { loader } = loaderWith(
 			{
-				project: { name: "demo" },
+				name: "demo",
 				providers: { vault: "1password", source: "gitlab" },
 			},
 			{ "@theholocron/holocron-plugin-1password": makePlugin("1password", { vault: {} }) }
@@ -70,7 +70,7 @@ describe("PluginLoader — single cardinality", () => {
 	it("throws when the package does not export createPlugin", async () => {
 		const { loader } = loaderWith(
 			{
-				project: { name: "demo" },
+				name: "demo",
 				providers: { vault: "1password", source: "broken" },
 			},
 			{
@@ -84,7 +84,7 @@ describe("PluginLoader — single cardinality", () => {
 	it("throws when the plugin does not implement the requested capability", async () => {
 		const { loader } = loaderWith(
 			{
-				project: { name: "demo" },
+				name: "demo",
 				providers: { vault: "1password", source: "github" },
 			},
 			{
@@ -100,7 +100,7 @@ describe("PluginLoader — single cardinality", () => {
 		const captured: Record<string, unknown> = {};
 		const { loader } = loaderWith(
 			{
-				project: { name: "demo" },
+				name: "demo",
 				providers: {
 					vault: "1password",
 					source: ["github", { repo: "theholocron/holocron" }],
@@ -127,7 +127,7 @@ describe("PluginLoader — single cardinality", () => {
 		const capturedAtVault: Record<string, unknown> = {};
 		const capturedAtSource: Record<string, unknown> = {};
 		const config = resolveConfig({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", source: "github" },
 		});
 		const importer = vi.fn(async (pkg: string) => {
@@ -159,11 +159,12 @@ describe("PluginLoader — single cardinality", () => {
 	});
 });
 
-describe("PluginLoader — project.repo defaults", () => {
-	it("injects config.project.repo into plugin options when context.repo is absent", async () => {
+describe("PluginLoader — repo defaults", () => {
+	it("injects config.repo into plugin options when context.repo is absent", async () => {
 		const captured: Record<string, unknown> = {};
 		const config = resolveConfig({
-			project: { name: "demo", repo: { name: "acme/foo" } },
+			name: "demo",
+			repo: { name: "acme/foo" },
 			providers: { vault: "1password", source: "github" },
 		});
 		const importer = vi.fn(async (pkg: string) => {
@@ -182,10 +183,11 @@ describe("PluginLoader — project.repo defaults", () => {
 		expect(captured.repo).toBe("acme/foo");
 	});
 
-	it("context.repo (CLI --repo flag) overrides config.project.repo", async () => {
+	it("context.repo (CLI --repo flag) overrides config.repo", async () => {
 		const captured: Record<string, unknown> = {};
 		const config = resolveConfig({
-			project: { name: "demo", repo: { name: "acme/from-config" } },
+			name: "demo",
+			repo: { name: "acme/from-config" },
 			providers: { vault: "1password", source: "github" },
 		});
 		const importer = vi.fn(async (pkg: string) => {
@@ -208,10 +210,11 @@ describe("PluginLoader — project.repo defaults", () => {
 		expect(captured.repo).toBe("override/from-flag");
 	});
 
-	it("per-plugin tuple options override both context and project defaults", async () => {
+	it("per-plugin tuple options override both context and repo defaults", async () => {
 		const captured: Record<string, unknown> = {};
 		const config = resolveConfig({
-			project: { name: "demo", repo: { name: "acme/from-config" } },
+			name: "demo",
+			repo: { name: "acme/from-config" },
 			providers: {
 				vault: "1password",
 				source: ["github", { repo: "override/from-tuple" }],
@@ -241,7 +244,7 @@ describe("PluginLoader — project.repo defaults", () => {
 	it("omits repo entirely when neither config nor context sets it (non-github configs)", async () => {
 		const captured: Record<string, unknown> = {};
 		const config = resolveConfig({
-			project: { name: "demo" }, // no repo
+			name: "demo", // no repo
 			providers: { vault: "1password" },
 		});
 		const importer = vi.fn(async () => ({
@@ -262,7 +265,7 @@ describe("PluginLoader — many cardinality", () => {
 		const discordImpl = { key: "notifications", providerName: "discord" };
 		const { loader } = loaderWith(
 			{
-				project: { name: "demo" },
+				name: "demo",
 				providers: {
 					vault: "1password",
 					notifications: ["slack", "discord"],
@@ -287,7 +290,7 @@ describe("PluginLoader.loadedKeys", () => {
 	it("returns the set of currently-loaded capability keys", async () => {
 		const { loader } = loaderWith(
 			{
-				project: { name: "demo" },
+				name: "demo",
 				providers: { vault: "1password", source: "github" },
 			},
 			{
@@ -305,7 +308,7 @@ describe("PluginLoader — capability config packages (#75 Level 1)", () => {
 		const vaultImpl = { key: "vault", providerName: "1password" };
 		const { loader, importer } = loaderWith(
 			{
-				project: { name: "demo" },
+				name: "demo",
 				// @acme/holocron-vault is a capability config package, not a plugin
 				providers: { vault: "@acme/holocron-vault" },
 			},
@@ -326,7 +329,7 @@ describe("PluginLoader — capability config packages (#75 Level 1)", () => {
 		const captured: Record<string, unknown> = {};
 		const { loader } = loaderWith(
 			{
-				project: { name: "demo" },
+				name: "demo",
 				// ["@acme/holocron-vault", { vault: "override" }] — project overrides preset
 				providers: { vault: ["@acme/holocron-vault", { vault: "override" }] },
 			},
@@ -354,7 +357,7 @@ describe("PluginLoader — capability config packages (#75 Level 1)", () => {
 		const slackImpl = { key: "notifications", providerName: "slack" };
 		const { loader } = loaderWith(
 			{
-				project: { name: "demo" },
+				name: "demo",
 				providers: {
 					notifications: ["@acme/holocron-slack", "discord"],
 				},
@@ -374,7 +377,7 @@ describe("PluginLoader — capability config packages (#75 Level 1)", () => {
 	it("errors when a config package exports an unresolvable provider", async () => {
 		const { loader } = loaderWith(
 			{
-				project: { name: "demo" },
+				name: "demo",
 				providers: { vault: "@acme/holocron-vault" },
 			},
 			{
@@ -390,7 +393,7 @@ describe("PluginLoader — capability config packages (#75 Level 1)", () => {
 	it("errors when a package exports neither createPlugin nor a capability config", async () => {
 		const { loader } = loaderWith(
 			{
-				project: { name: "demo" },
+				name: "demo",
 				providers: { vault: "broken" },
 			},
 			{

--- a/packages/cli/src/__tests__/secret-set.test.ts
+++ b/packages/cli/src/__tests__/secret-set.test.ts
@@ -35,7 +35,7 @@ function makeLoaderWith(loaded: LoadedConfig, modules: Record<string, unknown>):
 
 function loadedDemo() {
 	return loadedFrom({
-		project: { name: "demo" },
+		name: "demo",
 		providers: { vault: "1password", secrets: "github" },
 	});
 }
@@ -209,7 +209,7 @@ describe("runSecretSet — scope + capability wiring", () => {
 
 	it("throws when secrets capability is not loaded", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password" },
 		});
 		const loader = makeLoaderWith(loaded, {

--- a/packages/cli/src/__tests__/secrets-sync.test.ts
+++ b/packages/cli/src/__tests__/secrets-sync.test.ts
@@ -36,7 +36,7 @@ function makeLoaderWith(loaded: LoadedConfig, modules: Record<string, unknown>):
 describe("runSecretsSync", () => {
 	it("errors when the vault provider does not implement readEnvironment", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -60,7 +60,7 @@ describe("runSecretsSync", () => {
 	it("fans out vault keys to secrets (repo scope)", async () => {
 		const setSecretCalls: Array<{ name: string; value: string }> = [];
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", secrets: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -99,7 +99,7 @@ describe("runSecretsSync", () => {
 
 	it("skips deployment sync when projectId is missing", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", deployment: "vercel" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -140,7 +140,7 @@ describe("runSecretsSync", () => {
 			value: string;
 		}> = [];
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", deployment: "vercel" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -178,7 +178,7 @@ describe("runSecretsSync", () => {
 	it("dry-run reports `dry-run` rows without calling mutators", async () => {
 		let called = false;
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", secrets: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -213,7 +213,7 @@ describe("runSecretsSync", () => {
 
 	it("soft-skips with string coercion when provider throws a non-Error", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", secrets: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -248,7 +248,7 @@ describe("runSecretsSync", () => {
 
 	it("soft-skips individual key failures (continues with other keys)", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", secrets: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -68,7 +68,7 @@ describe("runSetup", () => {
 			},
 		};
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -107,7 +107,7 @@ describe("runSetup", () => {
 	it("soft-skips failed steps (continues subsequent capabilities)", async () => {
 		const calls: string[] = [];
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -164,7 +164,7 @@ describe("runSetup", () => {
 	it("dry-run reports `dry-run` status without calling mutators", async () => {
 		let called = false;
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -206,7 +206,7 @@ describe("runSetup", () => {
 	it("upserts staging + production environments when the capability is loaded", async () => {
 		const created: string[] = [];
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", environments: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -235,7 +235,7 @@ describe("runSetup", () => {
 	it("ensures the deployment project using the config project name", async () => {
 		let ensuredName: string | null = null;
 		const loaded = loadedFrom({
-			project: { name: "my-app" },
+			name: "my-app",
 			providers: { vault: "1password", deployment: "vercel" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -264,7 +264,7 @@ describe("runSetup", () => {
 
 	it("reports already-exists for ensureWebhookApp when the provider supports it", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", auth: "clerk" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -292,7 +292,7 @@ describe("runSetup", () => {
 
 	it("skips auth setup when the provider does not implement ensureWebhookApp", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", auth: "clerk" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -321,7 +321,7 @@ describe("runSetup", () => {
 	it("runs sync() once per tooling provider (many-cardinality)", async () => {
 		const synced: string[] = [];
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", tooling: ["postman", "storybook"] },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -360,7 +360,7 @@ describe("runSetup", () => {
 		const projectCreated: string[] = [];
 		const envsCreated: Array<[string, string]> = [];
 		const loaded = loadedFrom({
-			project: { name: "my-app" },
+			name: "my-app",
 			providers: { vault: "doppler" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -399,7 +399,7 @@ describe("runSetup", () => {
 
 	it("skips vault ensureProject + ensureEnvironment when the provider omits them (1P-shaped vaults)", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -423,7 +423,7 @@ describe("runSetup", () => {
 		let defaultSetupDisabled = false;
 		let defaultSetupEnabled = false;
 		const loaded = loadedFrom({
-			project: { name: "demo", workflows: ["lint", "codeql"] },
+			name: "demo", workflows: ["lint", "codeql"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -460,7 +460,7 @@ describe("runSetup", () => {
 	it("enables default CodeQL setup when no codeql workflow is configured", async () => {
 		let defaultSetupEnabled = false;
 		const loaded = loadedFrom({
-			project: { name: "demo", workflows: ["lint"] },
+			name: "demo", workflows: ["lint"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -492,7 +492,7 @@ describe("runSetup", () => {
 		let settingsApplied: Record<string, unknown> | null = null;
 		let rulesetCreated: Record<string, unknown> | null = null;
 		const loaded = loadedFrom({
-			project: { name: "demo", repo: { name: "theholocron/demo", protection: "balanced" } },
+			name: "demo", repo: { name: "theholocron/demo", protection: "balanced" },
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -538,11 +538,9 @@ describe("runSetup", () => {
 	it("derives required_status_checks from configured workflows when repo.protection is 'strict'", async () => {
 		let rulesetPayload: Record<string, unknown> | null = null;
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", protection: "strict" },
-				workflows: ["lint", "test", "typecheck"],
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", protection: "strict" },
+			workflows: ["lint", "test", "typecheck"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -585,11 +583,9 @@ describe("runSetup", () => {
 	it("appends extra requiredChecks from config to the auto-derived list", async () => {
 		let rulesetPayload: Record<string, unknown> | null = null;
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", protection: "strict", requiredChecks: ["some-extra-check"] },
-				workflows: ["lint"],
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", protection: "strict", requiredChecks: ["some-extra-check"] },
+			workflows: ["lint"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -630,7 +626,7 @@ describe("runSetup", () => {
 		const created: unknown[] = [];
 		const updated: unknown[] = [];
 		const loaded = loadedFrom({
-			project: { name: "demo", repo: { name: "theholocron/demo", protection: "balanced" } },
+			name: "demo", repo: { name: "theholocron/demo", protection: "balanced" },
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -674,7 +670,7 @@ describe("runSetup", () => {
 	it("skips repo policy steps when repo.protection is 'none'", async () => {
 		let settingsCalled = false;
 		const loaded = loadedFrom({
-			project: { name: "demo", repo: { name: "theholocron/demo", protection: "none" } },
+			name: "demo", repo: { name: "theholocron/demo", protection: "none" },
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -709,7 +705,7 @@ describe("runSetup", () => {
 	it("skips repo policy steps when no protection in config", async () => {
 		let settingsCalled = false;
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -737,7 +733,7 @@ describe("runSetup", () => {
 	it("writes thin wrapper files for each workflow listed in project.workflows", async () => {
 		const written: Record<string, string> = {};
 		const loaded = loadedFrom({
-			project: { name: "demo", workflows: ["lint", "test", "typecheck"] },
+			name: "demo", workflows: ["lint", "test", "typecheck"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -775,7 +771,7 @@ describe("runSetup", () => {
 	it("skips workflow writing when project.workflows is absent", async () => {
 		let writeCallCount = 0;
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -802,7 +798,7 @@ describe("runSetup", () => {
 
 	it("reports skip for an unknown workflow name", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo", workflows: ["lint", "not-a-real-workflow"] },
+			name: "demo", workflows: ["lint", "not-a-real-workflow"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -835,7 +831,7 @@ describe("runSetup", () => {
 	it("dry-run skips workflow writes", async () => {
 		let writeCallCount = 0;
 		const loaded = loadedFrom({
-			project: { name: "demo", workflows: ["lint", "test"] },
+			name: "demo", workflows: ["lint", "test"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -870,7 +866,7 @@ describe("runSetup", () => {
 	it("output includes a header + summary line", async () => {
 		const lines: string[] = [];
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -894,7 +890,7 @@ describe("runSetup", () => {
 	it("writes .alexrc.json whenever source is available", async () => {
 		const written: Record<string, string> = {};
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -949,7 +945,7 @@ describe("runSetup", () => {
 	it("writes .github/labeler.yml when bookkeeping-pr workflow is configured", async () => {
 		const written: Record<string, string> = {};
 		const loaded = loadedFrom({
-			project: { name: "demo", workflows: ["lint", "bookkeeping-pr"] },
+			name: "demo", workflows: ["lint", "bookkeeping-pr"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -984,7 +980,7 @@ describe("runSetup", () => {
 	it("does not write .github/labeler.yml when bookkeeping-pr is not configured", async () => {
 		const written: Record<string, string> = {};
 		const loaded = loadedFrom({
-			project: { name: "demo", workflows: ["lint", "test"] },
+			name: "demo", workflows: ["lint", "test"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -1013,17 +1009,15 @@ describe("runSetup", () => {
 	it("calls syncProperties with derived and manual properties when source supports it", async () => {
 		let captured: Record<string, string> | null = null;
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: {
-					name: "theholocron/demo",
-					protection: "strict",
-					properties: {
-						lifecycle: "active",
-						open_source: true,
-						runtime_environment: "node",
-						uses_external_packages: false,
-					},
+			name: "demo",
+			repo: {
+				name: "theholocron/demo",
+				protection: "strict",
+				properties: {
+					lifecycle: "active",
+					open_source: true,
+					runtime_environment: "node",
+					uses_external_packages: false,
 				},
 			},
 			providers: { vault: "1password", source: "github" },
@@ -1069,10 +1063,8 @@ describe("runSetup", () => {
 	it("does not set branch_protection_level property when no protection is configured", async () => {
 		let captured: Record<string, string> | null = null;
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", properties: { lifecycle: "experimental" } },
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", properties: { lifecycle: "experimental" } },
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -1104,10 +1096,8 @@ describe("runSetup", () => {
 	it("calls syncTopics with the configured topics", async () => {
 		let capturedTopics: string[] | null = null;
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", topics: ["cli", "nodejs", "typescript"] },
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", topics: ["cli", "nodejs", "typescript"] },
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -1140,10 +1130,8 @@ describe("runSetup", () => {
 	it("skips syncTopics when topics list is empty", async () => {
 		let called = false;
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", topics: [] },
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", topics: [] },
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -1174,7 +1162,7 @@ describe("runSetup", () => {
 	it("skips syncTopics when repo has no topics field", async () => {
 		let called = false;
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -1204,10 +1192,8 @@ describe("runSetup", () => {
 	it("skips dependabot when repo.protection is 'none'", async () => {
 		const written: string[] = [];
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", protection: "none" },
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", protection: "none" },
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -1235,7 +1221,7 @@ describe("runSetup", () => {
 	it("writes dependabot when no protection is configured (effectivePreset undefined)", async () => {
 		const written: string[] = [];
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -1263,7 +1249,7 @@ describe("runSetup", () => {
 	it("dry-run does not write .alexrc.json", async () => {
 		let writeCalled = false;
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {

--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -142,7 +142,7 @@ describe("runSyncGithub", () => {
 
 	it("respects holocron.config.json workflow allowlist for secondary repos", async () => {
 		const allowedNames = ["lint", "review", "stale"];
-		const config = { project: { workflows: allowedNames } };
+		const config = { workflows: allowedNames };
 		const { fn, calls } = makeFetch({}, config);
 		const report = await runSyncGithub({
 			token: "ghp_test",
@@ -168,7 +168,7 @@ describe("runSyncGithub", () => {
 
 	it("reads workflow allowlist from holocron.config.ts when .json is absent", async () => {
 		const allowedNames = ["lint", "review", "stale"];
-		const configTs = `export default defineConfig({ project: { workflows: ${JSON.stringify(allowedNames)} } })`;
+		const configTs = `export default defineConfig({ workflows: ${JSON.stringify(allowedNames)} })`;
 		const { fn } = makeFetch({}, undefined, configTs);
 		const report = await runSyncGithub({
 			token: "ghp_test",
@@ -183,7 +183,7 @@ describe("runSyncGithub", () => {
 	});
 
 	it("applies per-workflow with: overrides from config to thin callers", async () => {
-		const configTs = `export default defineConfig({ project: { workflows: [{ name: "release", with: { "run-build": false } }] } })`;
+		const configTs = `export default defineConfig({ workflows: [{ name: "release", with: { "run-build": false } }] })`;
 		const { fn, calls } = makeFetch({}, undefined, configTs);
 		await runSyncGithub({
 			token: "ghp_test",

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -37,10 +37,8 @@ describe("runSync", () => {
 	it("runs all three sync steps when no steps filter is given", async () => {
 		const called: string[] = [];
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", topics: ["ts", "cli"] },
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", topics: ["ts", "cli"] },
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -73,10 +71,8 @@ describe("runSync", () => {
 	it("runs only the requested step when a single step filter is given", async () => {
 		const called: string[] = [];
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", topics: ["ts"] },
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", topics: ["ts"] },
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -115,10 +111,8 @@ describe("runSync", () => {
 	it("runs a subset of steps when multiple steps are requested", async () => {
 		const called: string[] = [];
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", topics: ["ts"] },
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", topics: ["ts"] },
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -154,7 +148,7 @@ describe("runSync", () => {
 
 	it("reports skip for an unknown step name", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -182,10 +176,8 @@ describe("runSync", () => {
 	it("dry-run does not call any sync methods", async () => {
 		let called = false;
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", topics: ["ts"] },
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", topics: ["ts"] },
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -221,7 +213,7 @@ describe("runSync", () => {
 
 	it("reports skip when provider does not implement syncLabels", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -243,7 +235,7 @@ describe("runSync", () => {
 
 	it("reports skip when provider does not implement syncProperties", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -266,7 +258,7 @@ describe("runSync", () => {
 	it("skips syncTopics with 'no topics configured' when topics list is absent", async () => {
 		let called = false;
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -297,10 +289,8 @@ describe("runSync", () => {
 	it("skips syncTopics with 'no topics configured' when topics list is empty", async () => {
 		let called = false;
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", topics: [] },
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", topics: [] },
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -330,10 +320,8 @@ describe("runSync", () => {
 
 	it("reports skip when provider does not implement syncTopics (topics configured)", async () => {
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", topics: ["ts"] },
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", topics: ["ts"] },
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -356,10 +344,8 @@ describe("runSync", () => {
 	it("passes the configured topics to syncTopics", async () => {
 		let capturedTopics: string[] | null = null;
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", topics: ["cli", "nodejs", "typescript"] },
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", topics: ["cli", "nodejs", "typescript"] },
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -390,16 +376,14 @@ describe("runSync", () => {
 	it("passes manual and derived properties to syncProperties", async () => {
 		let captured: Record<string, string> | null = null;
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: {
-					name: "theholocron/demo",
-					properties: {
-						lifecycle: "active",
-						open_source: true,
-						runtime_environment: "node",
-						uses_external_packages: false,
-					},
+			name: "demo",
+			repo: {
+				name: "theholocron/demo",
+				properties: {
+					lifecycle: "active",
+					open_source: true,
+					runtime_environment: "node",
+					uses_external_packages: false,
 				},
 			},
 			providers: { source: "github" },
@@ -439,10 +423,8 @@ describe("runSync", () => {
 	it("includes branch_protection_level when repo.protection is set", async () => {
 		let captured: Record<string, string> | null = null;
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", protection: "strict" },
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", protection: "strict" },
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -465,10 +447,8 @@ describe("runSync", () => {
 	it("omits branch_protection_level when repo.protection is 'none'", async () => {
 		let captured: Record<string, string> | null = null;
 		const loaded = loadedFrom({
-			project: {
-				name: "demo",
-				repo: { name: "theholocron/demo", protection: "none" },
-			},
+			name: "demo",
+			repo: { name: "theholocron/demo", protection: "none" },
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -491,7 +471,7 @@ describe("runSync", () => {
 	it("output includes a header and summary line", async () => {
 		const lines: string[] = [];
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -513,7 +493,7 @@ describe("runSync", () => {
 
 	it("marks step as fail when syncLabels throws", async () => {
 		const loaded = loadedFrom({
-			project: { name: "demo" },
+			name: "demo",
 			providers: { source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -50,7 +50,7 @@ export async function runDoctor(input: RunDoctorInput): Promise<DoctorReport> {
 	const rows: DoctorRow[] = [];
 	const config = input.loaded.resolved;
 
-	print(`Holocron doctor — ${config.project.name}`);
+	print(`Holocron doctor — ${config.name}`);
 	print(`  config: ${input.loaded.filepath}`);
 	print("");
 

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -373,10 +373,10 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	const config = input.loaded.resolved;
 	const dryRun = input.context.dryRun ?? false;
 	const steps: SetupStepResult[] = [];
-	const repo = config.project.repo;
+	const repo = config.repo;
 	const effectivePreset = repo?.protection;
 
-	print(`Holocron setup — ${config.project.name}${dryRun ? " (dry-run)" : ""}`);
+	print(`Holocron setup — ${config.name}${dryRun ? " (dry-run)" : ""}`);
 	print(`  config: ${input.loaded.filepath}`);
 	print("");
 
@@ -399,7 +399,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			print(formatStep(steps[steps.length - 1]!));
 		}
 
-		const usesAdvancedCodeQL = (config.project.workflows ?? [])
+		const usesAdvancedCodeQL = (config.workflows ?? [])
 			.map((e) => (typeof e === "string" ? e : e.name))
 			.includes("codeql");
 		steps.push(
@@ -426,7 +426,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			);
 			print(formatStep(steps[steps.length - 1]!));
 
-			const configuredWorkflowNames = (config.project.workflows ?? []).map((entry) =>
+			const configuredWorkflowNames = (config.workflows ?? []).map((entry) =>
 				typeof entry === "string" ? entry : entry.name
 			);
 			const requiredChecks =
@@ -446,7 +446,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	}
 
 	// ── source: workflow thin wrappers ──────────────────────────────────
-	const workflows = config.project.workflows;
+	const workflows = config.workflows;
 	if (loader.has("source") && workflows && workflows.length > 0) {
 		const source = loader.get("source") as Source;
 		print("  → workflows");
@@ -478,7 +478,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	// ── source: labeler config ───────────────────────────────────────────
 	if (
 		loader.has("source") &&
-		(config.project.workflows ?? []).map((e) => (typeof e === "string" ? e : e.name)).includes("bookkeeping-pr")
+		(config.workflows ?? []).map((e) => (typeof e === "string" ? e : e.name)).includes("bookkeeping-pr")
 	) {
 		const source = loader.get("source") as Source;
 		steps.push(
@@ -580,8 +580,8 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		const deploy = loader.get("deployment") as Deployment;
 		print("  → deployment");
 		steps.push(
-			await runStep("deployment", `ensureProject ${config.project.name}`, dryRun, async () => {
-				await deploy.ensureProject({ name: config.project.name });
+			await runStep("deployment", `ensureProject ${config.name}`, dryRun, async () => {
+				await deploy.ensureProject({ name: config.name });
 			})
 		);
 		print(formatStep(steps[steps.length - 1]!));
@@ -618,8 +618,8 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		// ensureProject — providers that have a top-level container.
 		if (vault.ensureProject) {
 			steps.push(
-				await runStep("vault", `ensureProject ${config.project.name}`, dryRun, async () => {
-					const result = await vault.ensureProject!(config.project.name);
+				await runStep("vault", `ensureProject ${config.name}`, dryRun, async () => {
+					const result = await vault.ensureProject!(config.name);
 					return `project ${result.alreadyExists ? "exists" : "created"}`;
 				})
 			);
@@ -633,7 +633,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			for (const envName of ["dev", "stg", "prd"]) {
 				steps.push(
 					await runStep("vault", `ensureEnvironment ${envName}`, dryRun, async () => {
-						const result = await vault.ensureEnvironment!(config.project.name, envName);
+						const result = await vault.ensureEnvironment!(config.name, envName);
 						return `${envName} ${result.alreadyExists ? "exists" : "created"}`;
 					})
 				);

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -53,7 +53,7 @@ type FileBatch = Array<{ path: string; content: string }>;
 type WorkflowEntry = { name: string; with?: Record<string, unknown> };
 
 /**
- * Extracts the `project.workflows` array from a `holocron.config.ts` source string.
+ * Extracts the `workflows` array from a `holocron.config.ts` source string.
  * Handles both plain string entries and `{ name, with }` object entries.
  * Falls back to an empty array if the array cannot be found or parsed.
  */
@@ -255,9 +255,9 @@ export async function runSyncGithub(input: RunSyncGithubInput): Promise<SyncGith
 			try {
 				const data = await client.git.getContents(repo, "holocron.config.json");
 				const raw = JSON.parse(Buffer.from(data.content.replace(/\n/g, ""), "base64").toString("utf8")) as {
-					project?: { workflows?: Array<string | WorkflowEntry> };
+					workflows?: Array<string | WorkflowEntry>;
 				};
-				entries = (raw?.project?.workflows ?? []).map((w) => (typeof w === "string" ? { name: w } : w));
+				entries = (raw?.workflows ?? []).map((w) => (typeof w === "string" ? { name: w } : w));
 			} catch (err) {
 				if (!(err instanceof ProviderApiError) || err.status !== 404) throw err;
 				// Fall back to .ts config

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -28,7 +28,7 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 	const requestedSteps = input.steps;
 	const steps: SetupStepResult[] = [];
 
-	print(`Holocron sync — ${config.project.name}${dryRun ? " (dry-run)" : ""}`);
+	print(`Holocron sync — ${config.name}${dryRun ? " (dry-run)" : ""}`);
 	print(`  config: ${input.loaded.filepath}`);
 	print("");
 
@@ -62,7 +62,7 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 
 			if (stepName === "properties") {
 				if (source.syncProperties) {
-					const repo = config.project.repo;
+					const repo = config.repo;
 					const properties: Record<string, string> = {};
 					const effectivePreset = repo?.protection;
 					if (effectivePreset && effectivePreset !== "none")
@@ -94,7 +94,7 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 			}
 
 			if (stepName === "topics") {
-				const topics = config.project.repo?.topics ?? [];
+				const topics = config.repo?.topics ?? [];
 				if (topics.length === 0) {
 					steps.push({
 						capability: "source",

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -68,8 +68,8 @@ export interface RepoProperties {
 }
 
 export interface RepoConfig {
-	/** "owner/name" — the GitHub repository coordinate. */
-	name: string;
+	/** "owner/name" — the GitHub repository coordinate. Derived from the git remote when absent. */
+	name?: string;
 	/**
 	 * Branch protection preset applied by `holocron setup`. When omitted,
 	 * no protection is applied and no `branch_protection_level` property is set.
@@ -94,33 +94,32 @@ export interface DoctorConfig {
 }
 
 export interface HolocronConfig {
-	project: {
-		name: string;
-		description?: string;
-		/**
-		 * Repository identity and metadata. When set, `PluginLoader` injects
-		 * `repo.name` into every plugin's `RuntimeContext.repo` so plugins that
-		 * need a repo (github, etc.) don't require `--repo` on every invocation.
-		 * `--repo` on the command line still overrides.
-		 */
-		repo?: RepoConfig;
-		/**
-		 * CI workflow names to install as thin wrappers during `holocron setup`.
-		 * Each name maps to a reusable workflow in `theholocron/.github`.
-		 * Use the object form to pass `with:` inputs to the reusable workflow.
-		 *
-		 * Supported values: "lint" | "test" | "typecheck" | "codeql" | "review" |
-		 *   "release" | "stale" | "greetings" | "dependencies" | "bookkeeping-pr" | "audit"
-		 *
-		 * `holocron setup` writes `.github/workflows/<name>.yml` for each entry,
-		 * calling the corresponding `ci-<name>.yml@main` reusable workflow.
-		 * Files are overwritten on each run — they are generated artifacts.
-		 *
-		 * @example
-		 * ["lint", { "name": "release", "with": { "run-build": false } }]
-		 */
-		workflows?: Array<string | { name: string; with?: Record<string, unknown> }>;
-	};
+	/** Project name. Derived from package.json when absent. */
+	name?: string;
+	description?: string;
+	/**
+	 * Repository identity and metadata. When set, `PluginLoader` injects
+	 * `repo.name` into every plugin's `RuntimeContext.repo` so plugins that
+	 * need a repo (github, etc.) don't require `--repo` on every invocation.
+	 * `--repo` on the command line still overrides.
+	 */
+	repo?: RepoConfig;
+	/**
+	 * CI workflow names to install as thin wrappers during `holocron setup`.
+	 * Each name maps to a reusable workflow in `theholocron/.github`.
+	 * Use the object form to pass `with:` inputs to the reusable workflow.
+	 *
+	 * Supported values: "lint" | "test" | "typecheck" | "codeql" | "review" |
+	 *   "release" | "stale" | "greetings" | "dependencies" | "bookkeeping-pr" | "audit"
+	 *
+	 * `holocron setup` writes `.github/workflows/<name>.yml` for each entry,
+	 * calling the corresponding `ci-<name>.yml@main` reusable workflow.
+	 * Files are overwritten on each run — they are generated artifacts.
+	 *
+	 * @example
+	 * ["lint", { "name": "release", "with": { "run-build": false } }]
+	 */
+	workflows?: Array<string | { name: string; with?: Record<string, unknown> }>;
 	providers: RawProvidersConfig;
 	apps?: AppConfig[];
 	doctor?: DoctorConfig;
@@ -144,7 +143,10 @@ export type ResolvedProviderEntry =
 export type ResolvedProvidersConfig = Partial<Record<CapabilityKey, ResolvedProviderEntry>>;
 
 export interface ResolvedHolocronConfig {
-	project: HolocronConfig["project"];
+	name: string;
+	description?: string;
+	repo?: RepoConfig;
+	workflows?: Array<string | { name: string; with?: Record<string, unknown> }>;
 	providers: ResolvedProvidersConfig;
 	apps: AppConfig[];
 	doctor: DoctorConfig;
@@ -240,8 +242,8 @@ export function resolveEntry(key: CapabilityKey, raw: RawProviderEntry): Resolve
 }
 
 export function resolveConfig(raw: HolocronConfig): ResolvedHolocronConfig {
-	if (!raw.project?.name) {
-		throw new ConfigError("`project.name` is required");
+	if (!raw.name) {
+		throw new ConfigError("`name` is required");
 	}
 	if (!raw.providers || typeof raw.providers !== "object") {
 		throw new ConfigError("`providers` block is required");
@@ -260,7 +262,10 @@ export function resolveConfig(raw: HolocronConfig): ResolvedHolocronConfig {
 	}
 
 	return {
-		project: raw.project,
+		name: raw.name,
+		description: raw.description,
+		repo: raw.repo,
+		workflows: raw.workflows,
 		providers,
 		apps: raw.apps ?? [],
 		doctor: raw.doctor ?? {},

--- a/packages/cli/src/load-config.ts
+++ b/packages/cli/src/load-config.ts
@@ -10,9 +10,13 @@
  * Implements the lookup-order contract from issue #75 / #81.
  */
 
+import { execFile } from "node:child_process";
 import { readFile, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 import type { HolocronConfig, ResolvedHolocronConfig } from "./config.js";
 import { ConfigError, resolveConfig } from "./config.js";
@@ -60,21 +64,21 @@ async function loadJson(filepath: string): Promise<ResolvedHolocronConfig> {
 	} catch (err) {
 		throw new ConfigError(`${filepath} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`);
 	}
-	return resolveConfig(parsed);
+	return resolveConfig(await deriveDefaults(dirname(filepath), parsed));
 }
 
 async function loadJs(filepath: string): Promise<ResolvedHolocronConfig> {
 	const mod = await import(pathToFileURL(filepath).href);
-	return extractAndResolve(filepath, mod);
+	return resolveConfig(await deriveDefaults(dirname(filepath), extractRaw(filepath, mod)));
 }
 
 async function loadTs(filepath: string): Promise<ResolvedHolocronConfig> {
 	const { tsImport } = await import("tsx/esm/api");
 	const mod = await tsImport(pathToFileURL(filepath).href, import.meta.url);
-	return extractAndResolve(filepath, mod);
+	return resolveConfig(await deriveDefaults(dirname(filepath), extractRaw(filepath, mod)));
 }
 
-function extractAndResolve(filepath: string, mod: unknown): ResolvedHolocronConfig {
+function extractRaw(filepath: string, mod: unknown): HolocronConfig {
 	const outer = (mod as { default?: unknown }).default;
 	// tsx CJS-transforms `export default x` into `exports.default = x`, which
 	// dynamic import wraps as { default: { __esModule: true, default: x } }.
@@ -84,7 +88,46 @@ function extractAndResolve(filepath: string, mod: unknown): ResolvedHolocronConf
 	if (raw === undefined || raw === null) {
 		throw new ConfigFileError(`${filepath} must have a default export (use \`export default defineConfig({…})\`)`);
 	}
-	return resolveConfig(raw as HolocronConfig);
+	return raw as HolocronConfig;
+}
+
+async function deriveDefaults(configDir: string, raw: HolocronConfig): Promise<HolocronConfig> {
+	const result = { ...raw };
+	if (!result.name) {
+		result.name = (await readPackageJsonName(configDir)) ?? basename(configDir);
+	}
+	if (result.repo && !result.repo.name) {
+		const repoName = await readGitRemote(configDir);
+		if (repoName) result.repo = { ...result.repo, name: repoName };
+	}
+	return result;
+}
+
+async function readPackageJsonName(dir: string): Promise<string | undefined> {
+	try {
+		const content = await readFile(join(dir, "package.json"), "utf8");
+		const pkg = JSON.parse(content) as { name?: string };
+		return typeof pkg.name === "string" ? pkg.name.replace(/^@[^/]+\//, "") : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function readGitRemote(dir: string): Promise<string | undefined> {
+	try {
+		const { stdout } = await execFileAsync("git", ["remote", "get-url", "origin"], { cwd: dir });
+		return parseGitRemoteUrl(stdout.trim());
+	} catch {
+		return undefined;
+	}
+}
+
+function parseGitRemoteUrl(url: string): string | undefined {
+	const httpsMatch = url.match(/github\.com\/([^/]+\/[^/]+?)(?:\.git)?$/);
+	if (httpsMatch) return httpsMatch[1]!;
+	const sshMatch = url.match(/github\.com:([^/]+\/[^/]+?)(?:\.git)?$/);
+	if (sshMatch) return sshMatch[1]!;
+	return undefined;
 }
 
 async function fileExists(path: string): Promise<boolean> {

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -183,7 +183,7 @@ export class PluginLoader {
 	 */
 	private projectDefaults(): Partial<RuntimeContext> {
 		const defaults: Partial<RuntimeContext> = {};
-		if (this.config.project.repo) defaults.repo = this.config.project.repo.name;
+		if (this.config.repo?.name) defaults.repo = this.config.repo.name;
 		return defaults;
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,53 +7,53 @@ settings:
 catalogs:
   default:
     '@theholocron/clerk-client':
-      specifier: ^0.7.0
-      version: 0.7.0
+      specifier: ^0.11.3
+      version: 0.11.3
     '@theholocron/commitlint-config':
-      specifier: ^7.0.0
-      version: 7.0.0
+      specifier: ^7.3.0
+      version: 7.3.0
     '@theholocron/doppler-client':
-      specifier: ^0.7.0
-      version: 0.7.0
+      specifier: ^0.11.3
+      version: 0.11.3
     '@theholocron/eslint-config':
-      specifier: ^7.0.0
-      version: 7.0.0
+      specifier: ^7.3.0
+      version: 7.3.0
     '@theholocron/github-client':
-      specifier: ^0.7.0
-      version: 0.7.0
+      specifier: ^0.11.3
+      version: 0.11.3
     '@theholocron/holocron-config':
-      specifier: ^7.2.0
-      version: 7.2.0
+      specifier: ^7.3.0
+      version: 7.3.0
     '@theholocron/infisical-client':
-      specifier: ^0.10.0
-      version: 0.10.0
+      specifier: ^0.11.3
+      version: 0.11.3
     '@theholocron/lint-staged-config':
-      specifier: ^7.0.0
-      version: 7.0.0
+      specifier: ^7.3.0
+      version: 7.3.0
     '@theholocron/neon-client':
-      specifier: ^0.7.0
-      version: 0.7.0
+      specifier: ^0.11.3
+      version: 0.11.3
     '@theholocron/postman-client':
-      specifier: ^0.10.0
-      version: 0.10.0
+      specifier: ^0.11.3
+      version: 0.11.3
     '@theholocron/prettier-config':
-      specifier: ^7.0.0
-      version: 7.0.0
+      specifier: ^7.3.0
+      version: 7.3.0
     '@theholocron/semantic-release-config':
-      specifier: ^7.0.0
-      version: 7.0.0
+      specifier: ^7.3.0
+      version: 7.3.0
     '@theholocron/tsconfig':
-      specifier: ^7.0.0
-      version: 7.0.0
+      specifier: ^7.3.0
+      version: 7.3.0
     '@theholocron/tsdown-config':
-      specifier: ^7.0.0
-      version: 7.0.0
+      specifier: ^7.3.0
+      version: 7.3.0
     '@theholocron/vercel-client':
-      specifier: ^0.10.0
-      version: 0.10.0
+      specifier: ^0.11.3
+      version: 0.11.3
     '@theholocron/vitest-config':
-      specifier: ^7.2.3
-      version: 7.2.3
+      specifier: ^7.3.0
+      version: 7.3.0
     '@types/node':
       specifier: ^26
       version: 26.0.1
@@ -86,7 +86,7 @@ catalogs:
       version: 4.1.10
 
 overrides:
-  '@theholocron/http-client': ^0.7.0
+  '@theholocron/http-client': ^0.11.3
 
 importers:
 
@@ -106,13 +106,13 @@ importers:
         version: link:packages/cli
       '@theholocron/commitlint-config':
         specifier: 'catalog:'
-        version: 7.0.0(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)
+        version: 7.3.0(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.3.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/holocron-config':
         specifier: 'catalog:'
-        version: 7.2.0(@theholocron/cli@packages+cli)
+        version: 7.3.0(@theholocron/cli@packages+cli)
       '@theholocron/holocron-plugin-1password':
         specifier: workspace:*
         version: link:packages/holocron-plugin-1password
@@ -139,16 +139,16 @@ importers:
         version: link:packages/holocron-plugin-vercel
       '@theholocron/lint-staged-config':
         specifier: 'catalog:'
-        version: 7.0.0(husky@9.1.7)(imagemin-lint-staged@0.5.1)(lint-staged@16.4.0)
+        version: 7.3.0(husky@9.1.7)(lint-staged@16.4.0)
       '@theholocron/prettier-config':
         specifier: 'catalog:'
-        version: 7.0.0(prettier@3.9.3)
+        version: 7.3.0(prettier@3.9.3)
       '@theholocron/semantic-release-config':
         specifier: 'catalog:'
-        version: 7.0.0(@semantic-release/changelog@6.0.3(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/github@12.0.8(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.5(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.0)(semantic-release@25.0.5(typescript@5.9.3))
+        version: 7.3.0(@semantic-release/changelog@6.0.3(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/github@12.0.8(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.5(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.0)(semantic-release@25.0.5(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 7.0.0(typescript@5.9.3)
+        version: 7.3.0(typescript@5.9.3)
       '@vitest/eslint-plugin':
         specifier: 'catalog:'
         version: 1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10)
@@ -202,10 +202,10 @@ importers:
         version: 1.3.0
       '@theholocron/github-client':
         specifier: 'catalog:'
-        version: 0.7.0
+        version: 0.11.3
       '@theholocron/http-client':
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^0.11.3
+        version: 0.11.3
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
@@ -218,13 +218,13 @@ importers:
         version: link:../cli-utils
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.3.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 7.0.0(typescript@5.9.3)
+        version: 7.3.0(typescript@5.9.3)
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.3.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.0.1
@@ -300,7 +300,7 @@ importers:
     devDependencies:
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 7.0.0(typescript@5.9.3)
+        version: 7.3.0(typescript@5.9.3)
       '@types/play-sound':
         specifier: ^1.1.2
         version: 1.1.2
@@ -321,16 +321,16 @@ importers:
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.3.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 7.0.0(typescript@5.9.3)
+        version: 7.3.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 7.0.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.3.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.3.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.0.1
@@ -366,22 +366,22 @@ importers:
     devDependencies:
       '@theholocron/clerk-client':
         specifier: 'catalog:'
-        version: 0.7.0
+        version: 0.11.3
       '@theholocron/cli':
         specifier: workspace:*
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.3.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 7.0.0(typescript@5.9.3)
+        version: 7.3.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 7.0.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.3.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.3.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.0.1
@@ -420,19 +420,19 @@ importers:
         version: link:../cli
       '@theholocron/doppler-client':
         specifier: 'catalog:'
-        version: 0.7.0
+        version: 0.11.3
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.3.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 7.0.0(typescript@5.9.3)
+        version: 7.3.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 7.0.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.3.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.3.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.0.1
@@ -475,19 +475,19 @@ importers:
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.3.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/github-client':
         specifier: 'catalog:'
-        version: 0.7.0
+        version: 0.11.3
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 7.0.0(typescript@5.9.3)
+        version: 7.3.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 7.0.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.3.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.3.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/libsodium-wrappers':
         specifier: ^0.7.14
         version: 0.7.14
@@ -529,19 +529,19 @@ importers:
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.3.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/infisical-client':
         specifier: 'catalog:'
-        version: 0.10.0
+        version: 0.11.3
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 7.0.0(typescript@5.9.3)
+        version: 7.3.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 7.0.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.3.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.3.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.0.1
@@ -580,19 +580,19 @@ importers:
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.3.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/neon-client':
         specifier: 'catalog:'
-        version: 0.7.0
+        version: 0.11.3
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 7.0.0(typescript@5.9.3)
+        version: 7.3.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 7.0.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.3.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.3.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.0.1
@@ -631,19 +631,19 @@ importers:
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.3.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/postman-client':
         specifier: 'catalog:'
-        version: 0.10.0
+        version: 0.11.3
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 7.0.0(typescript@5.9.3)
+        version: 7.3.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 7.0.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.3.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.3.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.0.1
@@ -682,19 +682,19 @@ importers:
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: 'catalog:'
-        version: 7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
+        version: 7.3.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: 'catalog:'
-        version: 7.0.0(typescript@5.9.3)
+        version: 7.3.0(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: 'catalog:'
-        version: 7.0.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.3.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vercel-client':
         specifier: 'catalog:'
-        version: 0.10.0
+        version: 0.11.3
       '@theholocron/vitest-config':
         specifier: 'catalog:'
-        version: 7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.3.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.0.1
@@ -1695,10 +1695,6 @@ packages:
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
     engines: {node: '>=18'}
 
-  '@sindresorhus/is@0.7.0':
-    resolution: {integrity: sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==}
-    engines: {node: '>=4'}
-
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
@@ -1713,22 +1709,24 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@theholocron/clerk-client@0.7.0':
-    resolution: {integrity: sha512-tRlFeDc1DKGTW2C7cwKynUKQ4oPBNTJPqPNq8Rdo7B5S9/rZCkklz4eMGQNTjSzBUFVu+t/N6uTVfh3EULvPlA==}
+  '@theholocron/clerk-client@0.11.3':
+    resolution: {integrity: sha512-Ipw82OxNl+DNYRrsMyhfLXhPOiDq4/nNHZMd1hHv4ygcHew89Mzrdurz0ffOGeWTJTVuRcr1rxa+nFQjksWXgQ==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/commitlint-config@7.0.0':
-    resolution: {integrity: sha512-8hOkQ6k1cUbReyi56CL2z7RCwBJ7gYA011rY+RRXHm/c/EvNIKcIdCFWmncmhATBiafQdqv1AqhZIDPSm3pR/g==}
+  '@theholocron/commitlint-config@7.3.0':
+    resolution: {integrity: sha512-F2HXiI4hjtkDdJocsMl029rVqVRTL8BFMDm8Ct3jF9VP+W8ll523efPsqsYM2DVtqHDMxfMliqiwJj/88nvtvw==}
+    engines: {node: '>=22.0.0'}
     peerDependencies:
       '@commitlint/cli': ^21
       '@commitlint/config-conventional': ^21
 
-  '@theholocron/doppler-client@0.7.0':
-    resolution: {integrity: sha512-E2LKVQ7MHV4IiEP3kivB4uHUxtFkG4eV4JcNrNsS0RXpkQw9OnHTNNzPGGD8d+9pJRP4vltlEPlPZtXh+wU+WQ==}
+  '@theholocron/doppler-client@0.11.3':
+    resolution: {integrity: sha512-vIoxCH/q//krP6YL/qHGh5huRAUvxHUgXlGnUfYl+f5vCgsUxpkhwkoo+qmWACLxAhsMaKKQxSqSBFZjauL3EA==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/eslint-config@7.0.0':
-    resolution: {integrity: sha512-c5siaN8gwRTDHZJcTELMD4XMON4KFbrynMPTZsuvwqHksKgAdyRC2PqzzPJVvUWrcnqRqmIg5z44HVFk254z6A==}
+  '@theholocron/eslint-config@7.3.0':
+    resolution: {integrity: sha512-rf7skxqZa6L5Vbey6cgLOMYwXoFRbLZzdN9v3Q5A1knuB2Px4XN1nxpBUlrrkblvAeosTuEPnqJJkXYs301Dqw==}
+    engines: {node: '>=22.0.0'}
     peerDependencies:
       '@eslint/js': ^10
       '@next/eslint-plugin-next': ^16
@@ -1754,52 +1752,52 @@ packages:
       eslint-plugin-storybook:
         optional: true
 
-  '@theholocron/github-client@0.7.0':
-    resolution: {integrity: sha512-7fQ1AY0ZUh95cS7HARBfTWMyYnP56aBMJ0TfT6XKCzQEgSUc4VvsCzUsBW0gnBF/BrqgBHNWQXfK0Fs1kFXUVw==}
+  '@theholocron/github-client@0.11.3':
+    resolution: {integrity: sha512-5XilkR1+0L0sE6/KGs2rGGvCPySKnYu0hRJ3vf6YRf1sz1kA2YPy9/zeZTArG0PVtF4GQWGZQ0DQCUvOWZAc6g==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/holocron-config@7.2.0':
-    resolution: {integrity: sha512-eEQVNP5YGL1eA/ur8yjqbB4iq9khgL1jy2ZSR+8d7OSYjWMPe2osKL3GALF2qpaT9AjcVH9Enycy1kyDIviT9A==}
+  '@theholocron/holocron-config@7.3.0':
+    resolution: {integrity: sha512-Ptjs8yxR8aDInHUUAQkBvsiRsVtKMBvbnuqkZqwZPtvJ7x747Ew2dD8nZtflEDmnmBVEhIab7PEjdlAONavJIA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@theholocron/cli': '>=2.0.0-alpha.1'
 
-  '@theholocron/http-client@0.7.0':
-    resolution: {integrity: sha512-D2zC97WwBtMSrfKFtZM3GPVHxbuTJeMDjBH/JxlcB5YYSUzWX+LXrN8GrcHgm9heOPcwEf2GOGN6K9+DBq8Ntg==}
+  '@theholocron/http-client@0.11.3':
+    resolution: {integrity: sha512-eayCX5Na1tWRMYLeQdl1aA4IfbFrIbAC8nvbbc4QzlV/BeoVjZik0FK5jz3WAQZP9McEC1Y5nR4pFImXtxG1JA==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/infisical-client@0.10.0':
-    resolution: {integrity: sha512-yE89Ev/fjtbK6zckXUNRlu2bcMVNKT5xEarqdw1zUWkYdrkU59Vymku16/2MdhenMyPCookR42Yp0JbsOG6aMw==}
+  '@theholocron/infisical-client@0.11.3':
+    resolution: {integrity: sha512-KkRscoXP5PCnY++i1fKG/oVdEz0/wjO38H8FV4ZE0v/YbltrRMMvn5GET4OCORXSGWH+uPDz+rKgNPbJJ6hdlw==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/lint-staged-config@7.0.0':
-    resolution: {integrity: sha512-7KbmYo3czPfit3UE94OJH9kg5NPWYLY3iugm58swxxnBX5wIvKNIcyH007vjJ4M7zil030dqmASx1pT97dNg2g==}
+  '@theholocron/lint-staged-config@7.3.0':
+    resolution: {integrity: sha512-JGb8VOPHnvJbP/fGHGwVdMeKABJknD2RxB2YOOiZSoN0rX353wNH7npXV8KIE/Fe3SJ8+b0O9kfiUueANR/brA==}
+    engines: {node: '>=22.0.0'}
     peerDependencies:
       husky: ^9
-      imagemin-lint-staged: ^0.5
       lint-staged: ^16
       sort-package-json: ^4
     peerDependenciesMeta:
-      imagemin-lint-staged:
-        optional: true
       sort-package-json:
         optional: true
 
-  '@theholocron/neon-client@0.7.0':
-    resolution: {integrity: sha512-Zw9aHyHaOgXHb69LLx2bMGfhafOAFYQ74NP048Gv+fYP8o8gSlkxvLfNV+tY3vsUfFziVC9NhorvH/hnfYnyBA==}
+  '@theholocron/neon-client@0.11.3':
+    resolution: {integrity: sha512-l5DJppca5ha3zEcAl19BKn6Jyno3vC7N/KpnfP12SmJi9HD1QC1D62ZVB3UqEI2JV6uKg92KUkzIBT4GRrhDxw==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/postman-client@0.10.0':
-    resolution: {integrity: sha512-a6oIuo3l1n/b0dEkwNJrgv9RNhZ1Auz42P+ENiLRzqmRjEpKQ5dCb5kSpYi++7GFZvK4bgGTNHqslOfthY10Gg==}
+  '@theholocron/postman-client@0.11.3':
+    resolution: {integrity: sha512-WMTkMYP/btBbsbd5LWxJAXzkT3P0J9gXliVGuyQOrLFBHjgHebxqdcslbxoHZNTgB+PxzmBuUIvM9M+2j8/V9A==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/prettier-config@7.0.0':
-    resolution: {integrity: sha512-LiZ5GCV9QDTeRq8Rw+sV8r/j9W/w1OFCoO7SJWU+UujnhAge1/9Ka+ShsBcecpvZsj6VItJKwPA4vpc+dRYT/Q==}
+  '@theholocron/prettier-config@7.3.0':
+    resolution: {integrity: sha512-3kjeO4/oPyNoVFr7aYNxOAMKSSFEPfpz5pB97XnjcLBwxVsCVg1ritUY2fKGaJ5+WFUohPUlUtCnZ1G1LKzuaw==}
+    engines: {node: '>=22.0.0'}
     peerDependencies:
       prettier: ^3
 
-  '@theholocron/semantic-release-config@7.0.0':
-    resolution: {integrity: sha512-fXjNmO/TM09tUBM6X4TGZSz4j4iBkRFRSDS7OnMO4kL2c7JyF1vJdx6LkGaWKifmprdBHVVhEEppkLgtpo02Og==}
+  '@theholocron/semantic-release-config@7.3.0':
+    resolution: {integrity: sha512-dvDDbThxH3CprVBhWu5wmz2Xiz7Vx8T2A91ub0W1/MXAOSNLANiroPL3eXPUKZvvm68iIQ1/iR6q47zQw4jhRA==}
+    engines: {node: '>=22.0.0'}
     peerDependencies:
       '@semantic-release/changelog': ^6
       '@semantic-release/commit-analyzer': ^13
@@ -1813,13 +1811,15 @@ packages:
       '@semantic-release/exec':
         optional: true
 
-  '@theholocron/tsconfig@7.0.0':
-    resolution: {integrity: sha512-qswP8dhQVtfZpMViWj0XS4Ew54vcS4RsOXH24kOVXQ/R+YXojqQdAO6hIJ3s41hxG0QwfHRQw0KMZtei30PmwQ==}
+  '@theholocron/tsconfig@7.3.0':
+    resolution: {integrity: sha512-Yo7J1Iq78ufBoyLVZimwhxXPeeG2jBArt28Wpm7LzoCU2pJ8m0jpCwK7KoE7f+s4VOgHVb/14CGYGU4TQd5Gzw==}
+    engines: {node: '>=22.0.0'}
     peerDependencies:
       typescript: ^5
 
-  '@theholocron/tsdown-config@7.0.0':
-    resolution: {integrity: sha512-e8j9VJHNM9aeGPmhwuXODAodrjtrpcdNYnsbFw/mJDCTMWryRFai0dt4HHE8DHgQJ/PRe5xJw/2mxYmq/feLIw==}
+  '@theholocron/tsdown-config@7.3.0':
+    resolution: {integrity: sha512-GskZNofYwjzJYpRYNzDfh6zzQKssr+RX73phxxe7hQU5FiEpQ6iI1BUOgkf4oPOf6WHdd5T8qkbHTQz46ISQng==}
+    engines: {node: '>=22.0.0'}
     peerDependencies:
       tsdown: ^0
 
@@ -1827,12 +1827,12 @@ packages:
     resolution: {integrity: sha512-LCZqjEn+BCWzmTcK0HXaVo2fhHJPMk4XV0kRydYKLWZNnQPYuij6ib/HGo8bUVpLv6801hGm9AubPtVbYgktVg==}
     engines: {node: '>=20', npm: '>=10'}
 
-  '@theholocron/vercel-client@0.10.0':
-    resolution: {integrity: sha512-pzjPAJIa/rEzq9akE+ETX7t6MBtR1IDeAcF9iDt9LeJoIQ9mSnbgerhgmLiPEfN+3np1vLaFipcUZqWstImSrQ==}
+  '@theholocron/vercel-client@0.11.3':
+    resolution: {integrity: sha512-eM/q41FHWTfN9kabzUGJ2OSyuVYeP2FSNtOGIFetthM4AKAk3Kkx+KbAummIVf/KlRWS9GsggVAX7shtsI5cNw==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/vitest-config@7.2.3':
-    resolution: {integrity: sha512-Esl4a2bpMPhYUfXq3LyuBeGUCrbuGoGz0Ol89IGFKE3Fz3kns4H6AW+cn+NmHjwSZfLHDxOy4e/aB+bkp/Fx5A==}
+  '@theholocron/vitest-config@7.3.0':
+    resolution: {integrity: sha512-GLK2S96tOoB8SAXctdHfHCqoq6idIALfuTXe6hXX09t6o8da4GTngIWeLYuVFcD4A+DHz9ztf4SmCTfde6JJ1Q==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@storybook/addon-vitest': ^9
@@ -1886,9 +1886,6 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/keyv@3.1.4':
-    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
-
   '@types/libsodium-wrappers@0.7.14':
     resolution: {integrity: sha512-5Kv68fXuXK0iDuUir1WPGw2R9fOZUlYlSAa0ztMcL0s0BfIDTqg9GXz8K30VJpPP3sxWhbolnQma2x+/TfkzDQ==}
 
@@ -1909,9 +1906,6 @@ packages:
 
   '@types/play-sound@1.1.2':
     resolution: {integrity: sha512-alq2D5sBtVcq5bzL/yLr5SSQ7B4VTIkX728V3nYfo6TaCtnwFLdHsFgy+N9oCjh67OOZQnj7kkJauWNW0L8bWw==}
-
-  '@types/responselike@1.0.3':
-    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
@@ -2095,10 +2089,6 @@ packages:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
-  ansi-regex@2.1.1:
-    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
-    engines: {node: '>=0.10.0'}
-
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2106,10 +2096,6 @@ packages:
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
-
-  ansi-styles@2.2.1:
-    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
-    engines: {node: '>=0.10.0'}
 
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -2130,13 +2116,6 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
-  arch@2.2.0:
-    resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
-
-  archive-type@4.0.0:
-    resolution: {integrity: sha512-zV4Ky0v1F8dBrdYElwTvQhweQ0P7Kwc1aluqJsYtOBP01jXcWCyW2IEfI1YiqsG+Iy7ZR+o5LF1N+PGECBxHWA==}
-    engines: {node: '>=4'}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2146,10 +2125,6 @@ packages:
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
-
-  array-find-index@1.0.2:
-    resolution: {integrity: sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==}
-    engines: {node: '>=0.10.0'}
 
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
@@ -2168,10 +2143,6 @@ packages:
 
   array.prototype.flatmap@1.3.3:
     resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
-    engines: {node: '>= 0.4'}
-
-  array.prototype.reduce@1.0.8:
-    resolution: {integrity: sha512-DwuEqgXFBwbmZSRqt3BpQigWNUoqw9Ml2dTWdF3B2zQlQX4OeUE0zyuzX0fX0IbTvjdkZbcBTU3idgpO78qkTw==}
     engines: {node: '>= 0.4'}
 
   array.prototype.tosorted@1.1.4:
@@ -2214,40 +2185,11 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
-  bin-build@3.0.0:
-    resolution: {integrity: sha512-jcUOof71/TNAI2uM5uoUaDq2ePcVBQ3R/qhxAz1rX7UfvduAL/RXD3jXzvn8cVcDJdGVkiR1shal3OH0ImpuhA==}
-    engines: {node: '>=4'}
-
-  bin-check@4.1.0:
-    resolution: {integrity: sha512-b6weQyEUKsDGFlACWSIOfveEnImkJyK/FGW6FAG42loyoquvjdtOIqO6yBFzHyqyVVhNgNkQxxx09SFLK28YnA==}
-    engines: {node: '>=4'}
-
-  bin-version-check@4.0.0:
-    resolution: {integrity: sha512-sR631OrhC+1f8Cvs8WyVWOA33Y8tgwjETNPyyD/myRBXLkfS/vl74FmH/lFcRl9KY3zwGh7jFhvyk9vV3/3ilQ==}
-    engines: {node: '>=6'}
-
-  bin-version@3.1.0:
-    resolution: {integrity: sha512-Mkfm4iE1VFt4xd4vH+gx+0/71esbfus2LsnCGe8Pi4mndSPyT+NGES/Eg99jx8/lUGWfu3z2yuB/bt5UB+iVbQ==}
-    engines: {node: '>=6'}
-
-  bin-wrapper@4.1.0:
-    resolution: {integrity: sha512-hfRmo7hWIXPkbpi0ZltboCMVrU+0ClXR/JgbCKKjlDjQf6igXa7OwdqNcFWQZPZTgiY7ZpzE3+LjjkLiTN2T7Q==}
-    engines: {node: '>=6'}
-
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
-
-  bl@1.2.3:
-    resolution: {integrity: sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==}
-
-  boolbase@1.0.0:
-    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
@@ -2271,21 +2213,6 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  buffer-alloc-unsafe@1.1.0:
-    resolution: {integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==}
-
-  buffer-alloc@1.2.0:
-    resolution: {integrity: sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==}
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-
-  buffer-fill@1.0.0:
-    resolution: {integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==}
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -2293,9 +2220,6 @@ packages:
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
-
-  cacheable-request@2.1.4:
-    resolution: {integrity: sha512-vag0O2LKZ/najSoUwDbVlnlCFvhBE/7mGTY2B5FgCBDcRD+oVV1HYTOwM6JZfMg/hIcM6IwnTZ1uQQL5/X3xIQ==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2313,14 +2237,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camelcase-keys@2.1.0:
-    resolution: {integrity: sha512-bA/Z/DERHKqoEOrp+qeGKw1QlvEQkGZSc0XaY6VnTxZr+Kv1G5zFwttpjv8qxZ/sBPT4nthwZaAcsAZTJlSKXQ==}
-    engines: {node: '>=0.10.0'}
-
-  camelcase@2.1.1:
-    resolution: {integrity: sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==}
-    engines: {node: '>=0.10.0'}
-
   camelcase@7.0.1:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
@@ -2329,17 +2245,9 @@ packages:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
 
-  caw@2.0.1:
-    resolution: {integrity: sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==}
-    engines: {node: '>=4'}
-
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
-
-  chalk@1.1.3:
-    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
-    engines: {node: '>=0.10.0'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -2415,9 +2323,6 @@ packages:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
 
-  clone-response@1.0.2:
-    resolution: {integrity: sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==}
-
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
 
@@ -2454,13 +2359,6 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
-  commander@2.20.3:
-    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-
-  commander@7.2.0:
-    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
-    engines: {node: '>= 10'}
-
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
@@ -2477,13 +2375,6 @@ packages:
   configstore@7.1.0:
     resolution: {integrity: sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==}
     engines: {node: '>=18'}
-
-  console-stream@0.1.1:
-    resolution: {integrity: sha512-QC/8l9e6ofi6nqZ5PawlDgzmMw3OxIXtvolBzap/F4UDBJlDaZRSNbL/lb41C29FcbSJncBFlJFj2WJoNyZRfQ==}
-
-  content-disposition@0.5.4:
-    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
-    engines: {node: '>= 0.6'}
 
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
@@ -2551,13 +2442,6 @@ packages:
       typescript:
         optional: true
 
-  cross-spawn@5.1.0:
-    resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
-
-  cross-spawn@6.0.6:
-    resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
-    engines: {node: '>=4.8'}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2565,25 +2449,6 @@ packages:
   crypto-random-string@4.0.0:
     resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
     engines: {node: '>=12'}
-
-  css-select@4.3.0:
-    resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
-
-  css-tree@1.1.3:
-    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
-    engines: {node: '>=8.0.0'}
-
-  css-what@6.2.2:
-    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
-    engines: {node: '>= 6'}
-
-  csso@4.2.0:
-    resolution: {integrity: sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==}
-    engines: {node: '>=8.0.0'}
-
-  currently-unhandled@0.4.1:
-    resolution: {integrity: sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==}
-    engines: {node: '>=0.10.0'}
 
   dargs@8.1.0:
     resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
@@ -2613,38 +2478,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  decamelize@1.2.0:
-    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
-    engines: {node: '>=0.10.0'}
-
-  decode-uri-component@0.2.2:
-    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
-    engines: {node: '>=0.10'}
-
-  decompress-response@3.3.0:
-    resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
-    engines: {node: '>=4'}
-
-  decompress-tar@4.1.1:
-    resolution: {integrity: sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==}
-    engines: {node: '>=4'}
-
-  decompress-tarbz2@4.1.1:
-    resolution: {integrity: sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==}
-    engines: {node: '>=4'}
-
-  decompress-targz@4.1.1:
-    resolution: {integrity: sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==}
-    engines: {node: '>=4'}
-
-  decompress-unzip@4.0.1:
-    resolution: {integrity: sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==}
-    engines: {node: '>=4'}
-
-  decompress@4.2.1:
-    resolution: {integrity: sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==}
-    engines: {node: '>=4'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -2684,19 +2517,6 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
-  dom-serializer@1.4.1:
-    resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
-
-  domelementtype@2.3.0:
-    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
-
-  domhandler@4.3.1:
-    resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
-    engines: {node: '>= 4'}
-
-  domutils@2.8.0:
-    resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
-
   dot-prop@10.1.0:
     resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
     engines: {node: '>=20'}
@@ -2713,14 +2533,6 @@ packages:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
-  download@6.2.5:
-    resolution: {integrity: sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==}
-    engines: {node: '>=4'}
-
-  download@7.1.0:
-    resolution: {integrity: sha512-xqnBTVd/E+GxJVrX5/eUJiLYjCGPwMpdL+jGhGU57BvtcA7wwhtHVbXBeUk51kOpW3S7Jn3BQbN9Q1R1Km2qDQ==}
-    engines: {node: '>=6'}
-
   dts-resolver@3.0.0:
     resolution: {integrity: sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==}
     engines: {node: ^22.18.0 || >=24.0.0}
@@ -2736,9 +2548,6 @@ packages:
 
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
-
-  duplexer3@0.1.5:
-    resolution: {integrity: sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2762,15 +2571,9 @@ packages:
   enabled@2.0.0:
     resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
 
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
   enhanced-resolve@5.24.2:
     resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
     engines: {node: '>=10.13.0'}
-
-  entities@2.2.0:
-    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
 
   env-ci@11.2.0:
     resolution: {integrity: sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==}
@@ -2802,9 +2605,6 @@ packages:
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
     engines: {node: '>= 0.4'}
-
-  es-array-method-boxes-properly@1.0.0:
-    resolution: {integrity: sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -2941,18 +2741,6 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
-  exec-buffer@3.2.0:
-    resolution: {integrity: sha512-wsiD+2Tp6BWHoVv3B+5Dcx6E7u5zky+hUwOHjuH2hKSLR3dvRmX8fk8UD8uqQixHs4Wk6eDmiegVrMPjKj7wpA==}
-    engines: {node: '>=4'}
-
-  execa@0.7.0:
-    resolution: {integrity: sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw==}
-    engines: {node: '>=4'}
-
-  execa@1.0.0:
-    resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
-    engines: {node: '>=6'}
-
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -2965,21 +2753,9 @@ packages:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
-  executable@4.1.1:
-    resolution: {integrity: sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==}
-    engines: {node: '>=4'}
-
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
-
-  ext-list@2.2.2:
-    resolution: {integrity: sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==}
-    engines: {node: '>=0.10.0'}
-
-  ext-name@5.0.0:
-    resolution: {integrity: sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==}
-    engines: {node: '>=4'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -3002,13 +2778,6 @@ packages:
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
-  fast-xml-parser@4.5.7:
-    resolution: {integrity: sha512-a6Qh1RMCNbSrU1+sAyAAZH3rTe+OaWJbNZIq0S+ifZciUUOQtlVxBJwoTUE2bYhysmG/RYyI5WJFIKdBahJdrQ==}
-    hasBin: true
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -3020,10 +2789,6 @@ packages:
 
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
-
-  figures@1.7.0:
-    resolution: {integrity: sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==}
-    engines: {node: '>=0.10.0'}
 
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -3045,38 +2810,6 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
-  file-type@10.11.0:
-    resolution: {integrity: sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==}
-    engines: {node: '>=6'}
-
-  file-type@3.9.0:
-    resolution: {integrity: sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==}
-    engines: {node: '>=0.10.0'}
-
-  file-type@4.4.0:
-    resolution: {integrity: sha512-f2UbFQEk7LXgWpi5ntcO86OeA/cC80fuDDDaX/fZ2ZGel+AF7leRQqBBW1eJNiiQkrZlAoM6P+VYP5P6bOlDEQ==}
-    engines: {node: '>=4'}
-
-  file-type@5.2.0:
-    resolution: {integrity: sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==}
-    engines: {node: '>=4'}
-
-  file-type@6.2.0:
-    resolution: {integrity: sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==}
-    engines: {node: '>=4'}
-
-  file-type@8.1.0:
-    resolution: {integrity: sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==}
-    engines: {node: '>=6'}
-
-  filename-reserved-regex@2.0.0:
-    resolution: {integrity: sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==}
-    engines: {node: '>=4'}
-
-  filenamify@2.1.0:
-    resolution: {integrity: sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==}
-    engines: {node: '>=4'}
-
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -3087,10 +2820,6 @@ packages:
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
-
-  find-up@1.1.2:
-    resolution: {integrity: sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==}
-    engines: {node: '>=0.10.0'}
 
   find-up@2.1.0:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
@@ -3103,10 +2832,6 @@ packages:
   find-up@7.0.0:
     resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
     engines: {node: '>=18'}
-
-  find-versions@3.2.0:
-    resolution: {integrity: sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==}
-    engines: {node: '>=6'}
 
   find-versions@6.0.0:
     resolution: {integrity: sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==}
@@ -3126,18 +2851,9 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  from2@2.3.0:
-    resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
-
-  fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
-
   fs-extra@11.3.6:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
-
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3178,26 +2894,6 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-proxy@2.1.0:
-    resolution: {integrity: sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==}
-    engines: {node: '>=4'}
-
-  get-stdin@4.0.1:
-    resolution: {integrity: sha512-F5aQMywwJ2n85s4hJPTT9RPxGmubonuB10MNYo17/xph174n2MIR33HRguhzVag10O/npM7SPk73LMZNP+FaWw==}
-    engines: {node: '>=0.10.0'}
-
-  get-stream@2.3.1:
-    resolution: {integrity: sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==}
-    engines: {node: '>=0.10.0'}
-
-  get-stream@3.0.0:
-    resolution: {integrity: sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==}
-    engines: {node: '>=4'}
-
-  get-stream@4.1.0:
-    resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
-    engines: {node: '>=6'}
-
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -3221,11 +2917,6 @@ packages:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
     engines: {node: '>=20.20.0'}
 
-  gifsicle@5.3.0:
-    resolution: {integrity: sha512-FJTpgdj1Ow/FITB7SVza5HlzXa+/lqEY0tHQazAJbuAdvyJtkH4wIdsR2K414oaTwRXHFLLF+tYbipj+OpYg+Q==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   git-log-parser@1.2.1:
     resolution: {integrity: sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==}
 
@@ -3238,10 +2929,6 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -3266,14 +2953,6 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  got@7.1.0:
-    resolution: {integrity: sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==}
-    engines: {node: '>=4'}
-
-  got@8.3.2:
-    resolution: {integrity: sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==}
-    engines: {node: '>=4'}
-
   graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
@@ -3284,10 +2963,6 @@ packages:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
-
-  has-ansi@2.0.0:
-    resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
-    engines: {node: '>=0.10.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -3308,15 +2983,9 @@ packages:
     resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
     engines: {node: '>= 0.4'}
 
-  has-symbol-support-x@1.4.2:
-    resolution: {integrity: sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==}
-
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
-
-  has-to-string-tag-x@1.4.1:
-    resolution: {integrity: sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==}
 
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
@@ -3336,9 +3005,6 @@ packages:
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
-  hosted-git-info@2.8.9:
-    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -3349,9 +3015,6 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
-
-  http-cache-semantics@3.8.1:
-    resolution: {integrity: sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==}
 
   http-proxy-agent@9.1.0:
     resolution: {integrity: sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==}
@@ -3382,9 +3045,6 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -3393,26 +3053,6 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  imagemin-gifsicle@7.0.0:
-    resolution: {integrity: sha512-LaP38xhxAwS3W8PFh4y5iQ6feoTSF+dTAXFRUEYQWYst6Xd+9L/iPk34QGgK/VO/objmIlmq9TStGfVY2IcHIA==}
-    engines: {node: '>=10'}
-
-  imagemin-jpegtran@7.0.0:
-    resolution: {integrity: sha512-MJoyTCW8YjMJf56NorFE41SR/WkaGA3IYk4JgvMlRwguJEEd3PnP9UxA8Y2UWjquz8d+On3Ds/03ZfiiLS8xTQ==}
-    engines: {node: '>=10'}
-
-  imagemin-lint-staged@0.5.1:
-    resolution: {integrity: sha512-W9Qqgas82CPG+7m4QgaGeCrlMeiewODnuzyWLNTYWhVnP9QGP4XfU6nFJDhJ0rI7qb6KsoCiz5+CWczng0Nciw==}
-    hasBin: true
-
-  imagemin-optipng@8.0.0:
-    resolution: {integrity: sha512-CUGfhfwqlPjAC0rm8Fy+R2DJDBGjzy2SkfyT09L8rasnF9jSoHFqJ1xxSZWK6HVPZBMhGPMxCTL70OgTHlLF5A==}
-    engines: {node: '>=10'}
-
-  imagemin-svgo@9.0.0:
-    resolution: {integrity: sha512-uNgXpKHd99C0WODkrJ8OO/3zW3qjgS4pW7hcuII0RcHN3tnKxDjJWcitdVC/TZyfIqSricU8WfrHn26bdSW62g==}
-    engines: {node: '>=10'}
-
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -3420,10 +3060,6 @@ packages:
   import-from-esm@2.0.0:
     resolution: {integrity: sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==}
     engines: {node: '>=18.20'}
-
-  import-lazy@3.1.0:
-    resolution: {integrity: sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==}
-    engines: {node: '>=6'}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -3436,10 +3072,6 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  indent-string@2.1.0:
-    resolution: {integrity: sha512-aqwDFWSgSgfRaEwao5lg5KEcVd/2a+D1rvoG7NdilmYz0NwRk6StWpWdz/Hpk34MKPpx7s8XxUqimfcQK6gGlg==}
-    engines: {node: '>=0.10.0'}
-
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -3451,10 +3083,6 @@ packages:
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
-
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -3473,10 +3101,6 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
-
-  into-stream@3.1.0:
-    resolution: {integrity: sha512-TcdjPibTksa1NQximqep2r17ISRiNE9fwlfbg3F8ANdvP5/yrFTew86VcO//jk4QTaMlbjypPBq76HN2zaKfZQ==}
-    engines: {node: '>=4'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -3530,10 +3154,6 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
-  is-finite@1.1.0:
-    resolution: {integrity: sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==}
-    engines: {node: '>=0.10.0'}
-
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -3545,10 +3165,6 @@ packages:
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
-
-  is-gif@3.0.0:
-    resolution: {integrity: sha512-IqJ/jlbw5WJSNfwQ/lHEDXF8rxhRgF6ythk2oiEvhpG29F704eX9NO6TvPfMiq9DrbwgcEDnETYNcZDPewQoVw==}
-    engines: {node: '>=6'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -3576,16 +3192,9 @@ packages:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
 
-  is-jpg@2.0.0:
-    resolution: {integrity: sha512-ODlO0ruzhkzD3sdynIainVP5eoOFNN85rxA1+cwwnPe4dKyX0r5+hxNO5XpCrxlHcmb9vkOit9mhRD2JVuimHg==}
-    engines: {node: '>=6'}
-
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
-
-  is-natural-number@4.0.1:
-    resolution: {integrity: sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==}
 
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
@@ -3607,32 +3216,17 @@ packages:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
 
-  is-object@1.0.2:
-    resolution: {integrity: sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==}
-
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
-
-  is-plain-obj@1.1.0:
-    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
-    engines: {node: '>=0.10.0'}
 
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  is-png@2.0.0:
-    resolution: {integrity: sha512-4KPGizaVGj2LK7xwJIz8o5B2ubu1D/vcQsgOGFEDlpcvgZHto4gBnyd0ig7Ws+67ixmwKoNmu0hYnpo6AaKb5g==}
-    engines: {node: '>=8'}
-
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
-
-  is-retry-allowed@1.2.0:
-    resolution: {integrity: sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==}
-    engines: {node: '>=0.10.0'}
 
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
@@ -3641,10 +3235,6 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
-
-  is-stream@1.1.0:
-    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
-    engines: {node: '>=0.10.0'}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -3661,10 +3251,6 @@ packages:
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
-
-  is-svg@4.4.0:
-    resolution: {integrity: sha512-v+AgVwiK5DsGtT9ng+m4mClp6zDAmwrW8nZi6Gg15qzvBnRWWdfWA1TGaXyCDnWq5g5asofIgMVl3PjKxvk1ug==}
-    engines: {node: '>=6'}
 
   is-symbol@1.1.1:
     resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
@@ -3685,9 +3271,6 @@ packages:
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
-
-  is-utf8@0.2.1:
-    resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -3730,10 +3313,6 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
-  isurl@1.0.0:
-    resolution: {integrity: sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==}
-    engines: {node: '>= 4'}
-
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -3744,11 +3323,6 @@ packages:
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
-    hasBin: true
-
-  jpegtran-bin@5.0.2:
-    resolution: {integrity: sha512-4FSmgIcr8d5+V6T1+dHbPZjaFH0ogVyP4UVsE+zri7S9YLO4qAT2our4IN3sW3STVgNTbqPermdIgt2XuAJ4EA==}
-    engines: {node: '>=10'}
     hasBin: true
 
   js-tokens@10.0.0:
@@ -3765,9 +3339,6 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
-
-  json-buffer@3.0.0:
-    resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -3803,9 +3374,6 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
-
-  keyv@3.0.0:
-    resolution: {integrity: sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3846,10 +3414,6 @@ packages:
   listr2@9.0.5:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
-
-  load-json-file@1.1.0:
-    resolution: {integrity: sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==}
-    engines: {node: '>=0.10.0'}
 
   load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
@@ -3920,37 +3484,12 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
-  logalot@2.1.0:
-    resolution: {integrity: sha512-Ah4CgdSRfeCJagxQhcVNMi9BfGYyEKLa6d7OA6xSbld/Hg3Cf2QiOa1mDpmG7Ve8LOH6DN3mdttzjQAvWTyVkw==}
-    engines: {node: '>=0.10.0'}
-
   logform@2.7.0:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
 
-  longest@1.0.1:
-    resolution: {integrity: sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg==}
-    engines: {node: '>=0.10.0'}
-
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
-    hasBin: true
-
-  loud-rejection@1.6.0:
-    resolution: {integrity: sha512-RPNliZOFkqFumDhvYqOaNY4Uz9oJM2K9tC6JWsJJsNdhuONW4LQHRBpb0qf4pJApVffI5N39SwzWZJuEhfd7eQ==}
-    engines: {node: '>=0.10.0'}
-
-  lowercase-keys@1.0.0:
-    resolution: {integrity: sha512-RPlX0+PHuvxVDZ7xX+EBVAp4RsVxP/TdDSN2mJYdiq1Lc4Hz7EUSjUI7RZrKKlmrIzVhf6Jo2stj7++gVarS0A==}
-    engines: {node: '>=0.10.0'}
-
-  lowercase-keys@1.0.1:
-    resolution: {integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==}
-    engines: {node: '>=0.10.0'}
-
-  lpad-align@1.1.2:
-    resolution: {integrity: sha512-MMIcFmmR9zlGZtBcFOows6c2COMekHCIFJz3ew/rRpKZ1wR4mXDPzvcVqLarux8M33X4TPSq2Jdw8WJj0q0KbQ==}
-    engines: {node: '>=0.10.0'}
     hasBin: true
 
   lru-cache@10.4.3:
@@ -3959,9 +3498,6 @@ packages:
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
-
-  lru-cache@4.1.5:
-    resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3973,17 +3509,9 @@ packages:
     resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
     engines: {node: '>=18'}
 
-  make-dir@1.3.0:
-    resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}
-    engines: {node: '>=4'}
-
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
-
-  map-obj@1.0.1:
-    resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
-    engines: {node: '>=0.10.0'}
 
   marked-man@2.1.1:
     resolution: {integrity: sha512-GnAyyylcexZLPAKCOax8i/YJtAytcREmx485Y+JYBVGdzkCXzx1oDIqSU3vPzRcSEowsxuEVGtDyT/g2guVSyA==}
@@ -4009,9 +3537,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mdn-data@2.0.14:
-    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
-
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
     engines: {node: '>=16.10'}
@@ -4020,20 +3545,12 @@ packages:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
 
-  meow@3.7.0:
-    resolution: {integrity: sha512-TNdwZs0skRlpPpCUK25StC4VH+tP5GgeY1HQOOGP+lQ2xtdkN2VtT/5tiX9k3IWpkBPV9b3LsAWXn4GGi/PrSA==}
-    engines: {node: '>=0.10.0'}
-
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
-
-  mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
 
   mime@4.1.0:
     resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
@@ -4051,10 +3568,6 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
-
-  mimic-response@1.0.1:
-    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
-    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -4094,9 +3607,6 @@ packages:
   nerf-dart@1.0.0:
     resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
 
-  nice-try@1.0.5:
-    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
-
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
@@ -4104,9 +3614,6 @@ packages:
   node-exports-info@1.6.2:
     resolution: {integrity: sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==}
     engines: {node: '>= 0.4'}
-
-  normalize-package-data@2.5.0:
-    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
 
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
@@ -4116,21 +3623,9 @@ packages:
     resolution: {integrity: sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  normalize-url@2.0.1:
-    resolution: {integrity: sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==}
-    engines: {node: '>=4'}
-
   normalize-url@9.0.1:
     resolution: {integrity: sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==}
     engines: {node: '>=20'}
-
-  npm-conf@1.1.3:
-    resolution: {integrity: sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==}
-    engines: {node: '>=4'}
-
-  npm-run-path@2.0.2:
-    resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
-    engines: {node: '>=4'}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -4215,9 +3710,6 @@ packages:
       - validate-npm-package-name
       - which
 
-  nth-check@2.1.1:
-    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -4242,10 +3734,6 @@ packages:
     resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
     engines: {node: '>= 0.4'}
 
-  object.getownpropertydescriptors@2.1.9:
-    resolution: {integrity: sha512-mt8YM6XwsTTovI+kdZdHSxoyF2DI59up034orlC9NfweclcWOt7CVascNNLp6U+bjFVCVCIh9PwS76tDM/rH8g==}
-    engines: {node: '>= 0.4'}
-
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
@@ -4257,9 +3745,6 @@ packages:
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   one-time@1.0.0:
     resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
@@ -4288,42 +3773,17 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
-  optipng-bin@7.0.1:
-    resolution: {integrity: sha512-W99mpdW7Nt2PpFiaO+74pkht7KEqkXkeRomdWXfEz3SALZ6hns81y/pm1dsGZ6ItUIfchiNIP6ORDr1zETU1jA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   ora@9.4.1:
     resolution: {integrity: sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==}
     engines: {node: '>=20'}
-
-  os-filter-obj@2.0.0:
-    resolution: {integrity: sha512-uksVLsqG3pVdzzPvmAHpBK0wKxYItuzZr7SziusRPoz67tGV8rL1szZ6IdeUrbqLjGDwApBtN29eEE3IqGHOjg==}
-    engines: {node: '>=4'}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
-  p-cancelable@0.3.0:
-    resolution: {integrity: sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==}
-    engines: {node: '>=4'}
-
-  p-cancelable@0.4.1:
-    resolution: {integrity: sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==}
-    engines: {node: '>=4'}
-
   p-each-series@3.0.0:
     resolution: {integrity: sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==}
     engines: {node: '>=12'}
-
-  p-event@1.3.0:
-    resolution: {integrity: sha512-hV1zbA7gwqPVFcapfeATaNjQ3J0NuzorHPyG8GPL9g/Y/TplWVBVoCKCXL6Ej2zscrCEv195QNWJXuBH6XZuzA==}
-    engines: {node: '>=4'}
-
-  p-event@2.3.1:
-    resolution: {integrity: sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==}
-    engines: {node: '>=6'}
 
   p-event@6.0.1:
     resolution: {integrity: sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==}
@@ -4332,14 +3792,6 @@ packages:
   p-filter@4.1.0:
     resolution: {integrity: sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==}
     engines: {node: '>=18'}
-
-  p-finally@1.0.0:
-    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
-    engines: {node: '>=4'}
-
-  p-is-promise@1.1.0:
-    resolution: {integrity: sha512-zL7VE4JVS2IFSkR2GQKDSPEVxkoH43/p7oEnwpdCndKYJO0HVeRB7fA8TJwuLOTBREtK0ea8eHaxdwcpob5dmg==}
-    engines: {node: '>=4'}
 
   p-limit@1.3.0:
     resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
@@ -4365,17 +3817,9 @@ packages:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  p-map-series@1.0.0:
-    resolution: {integrity: sha512-4k9LlvY6Bo/1FcIdV33wqZQES0Py+iKISU9Uc8p8AjWoZPnFKMpVIVD3s0EYn4jzLh1I+WeUZkJ0Yoa4Qfw3Kg==}
-    engines: {node: '>=4'}
-
   p-map@7.0.5:
     resolution: {integrity: sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==}
     engines: {node: '>=18'}
-
-  p-reduce@1.0.0:
-    resolution: {integrity: sha512-3Tx1T3oM1xO/Y8Gj0sWyE78EIJZ+t+aEmXUdvQgvGmSMri7aPTHoovbXEreWKkL5j21Er60XAWLTzKbAKYOujQ==}
-    engines: {node: '>=4'}
 
   p-reduce@2.1.0:
     resolution: {integrity: sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==}
@@ -4384,14 +3828,6 @@ packages:
   p-reduce@3.0.0:
     resolution: {integrity: sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==}
     engines: {node: '>=12'}
-
-  p-timeout@1.2.1:
-    resolution: {integrity: sha512-gb0ryzr+K2qFqFv6qi3khoeqMZF/+ajxQipEF6NteZVnvz9tzdsfAVj3lYtn1gAXvH5lfLwfxEII799gt/mRIA==}
-    engines: {node: '>=4'}
-
-  p-timeout@2.0.1:
-    resolution: {integrity: sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==}
-    engines: {node: '>=4'}
 
   p-timeout@6.1.4:
     resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
@@ -4408,10 +3844,6 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
-
-  parse-json@2.2.0:
-    resolution: {integrity: sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==}
-    engines: {node: '>=0.10.0'}
 
   parse-json@4.0.0:
     resolution: {integrity: sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==}
@@ -4438,10 +3870,6 @@ packages:
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
-  path-exists@2.1.0:
-    resolution: {integrity: sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==}
-    engines: {node: '>=0.10.0'}
-
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
     engines: {node: '>=4'}
@@ -4454,14 +3882,6 @@ packages:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
-
-  path-key@2.0.1:
-    resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
-    engines: {node: '>=4'}
-
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -4473,19 +3893,12 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-type@1.1.0:
-    resolution: {integrity: sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==}
-    engines: {node: '>=0.10.0'}
-
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4502,25 +3915,9 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
-
   pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
-
-  pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
-    engines: {node: '>=6'}
-
-  pinkie-promise@2.0.1:
-    resolution: {integrity: sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==}
-    engines: {node: '>=0.10.0'}
-
-  pinkie@2.0.4:
-    resolution: {integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==}
-    engines: {node: '>=0.10.0'}
 
   pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}
@@ -4544,14 +3941,6 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-
-  prepend-http@1.0.4:
-    resolution: {integrity: sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==}
-    engines: {node: '>=0.10.0'}
-
-  prepend-http@2.0.0:
-    resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==}
-    engines: {node: '>=4'}
 
   prettier@3.9.3:
     resolution: {integrity: sha512-HWmu+K+zvHNpaMfSnYeqdqrDbR16cuIXaPx8WoHaviQkDJh1/0BNtOZmHVQI5jc3wXv0H1yXc9wjvFdXh+n3hQ==}
@@ -4583,12 +3972,6 @@ packages:
       kerberos:
         optional: true
 
-  pseudomap@1.0.2:
-    resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
-
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -4599,10 +3982,6 @@ packages:
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
-
-  query-string@5.1.1:
-    resolution: {integrity: sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==}
-    engines: {node: '>=0.10.0'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -4618,14 +3997,6 @@ packages:
   read-package-up@12.0.0:
     resolution: {integrity: sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==}
     engines: {node: '>=20'}
-
-  read-pkg-up@1.0.1:
-    resolution: {integrity: sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==}
-    engines: {node: '>=0.10.0'}
-
-  read-pkg@1.1.0:
-    resolution: {integrity: sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==}
-    engines: {node: '>=0.10.0'}
 
   read-pkg@10.1.0:
     resolution: {integrity: sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==}
@@ -4645,10 +4016,6 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
-  redent@1.0.0:
-    resolution: {integrity: sha512-qtW5hKzGQZqKoh6JNSD+4lfitfPKGz42e6QwiRmPM5mmKtR0N41AbJRYu0xJi7nhOJ4WDgRkKvAk6tw4WIwR4g==}
-    engines: {node: '>=0.10.0'}
-
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -4664,10 +4031,6 @@ packages:
   registry-url@6.0.1:
     resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
     engines: {node: '>=12'}
-
-  repeating@2.0.1:
-    resolution: {integrity: sha512-ZqtSMuVybkISo2OWvqvm7iHSWngvdaW3IpsT9/uP8v4gMi591LY6h35wdOfvQdWCKFWZWm2Y1Opp4kV7vQKT6A==}
-    engines: {node: '>=0.10.0'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4688,18 +4051,10 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  resolve@1.22.12:
-    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
-
   resolve@2.0.0-next.7:
     resolution: {integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
-
-  responselike@1.0.2:
-    resolution: {integrity: sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -4707,11 +4062,6 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
-  rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
 
   rolldown-plugin-dts@0.26.0:
     resolution: {integrity: sha512-e+kEPtUiDES0htk5iqkSeF4EzAV7R+vugGB44iPDuw1Kw9E+WyL1VG7PaV0IIjGHLiacztMBcMTyrr8ON9CT1Q==}
@@ -4775,34 +4125,14 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sax@1.6.0:
-    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
-    engines: {node: '>=11.0.0'}
-
-  seek-bzip@1.0.6:
-    resolution: {integrity: sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==}
-    hasBin: true
-
   semantic-release@25.0.5:
     resolution: {integrity: sha512-mn61SUJwtM8ThrWn2WmgLVpwVJeG/hPSupua1psdMoufmwRIPyvRLkRkL0JDXkP67OntlLWUYnBnfVc8EDO3/g==}
     engines: {node: ^22.14.0 || >= 24.10.0}
     hasBin: true
 
-  semver-regex@2.0.0:
-    resolution: {integrity: sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==}
-    engines: {node: '>=6'}
-
   semver-regex@4.0.5:
     resolution: {integrity: sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==}
     engines: {node: '>=12'}
-
-  semver-truncate@1.1.2:
-    resolution: {integrity: sha512-V1fGg9i4CL3qesB6U0L6XAm4xOJiHmt4QAacazumuasc03BvtFGIMCduv01JWQ69Nv+JST9TqhSCiJoxoY031w==}
-    engines: {node: '>=0.10.0'}
-
-  semver@5.7.2:
-    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
-    hasBin: true
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -4825,17 +4155,9 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  shebang-command@1.2.0:
-    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
-    engines: {node: '>=0.10.0'}
-
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
-
-  shebang-regex@1.0.0:
-    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
-    engines: {node: '>=0.10.0'}
 
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
@@ -4887,18 +4209,6 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
-  sort-keys-length@1.0.1:
-    resolution: {integrity: sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==}
-    engines: {node: '>=0.10.0'}
-
-  sort-keys@1.1.2:
-    resolution: {integrity: sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==}
-    engines: {node: '>=0.10.0'}
-
-  sort-keys@2.0.0:
-    resolution: {integrity: sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==}
-    engines: {node: '>=4'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -4929,14 +4239,6 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
-  squeak@1.3.0:
-    resolution: {integrity: sha512-YQL1ulInM+ev8nXX7vfXsCsDh6IqXlrremc1hzi77776BtpWgYJUMto3UM05GSAaGzJgWekszjoKDrVNB5XG+A==}
-    engines: {node: '>=0.10.0'}
-
-  stable@0.1.8:
-    resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
-    deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
-
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
 
@@ -4956,10 +4258,6 @@ packages:
 
   stream-combiner2@1.1.1:
     resolution: {integrity: sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==}
-
-  strict-uri-encode@1.1.0:
-    resolution: {integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==}
-    engines: {node: '>=0.10.0'}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -5009,10 +4307,6 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
-  strip-ansi@3.0.1:
-    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
-    engines: {node: '>=0.10.0'}
-
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -5021,20 +4315,9 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
-  strip-bom@2.0.0:
-    resolution: {integrity: sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==}
-    engines: {node: '>=0.10.0'}
-
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
-
-  strip-dirs@2.1.0:
-    resolution: {integrity: sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==}
-
-  strip-eof@1.0.0:
-    resolution: {integrity: sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==}
-    engines: {node: '>=0.10.0'}
 
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
@@ -5048,21 +4331,9 @@ packages:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
 
-  strip-indent@1.0.1:
-    resolution: {integrity: sha512-I5iQq6aFMM62fBEAIB/hXzwJD6EEZ0xEGCX2t7oXqaKPIRgt4WruAQ285BISgdkP+HLGWyeGmNJcpIwFeRYRUA==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
-
-  strip-outer@1.0.1:
-    resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
-    engines: {node: '>=0.10.0'}
-
-  strnum@1.1.2:
-    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
   stubborn-fs@2.0.0:
     resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
@@ -5073,10 +4344,6 @@ packages:
   super-regex@1.1.0:
     resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
     engines: {node: '>=18'}
-
-  supports-color@2.0.0:
-    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
-    engines: {node: '>=0.8.0'}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -5094,11 +4361,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svgo@2.8.3:
-    resolution: {integrity: sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
@@ -5107,21 +4369,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar-stream@1.6.2:
-    resolution: {integrity: sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==}
-    engines: {node: '>= 0.8.0'}
-
-  temp-dir@1.0.0:
-    resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==}
-    engines: {node: '>=4'}
-
   temp-dir@3.0.0:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
     engines: {node: '>=14.16'}
-
-  tempfile@2.0.0:
-    resolution: {integrity: sha512-ZOn6nJUgvgC09+doCEF3oB+r3ag7kUvlsXEGX069QRD60p+P3uP7XG9N2/at+EyIRGSN//ZY3LyEotA1YpmjuA==}
-    engines: {node: '>=4'}
 
   tempy@3.2.0:
     resolution: {integrity: sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==}
@@ -5151,10 +4401,6 @@ packages:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
 
-  timed-out@4.0.1:
-    resolution: {integrity: sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==}
-    engines: {node: '>=0.10.0'}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -5173,10 +4419,6 @@ packages:
   title-case@4.3.2:
     resolution: {integrity: sha512-I/nkcBo73mO42Idfv08jhInV61IMb61OdIFxk+B4Gu1oBjWBPOLmhZdsli+oJCVaD+86pYQA93cJfFt224ZFAA==}
 
-  to-buffer@1.2.2:
-    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
-    engines: {node: '>= 0.4'}
-
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -5188,14 +4430,6 @@ packages:
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
-
-  trim-newlines@1.0.0:
-    resolution: {integrity: sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==}
-    engines: {node: '>=0.10.0'}
-
-  trim-repeated@1.0.0:
-    resolution: {integrity: sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==}
-    engines: {node: '>=0.10.0'}
 
   triple-beam@1.4.1:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
@@ -5248,9 +4482,6 @@ packages:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
-
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
@@ -5321,9 +4552,6 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  unbzip2-stream@1.4.3:
-    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
-
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
@@ -5379,29 +4607,8 @@ packages:
     resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  url-parse-lax@1.0.0:
-    resolution: {integrity: sha512-BVA4lR5PIviy2PMseNd2jbFQ+jwSwQGdJejf5ctd1rEXt0Ypd7yanUK9+lYechVlN5VaTJGsu2U/3MDDu6KgBA==}
-    engines: {node: '>=0.10.0'}
-
-  url-parse-lax@3.0.0:
-    resolution: {integrity: sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==}
-    engines: {node: '>=4'}
-
-  url-to-options@1.0.1:
-    resolution: {integrity: sha512-0kQLIzG4fdk/G5NONku64rSH/x32NOA39LVQqlK8Le6lvTF6GGRJpqaQFGgU+CLwySIqBSMdwYM0sYcW9f6P4A==}
-    engines: {node: '>= 4'}
-
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  util.promisify@1.1.3:
-    resolution: {integrity: sha512-GIEaZ6o86fj09Wtf0VfZ5XP7tmd4t3jM5aZCgmBi231D0DB1AEBa3Aa6MP48DMsAIi96WkpWLimIWVwOjbDMOw==}
-    engines: {node: '>= 0.8'}
-
-  uuid@3.4.0:
-    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -5509,10 +4716,6 @@ packages:
     resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
     engines: {node: '>= 0.4'}
 
-  which@1.3.1:
-    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
-    hasBin: true
-
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -5562,9 +4765,6 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
@@ -5580,9 +4780,6 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
-
-  yallist@2.1.2:
-    resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -5612,9 +4809,6 @@ packages:
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -6484,9 +5678,6 @@ snapshots:
 
   '@simple-libs/stream-utils@1.2.0': {}
 
-  '@sindresorhus/is@0.7.0':
-    optional: true
-
   '@sindresorhus/is@4.6.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
@@ -6498,20 +5689,20 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@theholocron/clerk-client@0.7.0':
+  '@theholocron/clerk-client@0.11.3':
     dependencies:
-      '@theholocron/http-client': 0.7.0
+      '@theholocron/http-client': 0.11.3
 
-  '@theholocron/commitlint-config@7.0.0(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)':
+  '@theholocron/commitlint-config@7.3.0(@commitlint/cli@19.8.1(@types/node@26.1.1)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)':
     dependencies:
       '@commitlint/cli': 19.8.1(@types/node@26.1.1)(typescript@5.9.3)
       '@commitlint/config-conventional': 19.8.1
 
-  '@theholocron/doppler-client@0.7.0':
+  '@theholocron/doppler-client@0.11.3':
     dependencies:
-      '@theholocron/http-client': 0.7.0
+      '@theholocron/http-client': 0.11.3
 
-  '@theholocron/eslint-config@7.0.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))':
+  '@theholocron/eslint-config@7.3.0(@eslint/js@10.0.1(eslint@10.7.0(jiti@2.6.1)))(@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.7.0(jiti@2.6.1)))(eslint@10.7.0(jiti@2.6.1))(globals@17.7.0)(typescript-eslint@8.62.1(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3))':
     dependencies:
       '@eslint/js': 10.0.1(eslint@10.7.0(jiti@2.6.1))
       eslint: 10.7.0(jiti@2.6.1)
@@ -6522,40 +5713,38 @@ snapshots:
       eslint-plugin-n: 18.2.2(eslint@10.7.0(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-react: 7.37.5(eslint@10.7.0(jiti@2.6.1))
 
-  '@theholocron/github-client@0.7.0':
+  '@theholocron/github-client@0.11.3':
     dependencies:
-      '@theholocron/http-client': 0.7.0
+      '@theholocron/http-client': 0.11.3
 
-  '@theholocron/holocron-config@7.2.0(@theholocron/cli@packages+cli)':
+  '@theholocron/holocron-config@7.3.0(@theholocron/cli@packages+cli)':
     dependencies:
       '@theholocron/cli': link:packages/cli
 
-  '@theholocron/http-client@0.7.0': {}
+  '@theholocron/http-client@0.11.3': {}
 
-  '@theholocron/infisical-client@0.10.0':
+  '@theholocron/infisical-client@0.11.3':
     dependencies:
-      '@theholocron/http-client': 0.7.0
+      '@theholocron/http-client': 0.11.3
 
-  '@theholocron/lint-staged-config@7.0.0(husky@9.1.7)(imagemin-lint-staged@0.5.1)(lint-staged@16.4.0)':
+  '@theholocron/lint-staged-config@7.3.0(husky@9.1.7)(lint-staged@16.4.0)':
     dependencies:
       husky: 9.1.7
       lint-staged: 16.4.0
-    optionalDependencies:
-      imagemin-lint-staged: 0.5.1
 
-  '@theholocron/neon-client@0.7.0':
+  '@theholocron/neon-client@0.11.3':
     dependencies:
-      '@theholocron/http-client': 0.7.0
+      '@theholocron/http-client': 0.11.3
 
-  '@theholocron/postman-client@0.10.0':
+  '@theholocron/postman-client@0.11.3':
     dependencies:
-      '@theholocron/http-client': 0.7.0
+      '@theholocron/http-client': 0.11.3
 
-  '@theholocron/prettier-config@7.0.0(prettier@3.9.3)':
+  '@theholocron/prettier-config@7.3.0(prettier@3.9.3)':
     dependencies:
       prettier: 3.9.3
 
-  '@theholocron/semantic-release-config@7.0.0(@semantic-release/changelog@6.0.3(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/github@12.0.8(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.5(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.0)(semantic-release@25.0.5(typescript@5.9.3))':
+  '@theholocron/semantic-release-config@7.3.0(@semantic-release/changelog@6.0.3(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/github@12.0.8(semantic-release@25.0.5(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.5(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.0)(semantic-release@25.0.5(typescript@5.9.3))':
     dependencies:
       '@semantic-release/changelog': 6.0.3(semantic-release@25.0.5(typescript@5.9.3))
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.5(typescript@5.9.3))
@@ -6567,11 +5756,11 @@ snapshots:
     optionalDependencies:
       '@semantic-release/exec': 7.1.0(semantic-release@25.0.5(typescript@5.9.3))
 
-  '@theholocron/tsconfig@7.0.0(typescript@5.9.3)':
+  '@theholocron/tsconfig@7.3.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@theholocron/tsdown-config@7.0.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))':
+  '@theholocron/tsdown-config@7.3.0(tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3))':
     dependencies:
       tsdown: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
 
@@ -6580,11 +5769,11 @@ snapshots:
       change-case: 5.4.4
       title-case: 4.3.2
 
-  '@theholocron/vercel-client@0.10.0':
+  '@theholocron/vercel-client@0.11.3':
     dependencies:
-      '@theholocron/http-client': 0.7.0
+      '@theholocron/http-client': 0.11.3
 
-  '@theholocron/vitest-config@7.2.3(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
+  '@theholocron/vitest-config@7.3.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
     dependencies:
       vitest: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
@@ -6616,11 +5805,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/keyv@3.1.4':
-    dependencies:
-      '@types/node': 26.1.1
-    optional: true
-
   '@types/libsodium-wrappers@0.7.14': {}
 
   '@types/mute-stream@0.0.1':
@@ -6644,11 +5828,6 @@ snapshots:
   '@types/play-sound@1.1.2':
     dependencies:
       '@types/node': 26.0.1
-
-  '@types/responselike@1.0.3':
-    dependencies:
-      '@types/node': 26.1.1
-    optional: true
 
   '@types/triple-beam@1.3.5': {}
 
@@ -6886,15 +6065,9 @@ snapshots:
     dependencies:
       environment: 1.1.0
 
-  ansi-regex@2.1.1:
-    optional: true
-
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
-
-  ansi-styles@2.2.1:
-    optional: true
 
   ansi-styles@3.2.1:
     dependencies:
@@ -6910,14 +6083,6 @@ snapshots:
 
   any-promise@1.3.0: {}
 
-  arch@2.2.0:
-    optional: true
-
-  archive-type@4.0.0:
-    dependencies:
-      file-type: 4.4.0
-    optional: true
-
   argparse@2.0.1: {}
 
   argv-formatter@1.0.0: {}
@@ -6926,9 +6091,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
-    optional: true
-
-  array-find-index@1.0.2:
     optional: true
 
   array-ify@1.0.0: {}
@@ -6969,18 +6131,6 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.24.2
       es-shim-unscopables: 1.1.0
-    optional: true
-
-  array.prototype.reduce@1.0.8:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-array-method-boxes-properly: 1.0.0
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      is-string: 1.1.1
     optional: true
 
   array.prototype.tosorted@1.1.4:
@@ -7037,59 +6187,9 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  base64-js@1.5.1:
-    optional: true
-
   before-after-hook@4.0.0: {}
 
-  bin-build@3.0.0:
-    dependencies:
-      decompress: 4.2.1
-      download: 6.2.5
-      execa: 0.7.0
-      p-map-series: 1.0.0
-      tempfile: 2.0.0
-    optional: true
-
-  bin-check@4.1.0:
-    dependencies:
-      execa: 0.7.0
-      executable: 4.1.1
-    optional: true
-
-  bin-version-check@4.0.0:
-    dependencies:
-      bin-version: 3.1.0
-      semver: 5.7.2
-      semver-truncate: 1.1.2
-    optional: true
-
-  bin-version@3.1.0:
-    dependencies:
-      execa: 1.0.0
-      find-versions: 3.2.0
-    optional: true
-
-  bin-wrapper@4.1.0:
-    dependencies:
-      bin-check: 4.1.0
-      bin-version-check: 4.0.0
-      download: 7.1.0
-      import-lazy: 3.1.0
-      os-filter-obj: 2.0.0
-      pify: 4.0.1
-    optional: true
-
   birpc@4.0.0: {}
-
-  bl@1.2.3:
-    dependencies:
-      readable-stream: 2.3.8
-      safe-buffer: 5.2.1
-    optional: true
-
-  boolbase@1.0.0:
-    optional: true
 
   bottleneck@2.19.5: {}
 
@@ -7129,43 +6229,11 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  buffer-alloc-unsafe@1.1.0:
-    optional: true
-
-  buffer-alloc@1.2.0:
-    dependencies:
-      buffer-alloc-unsafe: 1.1.0
-      buffer-fill: 1.0.0
-    optional: true
-
-  buffer-crc32@0.2.13:
-    optional: true
-
-  buffer-fill@1.0.0:
-    optional: true
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-    optional: true
-
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
 
   cac@7.0.0: {}
-
-  cacheable-request@2.1.4:
-    dependencies:
-      clone-response: 1.0.2
-      get-stream: 3.0.0
-      http-cache-semantics: 3.8.1
-      keyv: 3.0.0
-      lowercase-keys: 1.0.0
-      normalize-url: 2.0.1
-      responselike: 1.0.2
-    optional: true
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -7189,37 +6257,11 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camelcase-keys@2.1.0:
-    dependencies:
-      camelcase: 2.1.1
-      map-obj: 1.0.1
-    optional: true
-
-  camelcase@2.1.1:
-    optional: true
-
   camelcase@7.0.1: {}
 
   camelcase@8.0.0: {}
 
-  caw@2.0.1:
-    dependencies:
-      get-proxy: 2.1.0
-      isurl: 1.0.0
-      tunnel-agent: 0.6.0
-      url-to-options: 1.0.1
-    optional: true
-
   chai@6.2.2: {}
-
-  chalk@1.1.3:
-    dependencies:
-      ansi-styles: 2.2.1
-      escape-string-regexp: 1.0.5
-      has-ansi: 2.0.0
-      strip-ansi: 3.0.1
-      supports-color: 2.0.0
-    optional: true
 
   chalk@2.4.2:
     dependencies:
@@ -7296,11 +6338,6 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
-  clone-response@1.0.2:
-    dependencies:
-      mimic-response: 1.0.1
-    optional: true
-
   color-convert@1.9.3:
     dependencies:
       color-name: 1.1.3
@@ -7331,12 +6368,6 @@ snapshots:
   colorette@2.0.20: {}
 
   commander@14.0.3: {}
-
-  commander@2.20.3:
-    optional: true
-
-  commander@7.2.0:
-    optional: true
 
   compare-func@2.0.0:
     dependencies:
@@ -7369,14 +6400,6 @@ snapshots:
       dot-prop: 9.0.0
       graceful-fs: 4.2.11
       xdg-basedir: 5.1.0
-
-  console-stream@0.1.1:
-    optional: true
-
-  content-disposition@0.5.4:
-    dependencies:
-      safe-buffer: 5.2.1
-    optional: true
 
   content-type@2.0.0: {}
 
@@ -7440,22 +6463,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  cross-spawn@5.1.0:
-    dependencies:
-      lru-cache: 4.1.5
-      shebang-command: 1.2.0
-      which: 1.3.1
-    optional: true
-
-  cross-spawn@6.0.6:
-    dependencies:
-      nice-try: 1.0.5
-      path-key: 2.0.1
-      semver: 5.7.2
-      shebang-command: 1.2.0
-      which: 1.3.1
-    optional: true
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -7465,34 +6472,6 @@ snapshots:
   crypto-random-string@4.0.0:
     dependencies:
       type-fest: 1.4.0
-
-  css-select@4.3.0:
-    dependencies:
-      boolbase: 1.0.0
-      css-what: 6.2.2
-      domhandler: 4.3.1
-      domutils: 2.8.0
-      nth-check: 2.1.1
-    optional: true
-
-  css-tree@1.1.3:
-    dependencies:
-      mdn-data: 2.0.14
-      source-map: 0.6.1
-    optional: true
-
-  css-what@6.2.2:
-    optional: true
-
-  csso@4.2.0:
-    dependencies:
-      css-tree: 1.1.3
-    optional: true
-
-  currently-unhandled@0.4.1:
-    dependencies:
-      array-find-index: 1.0.2
-    optional: true
 
   dargs@8.1.0: {}
 
@@ -7524,60 +6503,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  decamelize@1.2.0:
-    optional: true
-
-  decode-uri-component@0.2.2:
-    optional: true
-
-  decompress-response@3.3.0:
-    dependencies:
-      mimic-response: 1.0.1
-    optional: true
-
-  decompress-tar@4.1.1:
-    dependencies:
-      file-type: 5.2.0
-      is-stream: 1.1.0
-      tar-stream: 1.6.2
-    optional: true
-
-  decompress-tarbz2@4.1.1:
-    dependencies:
-      decompress-tar: 4.1.1
-      file-type: 6.2.0
-      is-stream: 1.1.0
-      seek-bzip: 1.0.6
-      unbzip2-stream: 1.4.3
-    optional: true
-
-  decompress-targz@4.1.1:
-    dependencies:
-      decompress-tar: 4.1.1
-      file-type: 5.2.0
-      is-stream: 1.1.0
-    optional: true
-
-  decompress-unzip@4.0.1:
-    dependencies:
-      file-type: 3.9.0
-      get-stream: 2.3.1
-      pify: 2.3.0
-      yauzl: 2.10.0
-    optional: true
-
-  decompress@4.2.1:
-    dependencies:
-      decompress-tar: 4.1.1
-      decompress-tarbz2: 4.1.1
-      decompress-targz: 4.1.1
-      decompress-unzip: 4.0.1
-      graceful-fs: 4.2.11
-      make-dir: 1.3.0
-      pify: 2.3.0
-      strip-dirs: 2.1.0
-    optional: true
 
   deep-extend@0.6.0: {}
 
@@ -7617,28 +6542,6 @@ snapshots:
       esutils: 2.0.3
     optional: true
 
-  dom-serializer@1.4.1:
-    dependencies:
-      domelementtype: 2.3.0
-      domhandler: 4.3.1
-      entities: 2.2.0
-    optional: true
-
-  domelementtype@2.3.0:
-    optional: true
-
-  domhandler@4.3.1:
-    dependencies:
-      domelementtype: 2.3.0
-    optional: true
-
-  domutils@2.8.0:
-    dependencies:
-      dom-serializer: 1.4.1
-      domelementtype: 2.3.0
-      domhandler: 4.3.1
-    optional: true
-
   dot-prop@10.1.0:
     dependencies:
       type-fest: 5.7.0
@@ -7653,37 +6556,6 @@ snapshots:
 
   dotenv@17.4.2: {}
 
-  download@6.2.5:
-    dependencies:
-      caw: 2.0.1
-      content-disposition: 0.5.4
-      decompress: 4.2.1
-      ext-name: 5.0.0
-      file-type: 5.2.0
-      filenamify: 2.1.0
-      get-stream: 3.0.0
-      got: 7.1.0
-      make-dir: 1.3.0
-      p-event: 1.3.0
-      pify: 3.0.0
-    optional: true
-
-  download@7.1.0:
-    dependencies:
-      archive-type: 4.0.0
-      caw: 2.0.1
-      content-disposition: 0.5.4
-      decompress: 4.2.1
-      ext-name: 5.0.0
-      file-type: 8.1.0
-      filenamify: 2.1.0
-      get-stream: 3.0.0
-      got: 8.3.2
-      make-dir: 1.3.0
-      p-event: 2.3.1
-      pify: 3.0.0
-    optional: true
-
   dts-resolver@3.0.0: {}
 
   dunder-proto@1.0.1:
@@ -7696,9 +6568,6 @@ snapshots:
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
-
-  duplexer3@0.1.5:
-    optional: true
 
   eastasianwidth@0.2.0: {}
 
@@ -7714,18 +6583,10 @@ snapshots:
 
   enabled@2.0.0: {}
 
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
-    optional: true
-
   enhanced-resolve@5.24.2:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
-
-  entities@2.2.0:
-    optional: true
 
   env-ci@11.2.0:
     dependencies:
@@ -7808,9 +6669,6 @@ snapshots:
       typed-array-length: 1.0.8
       unbox-primitive: 1.1.0
       which-typed-array: 1.1.22
-    optional: true
-
-  es-array-method-boxes-properly@1.0.0:
     optional: true
 
   es-define-property@1.0.1:
@@ -8029,37 +6887,6 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  exec-buffer@3.2.0:
-    dependencies:
-      execa: 0.7.0
-      p-finally: 1.0.0
-      pify: 3.0.0
-      rimraf: 2.7.1
-      tempfile: 2.0.0
-    optional: true
-
-  execa@0.7.0:
-    dependencies:
-      cross-spawn: 5.1.0
-      get-stream: 3.0.0
-      is-stream: 1.1.0
-      npm-run-path: 2.0.2
-      p-finally: 1.0.0
-      signal-exit: 3.0.7
-      strip-eof: 1.0.0
-    optional: true
-
-  execa@1.0.0:
-    dependencies:
-      cross-spawn: 6.0.6
-      get-stream: 4.1.0
-      is-stream: 1.1.0
-      npm-run-path: 2.0.2
-      p-finally: 1.0.0
-      signal-exit: 3.0.7
-      strip-eof: 1.0.0
-    optional: true
-
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8099,23 +6926,7 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
-  executable@4.1.1:
-    dependencies:
-      pify: 2.3.0
-    optional: true
-
   expect-type@1.4.0: {}
-
-  ext-list@2.2.2:
-    dependencies:
-      mime-db: 1.54.0
-    optional: true
-
-  ext-name@5.0.0:
-    dependencies:
-      ext-list: 2.2.2
-      sort-keys-length: 1.0.1
-    optional: true
 
   fast-deep-equal@3.1.3: {}
 
@@ -8135,16 +6946,6 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
-  fast-xml-parser@4.5.7:
-    dependencies:
-      strnum: 1.1.2
-    optional: true
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
-    optional: true
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -8154,12 +6955,6 @@ snapshots:
       picomatch: 4.0.5
 
   fecha@4.2.3: {}
-
-  figures@1.7.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-      object-assign: 4.1.1
-    optional: true
 
   figures@2.0.0:
     dependencies:
@@ -8182,34 +6977,6 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-type@10.11.0:
-    optional: true
-
-  file-type@3.9.0:
-    optional: true
-
-  file-type@4.4.0:
-    optional: true
-
-  file-type@5.2.0:
-    optional: true
-
-  file-type@6.2.0:
-    optional: true
-
-  file-type@8.1.0:
-    optional: true
-
-  filename-reserved-regex@2.0.0:
-    optional: true
-
-  filenamify@2.1.0:
-    dependencies:
-      filename-reserved-regex: 2.0.0
-      strip-outer: 1.0.1
-      trim-repeated: 1.0.0
-    optional: true
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -8219,12 +6986,6 @@ snapshots:
       shell-quote: 1.9.0
 
   find-up-simple@1.0.1: {}
-
-  find-up@1.1.2:
-    dependencies:
-      path-exists: 2.1.0
-      pinkie-promise: 2.0.1
-    optional: true
 
   find-up@2.1.0:
     dependencies:
@@ -8240,11 +7001,6 @@ snapshots:
       locate-path: 7.2.0
       path-exists: 5.0.0
       unicorn-magic: 0.1.0
-
-  find-versions@3.2.0:
-    dependencies:
-      semver-regex: 2.0.0
-    optional: true
 
   find-versions@6.0.0:
     dependencies:
@@ -8265,23 +7021,11 @@ snapshots:
       is-callable: 1.2.7
     optional: true
 
-  from2@2.3.0:
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 2.3.8
-    optional: true
-
-  fs-constants@1.0.0:
-    optional: true
-
   fs-extra@11.3.6:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
-
-  fs.realpath@1.0.0:
-    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -8334,28 +7078,6 @@ snapshots:
       es-object-atoms: 1.1.2
     optional: true
 
-  get-proxy@2.1.0:
-    dependencies:
-      npm-conf: 1.1.3
-    optional: true
-
-  get-stdin@4.0.1:
-    optional: true
-
-  get-stream@2.3.1:
-    dependencies:
-      object-assign: 4.1.1
-      pinkie-promise: 2.0.1
-    optional: true
-
-  get-stream@3.0.0:
-    optional: true
-
-  get-stream@4.1.0:
-    dependencies:
-      pump: 3.0.4
-    optional: true
-
   get-stream@6.0.1: {}
 
   get-stream@8.0.1: {}
@@ -8380,13 +7102,6 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  gifsicle@5.3.0:
-    dependencies:
-      bin-build: 3.0.0
-      bin-wrapper: 4.1.0
-      execa: 5.1.1
-    optional: true
-
   git-log-parser@1.2.1:
     dependencies:
       argv-formatter: 1.0.0
@@ -8405,16 +7120,6 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    optional: true
 
   global-directory@4.0.1:
     dependencies:
@@ -8435,49 +7140,6 @@ snapshots:
   gopd@1.2.0:
     optional: true
 
-  got@7.1.0:
-    dependencies:
-      '@types/keyv': 3.1.4
-      '@types/responselike': 1.0.3
-      decompress-response: 3.3.0
-      duplexer3: 0.1.5
-      get-stream: 3.0.0
-      is-plain-obj: 1.1.0
-      is-retry-allowed: 1.2.0
-      is-stream: 1.1.0
-      isurl: 1.0.0
-      lowercase-keys: 1.0.1
-      p-cancelable: 0.3.0
-      p-timeout: 1.2.1
-      safe-buffer: 5.2.1
-      timed-out: 4.0.1
-      url-parse-lax: 1.0.0
-      url-to-options: 1.0.1
-    optional: true
-
-  got@8.3.2:
-    dependencies:
-      '@sindresorhus/is': 0.7.0
-      '@types/keyv': 3.1.4
-      '@types/responselike': 1.0.3
-      cacheable-request: 2.1.4
-      decompress-response: 3.3.0
-      duplexer3: 0.1.5
-      get-stream: 3.0.0
-      into-stream: 3.1.0
-      is-retry-allowed: 1.2.0
-      isurl: 1.0.0
-      lowercase-keys: 1.0.1
-      mimic-response: 1.0.1
-      p-cancelable: 0.4.1
-      p-timeout: 2.0.1
-      pify: 3.0.0
-      safe-buffer: 5.2.1
-      timed-out: 4.0.1
-      url-parse-lax: 3.0.0
-      url-to-options: 1.0.1
-    optional: true
-
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
@@ -8490,11 +7152,6 @@ snapshots:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.19.3
-
-  has-ansi@2.0.0:
-    dependencies:
-      ansi-regex: 2.1.1
-    optional: true
 
   has-bigints@1.1.0:
     optional: true
@@ -8513,15 +7170,7 @@ snapshots:
       dunder-proto: 1.0.1
     optional: true
 
-  has-symbol-support-x@1.4.2:
-    optional: true
-
   has-symbols@1.1.0:
-    optional: true
-
-  has-to-string-tag-x@1.4.1:
-    dependencies:
-      has-symbol-support-x: 1.4.2
     optional: true
 
   has-tostringtag@1.0.2:
@@ -8540,9 +7189,6 @@ snapshots:
 
   hookable@6.1.1: {}
 
-  hosted-git-info@2.8.9:
-    optional: true
-
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
@@ -8552,9 +7198,6 @@ snapshots:
       lru-cache: 11.5.1
 
   html-escaper@2.0.2: {}
-
-  http-cache-semantics@3.8.1:
-    optional: true
 
   http-proxy-agent@9.1.0:
     dependencies:
@@ -8586,48 +7229,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1:
-    optional: true
-
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
-
-  imagemin-gifsicle@7.0.0:
-    dependencies:
-      execa: 1.0.0
-      gifsicle: 5.3.0
-      is-gif: 3.0.0
-    optional: true
-
-  imagemin-jpegtran@7.0.0:
-    dependencies:
-      exec-buffer: 3.2.0
-      is-jpg: 2.0.0
-      jpegtran-bin: 5.0.2
-    optional: true
-
-  imagemin-lint-staged@0.5.1:
-    dependencies:
-      imagemin-gifsicle: 7.0.0
-      imagemin-jpegtran: 7.0.0
-      imagemin-optipng: 8.0.0
-      imagemin-svgo: 9.0.0
-      util.promisify: 1.1.3
-    optional: true
-
-  imagemin-optipng@8.0.0:
-    dependencies:
-      exec-buffer: 3.2.0
-      is-png: 2.0.0
-      optipng-bin: 7.0.1
-    optional: true
-
-  imagemin-svgo@9.0.0:
-    dependencies:
-      is-svg: 4.4.0
-      svgo: 2.8.3
-    optional: true
 
   import-fresh@3.3.1:
     dependencies:
@@ -8641,31 +7245,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  import-lazy@3.1.0:
-    optional: true
-
   import-meta-resolve@4.2.0: {}
 
   import-without-cache@0.4.0: {}
 
   imurmurhash@0.1.4: {}
 
-  indent-string@2.1.0:
-    dependencies:
-      repeating: 2.0.1
-    optional: true
-
   indent-string@4.0.0: {}
 
   indent-string@5.0.0: {}
 
   index-to-position@1.2.0: {}
-
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-    optional: true
 
   inherits@2.0.4: {}
 
@@ -8685,12 +7275,6 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.1
-    optional: true
-
-  into-stream@3.1.0:
-    dependencies:
-      from2: 2.3.0
-      p-is-promise: 1.1.0
     optional: true
 
   is-array-buffer@3.0.5:
@@ -8757,9 +7341,6 @@ snapshots:
       call-bound: 1.0.4
     optional: true
 
-  is-finite@1.1.0:
-    optional: true
-
   is-fullwidth-code-point@3.0.0: {}
 
   is-fullwidth-code-point@5.1.0:
@@ -8773,11 +7354,6 @@ snapshots:
       get-proto: 1.0.1
       has-tostringtag: 1.0.2
       safe-regex-test: 1.1.0
-    optional: true
-
-  is-gif@3.0.0:
-    dependencies:
-      file-type: 10.11.0
     optional: true
 
   is-glob@4.0.3:
@@ -8799,13 +7375,7 @@ snapshots:
 
   is-interactive@2.0.0: {}
 
-  is-jpg@2.0.0:
-    optional: true
-
   is-map@2.0.3:
-    optional: true
-
-  is-natural-number@4.0.1:
     optional: true
 
   is-negative-zero@2.0.3:
@@ -8823,18 +7393,9 @@ snapshots:
 
   is-obj@2.0.0: {}
 
-  is-object@1.0.2:
-    optional: true
-
   is-path-inside@4.0.0: {}
 
-  is-plain-obj@1.1.0:
-    optional: true
-
   is-plain-obj@4.1.0: {}
-
-  is-png@2.0.0:
-    optional: true
 
   is-regex@1.2.1:
     dependencies:
@@ -8844,18 +7405,12 @@ snapshots:
       hasown: 2.0.4
     optional: true
 
-  is-retry-allowed@1.2.0:
-    optional: true
-
   is-set@2.0.3:
     optional: true
 
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
-    optional: true
-
-  is-stream@1.1.0:
     optional: true
 
   is-stream@2.0.1: {}
@@ -8868,11 +7423,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
-    optional: true
-
-  is-svg@4.4.0:
-    dependencies:
-      fast-xml-parser: 4.5.7
     optional: true
 
   is-symbol@1.1.1:
@@ -8894,9 +7444,6 @@ snapshots:
   is-unicode-supported@1.3.0: {}
 
   is-unicode-supported@2.1.0: {}
-
-  is-utf8@0.2.1:
-    optional: true
 
   is-weakmap@2.0.2:
     optional: true
@@ -8944,12 +7491,6 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
-  isurl@1.0.0:
-    dependencies:
-      has-to-string-tag-x: 1.4.1
-      is-object: 1.0.2
-    optional: true
-
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -8964,13 +7505,6 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jpegtran-bin@5.0.2:
-    dependencies:
-      bin-build: 3.0.0
-      bin-wrapper: 4.1.0
-      logalot: 2.1.0
-    optional: true
-
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -8980,9 +7514,6 @@ snapshots:
       argparse: 2.0.1
 
   jsesc@3.1.0: {}
-
-  json-buffer@3.0.0:
-    optional: true
 
   json-buffer@3.0.1: {}
 
@@ -9014,11 +7545,6 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
-    optional: true
-
-  keyv@3.0.0:
-    dependencies:
-      json-buffer: 3.0.0
     optional: true
 
   keyv@4.5.4:
@@ -9067,15 +7593,6 @@ snapshots:
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
-
-  load-json-file@1.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      parse-json: 2.2.0
-      pify: 2.3.0
-      pinkie-promise: 2.0.1
-      strip-bom: 2.0.0
-    optional: true
 
   load-json-file@4.0.0:
     dependencies:
@@ -9140,12 +7657,6 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
-  logalot@2.1.0:
-    dependencies:
-      figures: 1.7.0
-      squeak: 1.3.0
-    optional: true
-
   logform@2.7.0:
     dependencies:
       '@colors/colors': 1.6.0
@@ -9155,43 +7666,14 @@ snapshots:
       safe-stable-stringify: 2.5.0
       triple-beam: 1.4.1
 
-  longest@1.0.1:
-    optional: true
-
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
     optional: true
 
-  loud-rejection@1.6.0:
-    dependencies:
-      currently-unhandled: 0.4.1
-      signal-exit: 3.0.7
-    optional: true
-
-  lowercase-keys@1.0.0:
-    optional: true
-
-  lowercase-keys@1.0.1:
-    optional: true
-
-  lpad-align@1.1.2:
-    dependencies:
-      get-stdin: 4.0.1
-      indent-string: 2.1.0
-      longest: 1.0.1
-      meow: 3.7.0
-    optional: true
-
   lru-cache@10.4.3: {}
 
   lru-cache@11.5.1: {}
-
-  lru-cache@4.1.5:
-    dependencies:
-      pseudomap: 1.0.2
-      yallist: 2.1.2
-    optional: true
 
   magic-string@0.30.21:
     dependencies:
@@ -9209,17 +7691,9 @@ snapshots:
       type-fest: 4.41.0
       web-worker: 1.5.0
 
-  make-dir@1.3.0:
-    dependencies:
-      pify: 3.0.0
-    optional: true
-
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.5
-
-  map-obj@1.0.1:
-    optional: true
 
   marked-man@2.1.1:
     dependencies:
@@ -9244,26 +7718,9 @@ snapshots:
   math-intrinsics@1.1.0:
     optional: true
 
-  mdn-data@2.0.14:
-    optional: true
-
   meow@12.1.1: {}
 
   meow@13.2.0: {}
-
-  meow@3.7.0:
-    dependencies:
-      camelcase-keys: 2.1.0
-      decamelize: 1.2.0
-      loud-rejection: 1.6.0
-      map-obj: 1.0.1
-      minimist: 1.2.8
-      normalize-package-data: 2.5.0
-      object-assign: 4.1.1
-      read-pkg-up: 1.0.1
-      redent: 1.0.0
-      trim-newlines: 1.0.0
-    optional: true
 
   merge-stream@2.0.0: {}
 
@@ -9272,9 +7729,6 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
-  mime-db@1.54.0:
-    optional: true
-
   mime@4.1.0: {}
 
   mimic-fn@2.1.0: {}
@@ -9282,9 +7736,6 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   mimic-function@5.0.1: {}
-
-  mimic-response@1.0.1:
-    optional: true
 
   minimatch@10.2.5:
     dependencies:
@@ -9317,9 +7768,6 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  nice-try@1.0.5:
-    optional: true
-
   node-emoji@2.2.0:
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -9335,14 +7783,6 @@ snapshots:
       semver: 6.3.1
     optional: true
 
-  normalize-package-data@2.5.0:
-    dependencies:
-      hosted-git-info: 2.8.9
-      resolve: 1.22.12
-      semver: 5.7.2
-      validate-npm-package-license: 3.0.4
-    optional: true
-
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
@@ -9355,25 +7795,7 @@ snapshots:
       semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
-  normalize-url@2.0.1:
-    dependencies:
-      prepend-http: 2.0.0
-      query-string: 5.1.1
-      sort-keys: 2.0.0
-    optional: true
-
   normalize-url@9.0.1: {}
-
-  npm-conf@1.1.3:
-    dependencies:
-      config-chain: 1.1.13
-      pify: 3.0.0
-    optional: true
-
-  npm-run-path@2.0.2:
-    dependencies:
-      path-key: 2.0.1
-    optional: true
 
   npm-run-path@4.0.1:
     dependencies:
@@ -9389,11 +7811,6 @@ snapshots:
       unicorn-magic: 0.3.0
 
   npm@11.18.0: {}
-
-  nth-check@2.1.1:
-    dependencies:
-      boolbase: 1.0.0
-    optional: true
 
   object-assign@4.1.1: {}
 
@@ -9429,17 +7846,6 @@ snapshots:
       es-object-atoms: 1.1.2
     optional: true
 
-  object.getownpropertydescriptors@2.1.9:
-    dependencies:
-      array.prototype.reduce: 1.0.8
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-object-atoms: 1.1.2
-      gopd: 1.2.0
-      safe-array-concat: 1.1.4
-    optional: true
-
   object.values@1.2.1:
     dependencies:
       call-bind: 1.0.9
@@ -9451,11 +7857,6 @@ snapshots:
   obug@2.1.3: {}
 
   obug@2.1.4: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
-    optional: true
 
   one-time@1.0.0:
     dependencies:
@@ -9498,12 +7899,6 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  optipng-bin@7.0.1:
-    dependencies:
-      bin-build: 3.0.0
-      bin-wrapper: 4.1.0
-    optional: true
-
   ora@9.4.1:
     dependencies:
       chalk: 5.6.2
@@ -9515,11 +7910,6 @@ snapshots:
       stdin-discarder: 0.3.2
       string-width: 8.2.1
 
-  os-filter-obj@2.0.0:
-    dependencies:
-      arch: 2.2.0
-    optional: true
-
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -9527,23 +7917,7 @@ snapshots:
       safe-push-apply: 1.0.0
     optional: true
 
-  p-cancelable@0.3.0:
-    optional: true
-
-  p-cancelable@0.4.1:
-    optional: true
-
   p-each-series@3.0.0: {}
-
-  p-event@1.3.0:
-    dependencies:
-      p-timeout: 1.2.1
-    optional: true
-
-  p-event@2.3.1:
-    dependencies:
-      p-timeout: 2.0.1
-    optional: true
 
   p-event@6.0.1:
     dependencies:
@@ -9552,12 +7926,6 @@ snapshots:
   p-filter@4.1.0:
     dependencies:
       p-map: 7.0.5
-
-  p-finally@1.0.0:
-    optional: true
-
-  p-is-promise@1.1.0:
-    optional: true
 
   p-limit@1.3.0:
     dependencies:
@@ -9583,29 +7951,11 @@ snapshots:
     dependencies:
       p-limit: 4.0.0
 
-  p-map-series@1.0.0:
-    dependencies:
-      p-reduce: 1.0.0
-    optional: true
-
   p-map@7.0.5: {}
-
-  p-reduce@1.0.0:
-    optional: true
 
   p-reduce@2.1.0: {}
 
   p-reduce@3.0.0: {}
-
-  p-timeout@1.2.1:
-    dependencies:
-      p-finally: 1.0.0
-    optional: true
-
-  p-timeout@2.0.1:
-    dependencies:
-      p-finally: 1.0.0
-    optional: true
 
   p-timeout@6.1.4: {}
 
@@ -9621,11 +7971,6 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
-
-  parse-json@2.2.0:
-    dependencies:
-      error-ex: 1.3.4
-    optional: true
 
   parse-json@4.0.0:
     dependencies:
@@ -9655,22 +8000,11 @@ snapshots:
 
   parse5@6.0.1: {}
 
-  path-exists@2.1.0:
-    dependencies:
-      pinkie-promise: 2.0.1
-    optional: true
-
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
-
-  path-is-absolute@1.0.1:
-    optional: true
-
-  path-key@2.0.1:
-    optional: true
 
   path-key@3.1.1: {}
 
@@ -9679,19 +8013,9 @@ snapshots:
   path-parse@1.0.7:
     optional: true
 
-  path-type@1.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      pify: 2.3.0
-      pinkie-promise: 2.0.1
-    optional: true
-
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
-
-  pend@1.2.0:
-    optional: true
 
   picocolors@1.1.1: {}
 
@@ -9701,21 +8025,7 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  pify@2.3.0:
-    optional: true
-
   pify@3.0.0: {}
-
-  pify@4.0.1:
-    optional: true
-
-  pinkie-promise@2.0.1:
-    dependencies:
-      pinkie: 2.0.4
-    optional: true
-
-  pinkie@2.0.4:
-    optional: true
 
   pkg-conf@2.1.0:
     dependencies:
@@ -9739,12 +8049,6 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prepend-http@1.0.4:
-    optional: true
-
-  prepend-http@2.0.0:
-    optional: true
-
   prettier@3.9.3: {}
 
   pretty-ms@9.3.0:
@@ -9766,15 +8070,6 @@ snapshots:
 
   proxy-agent-negotiate@1.1.0: {}
 
-  pseudomap@1.0.2:
-    optional: true
-
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-    optional: true
-
   punycode@2.3.1: {}
 
   pupa@3.3.0:
@@ -9782,13 +8077,6 @@ snapshots:
       escape-goat: 4.0.0
 
   quansync@1.0.0: {}
-
-  query-string@5.1.1:
-    dependencies:
-      decode-uri-component: 0.2.2
-      object-assign: 4.1.1
-      strict-uri-encode: 1.1.0
-    optional: true
 
   rc@1.2.8:
     dependencies:
@@ -9811,19 +8099,6 @@ snapshots:
       find-up-simple: 1.0.1
       read-pkg: 10.1.0
       type-fest: 5.7.0
-
-  read-pkg-up@1.0.1:
-    dependencies:
-      find-up: 1.1.2
-      read-pkg: 1.1.0
-    optional: true
-
-  read-pkg@1.1.0:
-    dependencies:
-      load-json-file: 1.1.0
-      normalize-package-data: 2.5.0
-      path-type: 1.1.0
-    optional: true
 
   read-pkg@10.1.0:
     dependencies:
@@ -9866,12 +8141,6 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  redent@1.0.0:
-    dependencies:
-      indent-string: 2.1.0
-      strip-indent: 1.0.1
-    optional: true
-
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -9902,11 +8171,6 @@ snapshots:
     dependencies:
       rc: 1.2.8
 
-  repeating@2.0.1:
-    dependencies:
-      is-finite: 1.1.0
-    optional: true
-
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -9916,14 +8180,6 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
-
-  resolve@1.22.12:
-    dependencies:
-      es-errors: 1.3.0
-      is-core-module: 2.16.2
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-    optional: true
 
   resolve@2.0.0-next.7:
     dependencies:
@@ -9935,22 +8191,12 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
     optional: true
 
-  responselike@1.0.2:
-    dependencies:
-      lowercase-keys: 1.0.1
-    optional: true
-
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
   rfdc@1.4.1: {}
-
-  rimraf@2.7.1:
-    dependencies:
-      glob: 7.2.3
-    optional: true
 
   rolldown-plugin-dts@0.26.0(rolldown@1.1.3)(typescript@5.9.3):
     dependencies:
@@ -10054,14 +8300,6 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sax@1.6.0:
-    optional: true
-
-  seek-bzip@1.0.6:
-    dependencies:
-      commander: 2.20.3
-    optional: true
-
   semantic-release@25.0.5(typescript@5.9.3):
     dependencies:
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.5(typescript@5.9.3))
@@ -10097,18 +8335,7 @@ snapshots:
       - supports-color
       - typescript
 
-  semver-regex@2.0.0:
-    optional: true
-
   semver-regex@4.0.5: {}
-
-  semver-truncate@1.1.2:
-    dependencies:
-      semver: 5.7.2
-    optional: true
-
-  semver@5.7.2:
-    optional: true
 
   semver@6.3.1:
     optional: true
@@ -10140,17 +8367,9 @@ snapshots:
       es-object-atoms: 1.1.2
     optional: true
 
-  shebang-command@1.2.0:
-    dependencies:
-      shebang-regex: 1.0.0
-    optional: true
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
-
-  shebang-regex@1.0.0:
-    optional: true
 
   shebang-regex@3.0.0: {}
 
@@ -10214,21 +8433,6 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  sort-keys-length@1.0.1:
-    dependencies:
-      sort-keys: 1.1.2
-    optional: true
-
-  sort-keys@1.1.2:
-    dependencies:
-      is-plain-obj: 1.1.0
-    optional: true
-
-  sort-keys@2.0.0:
-    dependencies:
-      is-plain-obj: 1.1.0
-    optional: true
-
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
@@ -10255,16 +8459,6 @@ snapshots:
 
   split2@4.2.0: {}
 
-  squeak@1.3.0:
-    dependencies:
-      chalk: 1.1.3
-      console-stream: 0.1.1
-      lpad-align: 1.1.2
-    optional: true
-
-  stable@0.1.8:
-    optional: true
-
   stack-trace@0.0.10: {}
 
   stackback@0.0.2: {}
@@ -10283,9 +8477,6 @@ snapshots:
     dependencies:
       duplexer2: 0.1.4
       readable-stream: 2.3.8
-
-  strict-uri-encode@1.1.0:
-    optional: true
 
   string-argv@0.3.2: {}
 
@@ -10372,11 +8563,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  strip-ansi@3.0.1:
-    dependencies:
-      ansi-regex: 2.1.1
-    optional: true
-
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -10385,20 +8571,7 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  strip-bom@2.0.0:
-    dependencies:
-      is-utf8: 0.2.1
-    optional: true
-
   strip-bom@3.0.0: {}
-
-  strip-dirs@2.1.0:
-    dependencies:
-      is-natural-number: 4.0.1
-    optional: true
-
-  strip-eof@1.0.0:
-    optional: true
 
   strip-final-newline@2.0.0: {}
 
@@ -10406,20 +8579,7 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
-  strip-indent@1.0.1:
-    dependencies:
-      get-stdin: 4.0.1
-    optional: true
-
   strip-json-comments@2.0.1: {}
-
-  strip-outer@1.0.1:
-    dependencies:
-      escape-string-regexp: 1.0.5
-    optional: true
-
-  strnum@1.1.2:
-    optional: true
 
   stubborn-fs@2.0.0:
     dependencies:
@@ -10432,9 +8592,6 @@ snapshots:
       function-timeout: 1.0.2
       make-asynchronous: 1.1.0
       time-span: 5.1.0
-
-  supports-color@2.0.0:
-    optional: true
 
   supports-color@5.5.0:
     dependencies:
@@ -10452,42 +8609,11 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0:
     optional: true
 
-  svgo@2.8.3:
-    dependencies:
-      commander: 7.2.0
-      css-select: 4.3.0
-      css-tree: 1.1.3
-      csso: 4.2.0
-      picocolors: 1.1.1
-      sax: 1.6.0
-      stable: 0.1.8
-    optional: true
-
   tagged-tag@1.0.0: {}
 
   tapable@2.3.3: {}
 
-  tar-stream@1.6.2:
-    dependencies:
-      bl: 1.2.3
-      buffer-alloc: 1.2.0
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      readable-stream: 2.3.8
-      to-buffer: 1.2.2
-      xtend: 4.0.2
-    optional: true
-
-  temp-dir@1.0.0:
-    optional: true
-
   temp-dir@3.0.0: {}
-
-  tempfile@2.0.0:
-    dependencies:
-      temp-dir: 1.0.0
-      uuid: 3.4.0
-    optional: true
 
   tempy@3.2.0:
     dependencies:
@@ -10519,9 +8645,6 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
-  timed-out@4.0.1:
-    optional: true
-
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -10535,13 +8658,6 @@ snapshots:
 
   title-case@4.3.2: {}
 
-  to-buffer@1.2.2:
-    dependencies:
-      isarray: 2.0.5
-      safe-buffer: 5.2.1
-      typed-array-buffer: 1.0.3
-    optional: true
-
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -10549,14 +8665,6 @@ snapshots:
   traverse@0.6.8: {}
 
   tree-kill@1.2.2: {}
-
-  trim-newlines@1.0.0:
-    optional: true
-
-  trim-repeated@1.0.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-    optional: true
 
   triple-beam@1.4.1: {}
 
@@ -10598,11 +8706,6 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
-
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
-    optional: true
 
   tunnel@0.0.6: {}
 
@@ -10685,12 +8788,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
     optional: true
 
-  unbzip2-stream@1.4.3:
-    dependencies:
-      buffer: 5.7.1
-      through: 2.3.8
-    optional: true
-
   unconfig-core@7.5.0:
     dependencies:
       '@quansync/fs': 1.0.0
@@ -10739,39 +8836,7 @@ snapshots:
 
   url-join@5.0.0: {}
 
-  url-parse-lax@1.0.0:
-    dependencies:
-      prepend-http: 1.0.4
-    optional: true
-
-  url-parse-lax@3.0.0:
-    dependencies:
-      prepend-http: 2.0.0
-    optional: true
-
-  url-to-options@1.0.1:
-    optional: true
-
   util-deprecate@1.0.2: {}
-
-  util.promisify@1.1.3:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-data-property: 1.1.4
-      define-properties: 1.2.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      for-each: 0.3.5
-      get-intrinsic: 1.3.0
-      has-proto: 1.2.0
-      has-symbols: 1.1.0
-      object.getownpropertydescriptors: 2.1.9
-      safe-array-concat: 1.1.4
-    optional: true
-
-  uuid@3.4.0:
-    optional: true
 
   validate-npm-package-license@3.0.4:
     dependencies:
@@ -10913,11 +8978,6 @@ snapshots:
       has-tostringtag: 1.0.2
     optional: true
 
-  which@1.3.1:
-    dependencies:
-      isexe: 2.0.0
-    optional: true
-
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -10983,9 +9043,6 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  wrappy@1.0.2:
-    optional: true
-
   wsl-utils@0.3.1:
     dependencies:
       is-wsl: 3.1.1
@@ -10996,9 +9053,6 @@ snapshots:
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
-
-  yallist@2.1.2:
-    optional: true
 
   yaml@2.9.0: {}
 
@@ -11036,12 +9090,6 @@ snapshots:
       string-width: 7.2.0
       y18n: 5.0.8
       yargs-parser: 22.0.0
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
-    optional: true
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,23 +4,23 @@ packages:
 # Shared dep versions used across packages. Add named catalogs as
 # plugin packages grow.
 catalog:
-  '@theholocron/holocron-config': ^7.2.0
-  '@theholocron/commitlint-config': ^7.0.0
-  '@theholocron/semantic-release-config': ^7.0.0
-  '@theholocron/eslint-config': ^7.0.0
-  '@theholocron/clerk-client': ^0.7.0
-  '@theholocron/doppler-client': ^0.7.0
-  '@theholocron/infisical-client': ^0.10.0
-  '@theholocron/neon-client': ^0.7.0
-  '@theholocron/github-client': ^0.7.0
-  '@theholocron/http-client': ^0.7.0
-  '@theholocron/postman-client': ^0.10.0
-  '@theholocron/vercel-client': ^0.10.0
-  '@theholocron/lint-staged-config': ^7.0.0
-  '@theholocron/prettier-config': ^7.0.0
-  '@theholocron/tsconfig': ^7.0.0
-  '@theholocron/tsdown-config': ^7.0.0
-  '@theholocron/vitest-config': ^7.2.3
+  '@theholocron/holocron-config': ^7.3.0
+  '@theholocron/commitlint-config': ^7.3.0
+  '@theholocron/semantic-release-config': ^7.3.0
+  '@theholocron/eslint-config': ^7.3.0
+  '@theholocron/clerk-client': ^0.11.3
+  '@theholocron/doppler-client': ^0.11.3
+  '@theholocron/infisical-client': ^0.11.3
+  '@theholocron/neon-client': ^0.11.3
+  '@theholocron/github-client': ^0.11.3
+  '@theholocron/http-client': ^0.11.3
+  '@theholocron/postman-client': ^0.11.3
+  '@theholocron/vercel-client': ^0.11.3
+  '@theholocron/lint-staged-config': ^7.3.0
+  '@theholocron/prettier-config': ^7.3.0
+  '@theholocron/tsconfig': ^7.3.0
+  '@theholocron/tsdown-config': ^7.3.0
+  '@theholocron/vitest-config': ^7.3.0
   '@vitest/eslint-plugin': ^1.6.23
   eslint: ^10.7.0
   eslint-plugin-n: ^18.2.2
@@ -36,4 +36,4 @@ catalog:
 # same http-client instance — prevents instanceof ProviderApiError
 # dual-module hazard when github-client and cli both depend on it.
 overrides:
-  '@theholocron/http-client': ^0.7.0
+  '@theholocron/http-client': ^0.11.3


### PR DESCRIPTION
## Summary

Removes the explicit `name` field from `holocron.config.ts` — it now derives automatically from the `package.json` `name` field (scope stripped) introduced in the HolocronConfig flatten PR.

## Test plan

- [ ] `holocron doctor` displays `"holocron"` as the project name
- [ ] `holocron setup` / `sync` headers show the correct name
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->