### PR TITLE
chore: drop explicit repo.name from holocron.config (derived from git remote)

### DIFF
--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
 	description:
 		"The Holocron CLI — pluggable, capability-based infrastructure orchestrator. This file makes the repo self-hosted: holocron commands work inside it.",
 	repo: {
-		name: "theholocron/holocron",
 		topics: ["automation", "cli", "developer-tools", "holocron", "nodejs", "typescript"],
 		...repo,
 	},


### PR DESCRIPTION
## Summary

Removes `repo.name` — derived automatically from `git remote get-url origin`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->