### PR TITLE
fix(review): scope gitleaks to PR commits and skip yamllint without config

### DIFF
--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -531,6 +531,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Setup
         if: \${{ hashFiles('pnpm-lock.yaml') != '' }}
@@ -572,7 +574,7 @@ jobs:
         uses: reviewdog/action-gitleaks@2b7b5685e3e3eecddab5d30cfa04f18123031421 # v1
         with:
           reporter: github-pr-check
-          gitleaks_flags: --log-opts="\${{ github.event.pull_request.base.sha }}..\${{ github.event.pull_request.head.sha }}"
+          gitleaks_flags: --log-opts=\${{ github.event.pull_request.base.sha }}..\${{ github.event.pull_request.head.sha }}
 
       - name: YamlLint
         if: \${{ hashFiles('yamllint.config.yml') != '' }}

--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -572,15 +572,14 @@ jobs:
         uses: reviewdog/action-gitleaks@2b7b5685e3e3eecddab5d30cfa04f18123031421 # v1
         with:
           reporter: github-pr-check
+          gitleaks_flags: --log-opts="\${{ github.event.pull_request.base.sha }}..\${{ github.event.pull_request.head.sha }}"
 
       - name: YamlLint
+        if: \${{ hashFiles('yamllint.config.yml') != '' }}
         uses: reviewdog/action-yamllint@b5f7217d8c815ae374d1d55840d5e569d82f01f0 # v1
         with:
           reporter: github-pr-check
-          yamllint_flags: >-
-            \${{ hashFiles('yamllint.config.yml') != ''
-                && format('-c {0}/yamllint.config.yml {0}', github.workspace)
-                || github.workspace }}
+          yamllint_flags: -c \${{ github.workspace }}/yamllint.config.yml \${{ github.workspace }}
 
       - name: ActionLint (GitHub Actions)
         if: \${{ hashFiles('.github/workflows/*.yml', '.github/workflows/*.yaml') != '' }}


### PR DESCRIPTION
Closes #171
Closes #172

## Summary

- **Gitleaks (#171):** adds `--log-opts` so the scan covers only the commits new to the PR (`base..head`), not the full HEAD tree. Pre-existing secrets in test fixtures no longer block unrelated PRs.
- **YamlLint (#172):** replaces the `hashFiles` ternary inside `yamllint_flags` with a step-level `if: ${{ hashFiles('yamllint.config.yml') != '' }}` guard, skipping the step entirely when no config is present and eliminating the `FileNotFoundError` crash.

## Test plan

- [ ] All 282 CLI tests pass
- [ ] Sync a downstream repo and confirm the generated `.github/workflows/review.yml` contains `--log-opts` on gitleaks and `if:` on YamlLint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->