### PR TITLE
feat: sync topics → package.json keywords and description to all targets

### DIFF
--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -594,7 +594,13 @@ describe("runSync", () => {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 			});
 
-			const report = await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+			const report = await runSync({
+				loaded,
+				context: { repoRoot: tmpDir },
+				loader,
+				steps: ["description"],
+				print: () => {},
+			});
 
 			const step = report.steps.find((s) => s.step === "sync description");
 			expect(step?.status).toBe("ok");

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -523,13 +523,11 @@ describe("runSync", () => {
 			expect(pkg.description).toBe("A great tool");
 		});
 
-		it("updates the description line in README.md", async () => {
-			await writeFile(join(tmpDir, "README.md"), "# Demo\n\nOld description.\n\n## Usage\n");
-			const loaded = loadedFrom({
-				name: "demo",
-				description: "New description.",
-				providers: { source: "github" },
-			});
+		it("replaces description within existing marker block", async () => {
+			const initial =
+				"# Demo\n\n<!-- holocron:description -->\nOld description.\n<!-- /holocron:description -->\n\n## Usage\n";
+			await writeFile(join(tmpDir, "README.md"), initial);
+			const loaded = loadedFrom({ name: "demo", description: "New description.", providers: { source: "github" } });
 			const loader = makeLoaderWith(loaded, {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 			});
@@ -539,15 +537,29 @@ describe("runSync", () => {
 			const readme = await readFile(join(tmpDir, "README.md"), "utf8");
 			expect(readme).toContain("New description.");
 			expect(readme).not.toContain("Old description.");
+			expect(readme).toContain("## Usage");
 		});
 
-		it("inserts description into README.md when none exists", async () => {
-			await writeFile(join(tmpDir, "README.md"), "# Demo\n\n## Usage\n");
-			const loaded = loadedFrom({
-				name: "demo",
-				description: "A new description.",
-				providers: { source: "github" },
+		it("marker block update is idempotent across multiple syncs", async () => {
+			const initial =
+				"# Demo\n\n<!-- holocron:description -->\nFirst.\n<!-- /holocron:description -->\n\n## Usage\n";
+			await writeFile(join(tmpDir, "README.md"), initial);
+			const loaded = loadedFrom({ name: "demo", description: "Second.", providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 			});
+
+			await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+			await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+
+			const readme = await readFile(join(tmpDir, "README.md"), "utf8");
+			expect(readme.match(/<!-- holocron:description -->/g)).toHaveLength(1);
+			expect(readme).toContain("Second.");
+		});
+
+		it("inserts marker block after H1 when no block exists", async () => {
+			await writeFile(join(tmpDir, "README.md"), "# Demo\n\n## Usage\n");
+			const loaded = loadedFrom({ name: "demo", description: "A new description.", providers: { source: "github" } });
 			const loader = makeLoaderWith(loaded, {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 			});
@@ -555,8 +567,55 @@ describe("runSync", () => {
 			await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
 
 			const readme = await readFile(join(tmpDir, "README.md"), "utf8");
+			expect(readme).toContain("<!-- holocron:description -->");
 			expect(readme).toContain("A new description.");
+			expect(readme).toContain("<!-- /holocron:description -->");
 			expect(readme).toContain("## Usage");
+		});
+
+		it("does nothing when start marker exists but end marker is missing", async () => {
+			const initial = "# Demo\n\n<!-- holocron:description -->\nOrphaned content.\n\n## Usage\n";
+			await writeFile(join(tmpDir, "README.md"), initial);
+			const loaded = loadedFrom({ name: "demo", description: "My tool.", providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+			});
+
+			await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+
+			const readme = await readFile(join(tmpDir, "README.md"), "utf8");
+			expect(readme).toBe(initial);
+		});
+
+		it("does nothing when end marker appears before start marker", async () => {
+			const initial = "# Demo\n\n<!-- /holocron:description -->\nContent.\n<!-- holocron:description -->\n\n## Usage\n";
+			await writeFile(join(tmpDir, "README.md"), initial);
+			const loaded = loadedFrom({ name: "demo", description: "My tool.", providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+			});
+
+			await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+
+			const readme = await readFile(join(tmpDir, "README.md"), "utf8");
+			expect(readme).toBe(initial);
+		});
+
+		it("does not overwrite badge lines immediately after H1", async () => {
+			const initial =
+				"# Demo\n\n[![Build](https://img.shields.io/ci)](https://ci.example.com)\n\n## Usage\n";
+			await writeFile(join(tmpDir, "README.md"), initial);
+			const loaded = loadedFrom({ name: "demo", description: "My tool.", providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+			});
+
+			await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+
+			const readme = await readFile(join(tmpDir, "README.md"), "utf8");
+			expect(readme).toContain("[![Build]");
+			expect(readme).toContain("My tool.");
+			expect(readme).toContain("<!-- holocron:description -->");
 		});
 
 		it("calls source.syncDescription when provider implements it", async () => {

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { resolveConfig } from "../config.js";
 import { runSync } from "../commands/sync.js";
@@ -34,10 +38,11 @@ function makeLoaderWith(loaded: LoadedConfig, modules: Record<string, unknown>):
 }
 
 describe("runSync", () => {
-	it("runs all three sync steps when no steps filter is given", async () => {
+	it("runs all sync steps when no steps filter is given", async () => {
 		const called: string[] = [];
 		const loaded = loadedFrom({
 			name: "demo",
+			description: "A demo CLI tool",
 			repo: { name: "theholocron/demo", topics: ["ts", "cli"] },
 			providers: { source: "github" },
 		});
@@ -63,9 +68,9 @@ describe("runSync", () => {
 		const report = await runSync({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
 
 		expect(called).toEqual(["labels", "properties", "topics"]);
-		expect(report.steps).toHaveLength(3);
+		expect(report.steps).toHaveLength(5);
 		expect(report.steps.every((s) => s.status === "ok")).toBe(true);
-		expect(report.summary).toMatchObject({ ok: 3, fail: 0, skip: 0 });
+		expect(report.summary).toMatchObject({ ok: 5, fail: 0, skip: 0 });
 	});
 
 	it("runs only the requested step when a single step filter is given", async () => {
@@ -177,6 +182,7 @@ describe("runSync", () => {
 		let called = false;
 		const loaded = loadedFrom({
 			name: "demo",
+			description: "A demo CLI tool",
 			repo: { name: "theholocron/demo", topics: ["ts"] },
 			providers: { source: "github" },
 		});
@@ -208,7 +214,7 @@ describe("runSync", () => {
 
 		expect(called).toBe(false);
 		expect(report.steps.every((s) => s.status === "dry-run")).toBe(true);
-		expect(report.summary.dryRun).toBe(3);
+		expect(report.summary.dryRun).toBe(5);
 	});
 
 	it("reports skip when provider does not implement syncLabels", async () => {
@@ -371,6 +377,169 @@ describe("runSync", () => {
 		const step = report.steps.find((s) => s.step === "sync topics");
 		expect(step?.status).toBe("ok");
 		expect(step?.message).toBe("3 topics set");
+	});
+
+	it("skips sync keywords when no topics are configured", async () => {
+		const loaded = loadedFrom({ name: "demo", providers: { source: "github" } });
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+		});
+
+		const report = await runSync({ loaded, context: { repoRoot: "/tmp/test" }, loader, steps: ["keywords"], print: () => {} });
+
+		const step = report.steps.find((s) => s.step === "sync keywords");
+		expect(step?.status).toBe("skip");
+		expect(step?.message).toBe("no topics configured");
+	});
+
+	it("skips sync keywords when topics list is empty", async () => {
+		const loaded = loadedFrom({ name: "demo", repo: { topics: [] }, providers: { source: "github" } });
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+		});
+
+		const report = await runSync({ loaded, context: { repoRoot: "/tmp/test" }, loader, steps: ["keywords"], print: () => {} });
+
+		const step = report.steps.find((s) => s.step === "sync keywords");
+		expect(step?.status).toBe("skip");
+		expect(step?.message).toBe("no topics configured");
+	});
+
+	describe("sync keywords — package.json write", () => {
+		let tmpDir: string;
+		beforeEach(async () => { tmpDir = await mkdtemp(join(tmpdir(), "holocron-test-")); });
+		afterEach(async () => { await rm(tmpDir, { recursive: true }); });
+
+		it("writes topics to package.json#keywords", async () => {
+			await writeFile(join(tmpDir, "package.json"), JSON.stringify({ name: "demo", keywords: [] }, null, 2) + "\n");
+			const loaded = loadedFrom({
+				name: "demo",
+				repo: { topics: ["cli", "typescript"] },
+				providers: { source: "github" },
+			});
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+			});
+
+			const report = await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["keywords"], print: () => {} });
+
+			const step = report.steps.find((s) => s.step === "sync keywords");
+			expect(step?.status).toBe("ok");
+			expect(step?.message).toContain("2 keywords written");
+			const pkg = JSON.parse(await readFile(join(tmpDir, "package.json"), "utf8")) as { keywords: string[] };
+			expect(pkg.keywords).toEqual(["cli", "typescript"]);
+		});
+
+		it("succeeds gracefully when package.json is absent", async () => {
+			const loaded = loadedFrom({
+				name: "demo",
+				repo: { topics: ["cli"] },
+				providers: { source: "github" },
+			});
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+			});
+
+			const report = await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["keywords"], print: () => {} });
+
+			const step = report.steps.find((s) => s.step === "sync keywords");
+			expect(step?.status).toBe("ok");
+			expect(step?.message).toContain("no package.json");
+		});
+	});
+
+	it("skips sync description when no description is configured", async () => {
+		const loaded = loadedFrom({ name: "demo", providers: { source: "github" } });
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+		});
+
+		const report = await runSync({ loaded, context: { repoRoot: "/tmp/test" }, loader, steps: ["description"], print: () => {} });
+
+		const step = report.steps.find((s) => s.step === "sync description");
+		expect(step?.status).toBe("skip");
+		expect(step?.message).toBe("no description configured");
+	});
+
+	describe("sync description — file writes and GitHub sync", () => {
+		let tmpDir: string;
+		beforeEach(async () => { tmpDir = await mkdtemp(join(tmpdir(), "holocron-test-")); });
+		afterEach(async () => { await rm(tmpDir, { recursive: true }); });
+
+		it("writes description to package.json#description", async () => {
+			await writeFile(join(tmpDir, "package.json"), JSON.stringify({ name: "demo", description: "" }, null, 2) + "\n");
+			const loaded = loadedFrom({ name: "demo", description: "A great tool", providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+			});
+
+			await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+
+			const pkg = JSON.parse(await readFile(join(tmpDir, "package.json"), "utf8")) as { description: string };
+			expect(pkg.description).toBe("A great tool");
+		});
+
+		it("updates the description line in README.md", async () => {
+			await writeFile(join(tmpDir, "README.md"), "# Demo\n\nOld description.\n\n## Usage\n");
+			const loaded = loadedFrom({ name: "demo", description: "New description.", providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+			});
+
+			await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+
+			const readme = await readFile(join(tmpDir, "README.md"), "utf8");
+			expect(readme).toContain("New description.");
+			expect(readme).not.toContain("Old description.");
+		});
+
+		it("inserts description into README.md when none exists", async () => {
+			await writeFile(join(tmpDir, "README.md"), "# Demo\n\n## Usage\n");
+			const loaded = loadedFrom({ name: "demo", description: "A new description.", providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+			});
+
+			await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+
+			const readme = await readFile(join(tmpDir, "README.md"), "utf8");
+			expect(readme).toContain("A new description.");
+			expect(readme).toContain("## Usage");
+		});
+
+		it("calls source.syncDescription when provider implements it", async () => {
+			let capturedDesc: string | null = null;
+			const loaded = loadedFrom({ name: "demo", description: "A great tool", providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", {
+					source: {
+						syncDescription: async (desc: string) => {
+							capturedDesc = desc;
+							return "description updated";
+						},
+					},
+				}),
+			});
+
+			const report = await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+
+			expect(capturedDesc).toBe("A great tool");
+			const step = report.steps.find((s) => s.step === "sync description");
+			expect(step?.status).toBe("ok");
+			expect(step?.message).toContain("GitHub");
+		});
+
+		it("step reports ok even when package.json and README.md are absent", async () => {
+			const loaded = loadedFrom({ name: "demo", description: "A great tool", providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+			});
+
+			const report = await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+
+			const step = report.steps.find((s) => s.step === "sync description");
+			expect(step?.status).toBe("ok");
+		});
 	});
 
 	it("passes manual and derived properties to syncProperties", async () => {

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -587,6 +587,21 @@ describe("runSync", () => {
 			expect(step?.message).toContain("GitHub");
 		});
 
+		it("skips README.md update when file has no H1 heading", async () => {
+			await writeFile(join(tmpDir, "README.md"), "No heading here.\n\n## Usage\n");
+			const loaded = loadedFrom({ name: "demo", description: "A great tool", providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+			});
+
+			const report = await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+
+			const step = report.steps.find((s) => s.step === "sync description");
+			expect(step?.status).toBe("ok");
+			const readme = await readFile(join(tmpDir, "README.md"), "utf8");
+			expect(readme).not.toContain("A great tool");
+		});
+
 		it("step reports ok even when package.json and README.md are absent", async () => {
 			const loaded = loadedFrom({ name: "demo", description: "A great tool", providers: { source: "github" } });
 			const loader = makeLoaderWith(loaded, {

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -527,7 +527,11 @@ describe("runSync", () => {
 			const initial =
 				"# Demo\n\n<!-- holocron:description -->\nOld description.\n<!-- /holocron:description -->\n\n## Usage\n";
 			await writeFile(join(tmpDir, "README.md"), initial);
-			const loaded = loadedFrom({ name: "demo", description: "New description.", providers: { source: "github" } });
+			const loaded = loadedFrom({
+				name: "demo",
+				description: "New description.",
+				providers: { source: "github" },
+			});
 			const loader = makeLoaderWith(loaded, {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 			});
@@ -559,7 +563,11 @@ describe("runSync", () => {
 
 		it("inserts marker block after H1 when no block exists", async () => {
 			await writeFile(join(tmpDir, "README.md"), "# Demo\n\n## Usage\n");
-			const loaded = loadedFrom({ name: "demo", description: "A new description.", providers: { source: "github" } });
+			const loaded = loadedFrom({
+				name: "demo",
+				description: "A new description.",
+				providers: { source: "github" },
+			});
 			const loader = makeLoaderWith(loaded, {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 			});
@@ -588,7 +596,8 @@ describe("runSync", () => {
 		});
 
 		it("does nothing when end marker appears before start marker", async () => {
-			const initial = "# Demo\n\n<!-- /holocron:description -->\nContent.\n<!-- holocron:description -->\n\n## Usage\n";
+			const initial =
+				"# Demo\n\n<!-- /holocron:description -->\nContent.\n<!-- holocron:description -->\n\n## Usage\n";
 			await writeFile(join(tmpDir, "README.md"), initial);
 			const loaded = loadedFrom({ name: "demo", description: "My tool.", providers: { source: "github" } });
 			const loader = makeLoaderWith(loaded, {
@@ -602,8 +611,7 @@ describe("runSync", () => {
 		});
 
 		it("does not overwrite badge lines immediately after H1", async () => {
-			const initial =
-				"# Demo\n\n[![Build](https://img.shields.io/ci)](https://ci.example.com)\n\n## Usage\n";
+			const initial = "# Demo\n\n[![Build](https://img.shields.io/ci)](https://ci.example.com)\n\n## Usage\n";
 			await writeFile(join(tmpDir, "README.md"), initial);
 			const loaded = loadedFrom({ name: "demo", description: "My tool.", providers: { source: "github" } });
 			const loader = makeLoaderWith(loaded, {

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -385,7 +385,13 @@ describe("runSync", () => {
 			"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 		});
 
-		const report = await runSync({ loaded, context: { repoRoot: "/tmp/test" }, loader, steps: ["keywords"], print: () => {} });
+		const report = await runSync({
+			loaded,
+			context: { repoRoot: "/tmp/test" },
+			loader,
+			steps: ["keywords"],
+			print: () => {},
+		});
 
 		const step = report.steps.find((s) => s.step === "sync keywords");
 		expect(step?.status).toBe("skip");
@@ -398,7 +404,13 @@ describe("runSync", () => {
 			"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 		});
 
-		const report = await runSync({ loaded, context: { repoRoot: "/tmp/test" }, loader, steps: ["keywords"], print: () => {} });
+		const report = await runSync({
+			loaded,
+			context: { repoRoot: "/tmp/test" },
+			loader,
+			steps: ["keywords"],
+			print: () => {},
+		});
 
 		const step = report.steps.find((s) => s.step === "sync keywords");
 		expect(step?.status).toBe("skip");
@@ -407,11 +419,18 @@ describe("runSync", () => {
 
 	describe("sync keywords — package.json write", () => {
 		let tmpDir: string;
-		beforeEach(async () => { tmpDir = await mkdtemp(join(tmpdir(), "holocron-test-")); });
-		afterEach(async () => { await rm(tmpDir, { recursive: true }); });
+		beforeEach(async () => {
+			tmpDir = await mkdtemp(join(tmpdir(), "holocron-test-"));
+		});
+		afterEach(async () => {
+			await rm(tmpDir, { recursive: true });
+		});
 
 		it("writes topics to package.json#keywords", async () => {
-			await writeFile(join(tmpDir, "package.json"), JSON.stringify({ name: "demo", keywords: [] }, null, 2) + "\n");
+			await writeFile(
+				join(tmpDir, "package.json"),
+				JSON.stringify({ name: "demo", keywords: [] }, null, 2) + "\n"
+			);
 			const loaded = loadedFrom({
 				name: "demo",
 				repo: { topics: ["cli", "typescript"] },
@@ -421,7 +440,13 @@ describe("runSync", () => {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 			});
 
-			const report = await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["keywords"], print: () => {} });
+			const report = await runSync({
+				loaded,
+				context: { repoRoot: tmpDir },
+				loader,
+				steps: ["keywords"],
+				print: () => {},
+			});
 
 			const step = report.steps.find((s) => s.step === "sync keywords");
 			expect(step?.status).toBe("ok");
@@ -440,7 +465,13 @@ describe("runSync", () => {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 			});
 
-			const report = await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["keywords"], print: () => {} });
+			const report = await runSync({
+				loaded,
+				context: { repoRoot: tmpDir },
+				loader,
+				steps: ["keywords"],
+				print: () => {},
+			});
 
 			const step = report.steps.find((s) => s.step === "sync keywords");
 			expect(step?.status).toBe("ok");
@@ -454,7 +485,13 @@ describe("runSync", () => {
 			"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 		});
 
-		const report = await runSync({ loaded, context: { repoRoot: "/tmp/test" }, loader, steps: ["description"], print: () => {} });
+		const report = await runSync({
+			loaded,
+			context: { repoRoot: "/tmp/test" },
+			loader,
+			steps: ["description"],
+			print: () => {},
+		});
 
 		const step = report.steps.find((s) => s.step === "sync description");
 		expect(step?.status).toBe("skip");
@@ -463,11 +500,18 @@ describe("runSync", () => {
 
 	describe("sync description — file writes and GitHub sync", () => {
 		let tmpDir: string;
-		beforeEach(async () => { tmpDir = await mkdtemp(join(tmpdir(), "holocron-test-")); });
-		afterEach(async () => { await rm(tmpDir, { recursive: true }); });
+		beforeEach(async () => {
+			tmpDir = await mkdtemp(join(tmpdir(), "holocron-test-"));
+		});
+		afterEach(async () => {
+			await rm(tmpDir, { recursive: true });
+		});
 
 		it("writes description to package.json#description", async () => {
-			await writeFile(join(tmpDir, "package.json"), JSON.stringify({ name: "demo", description: "" }, null, 2) + "\n");
+			await writeFile(
+				join(tmpDir, "package.json"),
+				JSON.stringify({ name: "demo", description: "" }, null, 2) + "\n"
+			);
 			const loaded = loadedFrom({ name: "demo", description: "A great tool", providers: { source: "github" } });
 			const loader = makeLoaderWith(loaded, {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
@@ -481,7 +525,11 @@ describe("runSync", () => {
 
 		it("updates the description line in README.md", async () => {
 			await writeFile(join(tmpDir, "README.md"), "# Demo\n\nOld description.\n\n## Usage\n");
-			const loaded = loadedFrom({ name: "demo", description: "New description.", providers: { source: "github" } });
+			const loaded = loadedFrom({
+				name: "demo",
+				description: "New description.",
+				providers: { source: "github" },
+			});
 			const loader = makeLoaderWith(loaded, {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 			});
@@ -495,7 +543,11 @@ describe("runSync", () => {
 
 		it("inserts description into README.md when none exists", async () => {
 			await writeFile(join(tmpDir, "README.md"), "# Demo\n\n## Usage\n");
-			const loaded = loadedFrom({ name: "demo", description: "A new description.", providers: { source: "github" } });
+			const loaded = loadedFrom({
+				name: "demo",
+				description: "A new description.",
+				providers: { source: "github" },
+			});
 			const loader = makeLoaderWith(loaded, {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 			});
@@ -521,7 +573,13 @@ describe("runSync", () => {
 				}),
 			});
 
-			const report = await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+			const report = await runSync({
+				loaded,
+				context: { repoRoot: tmpDir },
+				loader,
+				steps: ["description"],
+				print: () => {},
+			});
 
 			expect(capturedDesc).toBe("A great tool");
 			const step = report.steps.find((s) => s.step === "sync description");
@@ -535,7 +593,13 @@ describe("runSync", () => {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 			});
 
-			const report = await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["description"], print: () => {} });
+			const report = await runSync({
+				loaded,
+				context: { repoRoot: tmpDir },
+				loader,
+				steps: ["description"],
+				print: () => {},
+			});
 
 			const step = report.steps.find((s) => s.step === "sync description");
 			expect(step?.status).toBe("ok");

--- a/packages/cli/src/capabilities/index.ts
+++ b/packages/cli/src/capabilities/index.ts
@@ -186,6 +186,12 @@ export interface Source extends ProviderIdentity {
 	 * Optional — providers that don't support topics omit this.
 	 */
 	syncTopics?(topics: string[]): Promise<string>;
+
+	/**
+	 * Set the repository description.
+	 * Optional — providers that don't support setting descriptions omit this.
+	 */
+	syncDescription?(description: string): Promise<string>;
 }
 
 // ───────────────────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,4 +1,4 @@
-import { access } from "node:fs/promises";
+import { access, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { Source } from "../capabilities/index.js";
@@ -7,7 +7,7 @@ import { PluginLoader, type RuntimeContext } from "../loader.js";
 import { CANONICAL_LABELS, STALE_LABELS } from "./setup.js";
 import type { SetupPrintLine, SetupReport, SetupStepResult } from "./setup.js";
 
-export const SYNC_STEPS = ["labels", "properties", "topics"] as const;
+export const SYNC_STEPS = ["labels", "properties", "topics", "keywords", "description"] as const;
 export type SyncStep = (typeof SYNC_STEPS)[number];
 
 export interface RunSyncInput {
@@ -116,6 +116,56 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 					print(formatSyncStep(steps[steps.length - 1]!));
 				}
 			}
+
+			if (stepName === "keywords") {
+				const topics = config.repo?.topics ?? [];
+				if (topics.length === 0) {
+					steps.push({
+						capability: "source",
+						step: "sync keywords",
+						status: "skip",
+						message: "no topics configured",
+					});
+					print(formatSyncStep(steps[steps.length - 1]!));
+				} else {
+					steps.push(
+						await runSyncStep("source", "sync keywords", dryRun, async () => {
+							const wrote = await writePackageJsonField(input.context.repoRoot, "keywords", topics);
+							return wrote ? `${topics.length} keywords written` : `${topics.length} topics (no package.json)`;
+						})
+					);
+					print(formatSyncStep(steps[steps.length - 1]!));
+				}
+			}
+
+			if (stepName === "description") {
+				const description = config.description;
+				if (!description) {
+					steps.push({
+						capability: "source",
+						step: "sync description",
+						status: "skip",
+						message: "no description configured",
+					});
+					print(formatSyncStep(steps[steps.length - 1]!));
+				} else {
+					steps.push(
+						await runSyncStep("source", "sync description", dryRun, async () => {
+							const pkgWrote = await writePackageJsonField(input.context.repoRoot, "description", description);
+							const readmeWrote = await updateReadmeDescription(input.context.repoRoot, description);
+							if (source.syncDescription) {
+								await source.syncDescription(description);
+							}
+							const parts: string[] = [];
+							if (pkgWrote) parts.push("package.json");
+							if (readmeWrote) parts.push("README.md");
+							if (source.syncDescription) parts.push("GitHub");
+							return parts.length > 0 ? parts.join(", ") + " updated" : "description synced";
+						})
+					);
+					print(formatSyncStep(steps[steps.length - 1]!));
+				}
+			}
 		}
 
 		// Report unknown step names
@@ -183,4 +233,47 @@ function formatSyncStep(step: SetupStepResult): string {
 	const icon = step.status === "ok" ? "✓" : step.status === "fail" ? "✗" : step.status === "dry-run" ? "…" : "·";
 	const detail = step.message ? `  (${step.message})` : "";
 	return `    ${icon} ${step.step}${detail}`;
+}
+
+async function writePackageJsonField(repoRoot: string, field: string, value: unknown): Promise<boolean> {
+	const pkgPath = join(repoRoot, "package.json");
+	let content: string;
+	try {
+		content = await readFile(pkgPath, "utf8");
+	} catch {
+		return false;
+	}
+	const pkg = JSON.parse(content) as Record<string, unknown>;
+	pkg[field] = value;
+	await writeFile(pkgPath, JSON.stringify(pkg, null, 2) + "\n", "utf8");
+	return true;
+}
+
+async function updateReadmeDescription(repoRoot: string, description: string): Promise<boolean> {
+	const readmePath = join(repoRoot, "README.md");
+	let content: string;
+	try {
+		content = await readFile(readmePath, "utf8");
+	} catch {
+		return false;
+	}
+	const lines = content.split("\n");
+	const h1Index = lines.findIndex((l) => /^# /.test(l));
+	if (h1Index === -1) return false;
+
+	let i = h1Index + 1;
+	while (i < lines.length && lines[i]!.trim() === "") i++;
+
+	if (i >= lines.length || lines[i]!.startsWith("#")) {
+		lines.splice(h1Index + 1, 0, "", description);
+	} else {
+		const descStart = i;
+		let descEnd = i;
+		while (descEnd < lines.length && lines[descEnd]!.trim() !== "" && !lines[descEnd]!.startsWith("#")) {
+			descEnd++;
+		}
+		lines.splice(descStart, descEnd - descStart, description);
+	}
+	await writeFile(readmePath, lines.join("\n"), "utf8");
+	return true;
 }

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -131,7 +131,9 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 					steps.push(
 						await runSyncStep("source", "sync keywords", dryRun, async () => {
 							const wrote = await writePackageJsonField(input.context.repoRoot, "keywords", topics);
-							return wrote ? `${topics.length} keywords written` : `${topics.length} topics (no package.json)`;
+							return wrote
+								? `${topics.length} keywords written`
+								: `${topics.length} topics (no package.json)`;
 						})
 					);
 					print(formatSyncStep(steps[steps.length - 1]!));
@@ -151,7 +153,11 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 				} else {
 					steps.push(
 						await runSyncStep("source", "sync description", dryRun, async () => {
-							const pkgWrote = await writePackageJsonField(input.context.repoRoot, "description", description);
+							const pkgWrote = await writePackageJsonField(
+								input.context.repoRoot,
+								"description",
+								description
+							);
 							const readmeWrote = await updateReadmeDescription(input.context.repoRoot, description);
 							if (source.syncDescription) {
 								await source.syncDescription(description);

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -255,6 +255,9 @@ async function writePackageJsonField(repoRoot: string, field: string, value: unk
 	return true;
 }
 
+const README_DESC_START = "<!-- holocron:description -->";
+const README_DESC_END = "<!-- /holocron:description -->";
+
 async function updateReadmeDescription(repoRoot: string, description: string): Promise<boolean> {
 	const readmePath = join(repoRoot, "README.md");
 	let content: string;
@@ -264,22 +267,20 @@ async function updateReadmeDescription(repoRoot: string, description: string): P
 		return false;
 	}
 	const lines = content.split("\n");
+
+	const startIdx = lines.findIndex((l) => l.trim() === README_DESC_START);
+	const endIdx = lines.findIndex((l) => l.trim() === README_DESC_END);
+	if (startIdx !== -1) {
+		if (endIdx === -1 || endIdx <= startIdx) return false;
+		lines.splice(startIdx + 1, endIdx - startIdx - 1, description);
+		await writeFile(readmePath, lines.join("\n"), "utf8");
+		return true;
+	}
+
 	const h1Index = lines.findIndex((l) => /^# /.test(l));
 	if (h1Index === -1) return false;
 
-	let i = h1Index + 1;
-	while (i < lines.length && lines[i]!.trim() === "") i++;
-
-	if (i >= lines.length || lines[i]!.startsWith("#")) {
-		lines.splice(h1Index + 1, 0, "", description);
-	} else {
-		const descStart = i;
-		let descEnd = i;
-		while (descEnd < lines.length && lines[descEnd]!.trim() !== "" && !lines[descEnd]!.startsWith("#")) {
-			descEnd++;
-		}
-		lines.splice(descStart, descEnd - descStart, description);
-	}
+	lines.splice(h1Index + 1, 0, "", README_DESC_START, description, README_DESC_END);
 	await writeFile(readmePath, lines.join("\n"), "utf8");
 	return true;
 }

--- a/packages/holocron-plugin-github/src/__tests__/source.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/source.test.ts
@@ -67,6 +67,15 @@ describe("GitHubSource — REST methods", () => {
 		expect(calls[0]?.body).toEqual({ allow_squash_merge: true });
 	});
 
+	it("syncDescription → PATCH /repos/{repo} with description", async () => {
+		const { source, calls } = makeSource([{ status: 200, body: {} }]);
+		const result = await source.syncDescription("A great tool.");
+		expect(calls[0]?.method).toBe("PATCH");
+		expect(calls[0]?.url).toBe(`https://api.github.com/repos/${REPO}`);
+		expect(calls[0]?.body).toEqual({ description: "A great tool." });
+		expect(result).toBe("description updated");
+	});
+
 	it("enableVulnerabilityAlerts → PUT /vulnerability-alerts", async () => {
 		const { source, calls } = makeSource([{ status: 204 }]);
 		await source.enableVulnerabilityAlerts();

--- a/packages/holocron-plugin-github/src/capabilities/source.ts
+++ b/packages/holocron-plugin-github/src/capabilities/source.ts
@@ -148,6 +148,11 @@ export class GitHubSource implements Source {
 	async syncTopics(topics: string[]): Promise<string> {
 		return syncTopics(this.client, this.repo, topics);
 	}
+
+	async syncDescription(description: string): Promise<string> {
+		await this.client.repos.updateRepo(this.repo, { description });
+		return "description updated";
+	}
 }
 
 function isENOENT(err: unknown): boolean {


### PR DESCRIPTION
## Summary

- Adds a **`keywords` sync step**: writes `repo.topics` from `holocron.config.ts` to `package.json#keywords`
- Adds a **`description` sync step**: writes `description` from `holocron.config.ts` to three places:
  1. `package.json#description`
  2. The line after the H1 title in `README.md` (replaces existing description or inserts one)
  3. The GitHub repository description via a new optional `syncDescription?` method on the `Source` capability (implemented in `GitHubSource` as `PATCH /repos/{owner}/{repo}`)
- Both steps skip gracefully when the prerequisite data is absent (no topics, no description, no `package.json`, no `README.md`)
- Both steps honour `--dry-run` and use the same `ok`/`skip`/`fail` reporting as existing steps

## Test plan

- [ ] All 292 CLI tests pass (`pnpm --filter @theholocron/cli test`)
- [ ] All 112 GitHub plugin tests pass (`pnpm --filter @theholocron/holocron-plugin-github test`)
- [ ] Both packages typecheck clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->