### PR TITLE
chore: drop explicit name from holocron.config (derived from package.json)

### DIFF
--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -3,7 +3,6 @@ import { node } from "@theholocron/holocron-config";
 
 const { repo, workflows, providers } = node();
 export default defineConfig({
-	name: "holocron",
 	description:
 		"The Holocron CLI — pluggable, capability-based infrastructure orchestrator. This file makes the repo self-hosted: holocron commands work inside it.",
 	repo: {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,10 +56,10 @@ export default defineConfig({
 `name` and `repo.name` are optional. When absent, Holocron fills them
 in at load time:
 
-| Field | Derived from | Fallback |
-|---|---|---|
-| `name` | `package.json` → `name` field (scope stripped) | directory basename |
-| `repo.name` | `git remote get-url origin` (parsed to `owner/repo`) | not set |
+| Field       | Derived from                                         | Fallback           |
+| ----------- | ---------------------------------------------------- | ------------------ |
+| `name`      | `package.json` → `name` field (scope stripped)       | directory basename |
+| `repo.name` | `git remote get-url origin` (parsed to `owner/repo`) | not set            |
 
 A minimal config — for repos with a `package.json` and a GitHub remote
 — only needs `providers`:

--- a/packages/cli/src/__tests__/load-config.test.ts
+++ b/packages/cli/src/__tests__/load-config.test.ts
@@ -119,29 +119,20 @@ describe("loadConfig", () => {
 
 	it("derives name from package.json when absent from config", async () => {
 		await writeFile(join(cwd, "package.json"), JSON.stringify({ name: "my-package" }));
-		await writeFile(
-			join(cwd, "holocron.config.json"),
-			JSON.stringify({ providers: { source: "github" } })
-		);
+		await writeFile(join(cwd, "holocron.config.json"), JSON.stringify({ providers: { source: "github" } }));
 		const { resolved } = await loadConfig(cwd);
 		expect(resolved.name).toBe("my-package");
 	});
 
 	it("strips @scope/ prefix from scoped package names", async () => {
 		await writeFile(join(cwd, "package.json"), JSON.stringify({ name: "@theholocron/my-package" }));
-		await writeFile(
-			join(cwd, "holocron.config.json"),
-			JSON.stringify({ providers: { source: "github" } })
-		);
+		await writeFile(join(cwd, "holocron.config.json"), JSON.stringify({ providers: { source: "github" } }));
 		const { resolved } = await loadConfig(cwd);
 		expect(resolved.name).toBe("my-package");
 	});
 
 	it("falls back to directory basename when no package.json exists", async () => {
-		await writeFile(
-			join(cwd, "holocron.config.json"),
-			JSON.stringify({ providers: { source: "github" } })
-		);
+		await writeFile(join(cwd, "holocron.config.json"), JSON.stringify({ providers: { source: "github" } }));
 		const { resolved } = await loadConfig(cwd);
 		expect(resolved.name).toBe(basename(cwd));
 	});
@@ -203,14 +194,8 @@ describe("loadConfig", () => {
 	// ── Priority ──────────────────────────────────────────────────────────
 
 	it("prefers .json over .js when both exist", async () => {
-		await writeFile(
-			join(cwd, "holocron.config.json"),
-			JSON.stringify({ name: "json-wins", providers: {} })
-		);
-		await writeFile(
-			join(cwd, "holocron.config.js"),
-			`export default { name: "js-loses", providers: {} };`
-		);
+		await writeFile(join(cwd, "holocron.config.json"), JSON.stringify({ name: "json-wins", providers: {} }));
+		await writeFile(join(cwd, "holocron.config.js"), `export default { name: "js-loses", providers: {} };`);
 		const { resolved } = await loadConfig(cwd);
 		expect(resolved.name).toBe("json-wins");
 	});

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -423,7 +423,8 @@ describe("runSetup", () => {
 		let defaultSetupDisabled = false;
 		let defaultSetupEnabled = false;
 		const loaded = loadedFrom({
-			name: "demo", workflows: ["lint", "codeql"],
+			name: "demo",
+			workflows: ["lint", "codeql"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -460,7 +461,8 @@ describe("runSetup", () => {
 	it("enables default CodeQL setup when no codeql workflow is configured", async () => {
 		let defaultSetupEnabled = false;
 		const loaded = loadedFrom({
-			name: "demo", workflows: ["lint"],
+			name: "demo",
+			workflows: ["lint"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -492,7 +494,8 @@ describe("runSetup", () => {
 		let settingsApplied: Record<string, unknown> | null = null;
 		let rulesetCreated: Record<string, unknown> | null = null;
 		const loaded = loadedFrom({
-			name: "demo", repo: { name: "theholocron/demo", protection: "balanced" },
+			name: "demo",
+			repo: { name: "theholocron/demo", protection: "balanced" },
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -626,7 +629,8 @@ describe("runSetup", () => {
 		const created: unknown[] = [];
 		const updated: unknown[] = [];
 		const loaded = loadedFrom({
-			name: "demo", repo: { name: "theholocron/demo", protection: "balanced" },
+			name: "demo",
+			repo: { name: "theholocron/demo", protection: "balanced" },
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -670,7 +674,8 @@ describe("runSetup", () => {
 	it("skips repo policy steps when repo.protection is 'none'", async () => {
 		let settingsCalled = false;
 		const loaded = loadedFrom({
-			name: "demo", repo: { name: "theholocron/demo", protection: "none" },
+			name: "demo",
+			repo: { name: "theholocron/demo", protection: "none" },
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -733,7 +738,8 @@ describe("runSetup", () => {
 	it("writes thin wrapper files for each workflow listed in project.workflows", async () => {
 		const written: Record<string, string> = {};
 		const loaded = loadedFrom({
-			name: "demo", workflows: ["lint", "test", "typecheck"],
+			name: "demo",
+			workflows: ["lint", "test", "typecheck"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -798,7 +804,8 @@ describe("runSetup", () => {
 
 	it("reports skip for an unknown workflow name", async () => {
 		const loaded = loadedFrom({
-			name: "demo", workflows: ["lint", "not-a-real-workflow"],
+			name: "demo",
+			workflows: ["lint", "not-a-real-workflow"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -831,7 +838,8 @@ describe("runSetup", () => {
 	it("dry-run skips workflow writes", async () => {
 		let writeCallCount = 0;
 		const loaded = loadedFrom({
-			name: "demo", workflows: ["lint", "test"],
+			name: "demo",
+			workflows: ["lint", "test"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -945,7 +953,8 @@ describe("runSetup", () => {
 	it("writes .github/labeler.yml when bookkeeping-pr workflow is configured", async () => {
 		const written: Record<string, string> = {};
 		const loaded = loadedFrom({
-			name: "demo", workflows: ["lint", "bookkeeping-pr"],
+			name: "demo",
+			workflows: ["lint", "bookkeeping-pr"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -980,7 +989,8 @@ describe("runSetup", () => {
 	it("does not write .github/labeler.yml when bookkeeping-pr is not configured", async () => {
 		const written: Record<string, string> = {};
 		const loaded = loadedFrom({
-			name: "demo", workflows: ["lint", "test"],
+			name: "demo",
+			workflows: ["lint", "test"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {


### PR DESCRIPTION
## Summary

Removes the explicit `name` field from `holocron.config.ts` — it now derives automatically from the `package.json` `name` field (scope stripped).

## Test plan

- [ ] `holocron doctor` displays `"holocron"` as the project name
- [ ] `holocron setup` / `sync` headers show the correct name
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->