### PR TITLE
fix(upgrade-node): match engines.node with or without .0.0 suffix

### DIFF
--- a/packages/cli/src/__tests__/upgrade-node.test.ts
+++ b/packages/cli/src/__tests__/upgrade-node.test.ts
@@ -94,6 +94,14 @@ describe("package.json", () => {
 		expect(JSON.parse(written["package.json"]!).engines.node).toBe(">=22.0.0");
 	});
 
+	it("updates engines.node when written without .0.0 suffix (>=20)", async () => {
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"package.json": pkg({ engines: { node: ">=20" } }),
+		});
+		await runUpgradeNode({ to: 22, from: 20, cwd: CWD, print: () => {}, readFile, writeFile, walkFiles });
+		expect(JSON.parse(written["package.json"]!).engines.node).toBe(">=22.0.0");
+	});
+
 	it("updates @types/node in devDependencies", async () => {
 		const { readFile, writeFile, walkFiles, written } = makeFs({
 			"package.json": pkg({ devDependencies: { "@types/node": "^20.0.0" } }),

--- a/packages/cli/src/commands/upgrade-node.ts
+++ b/packages/cli/src/commands/upgrade-node.ts
@@ -18,9 +18,12 @@ function patchPackageJson(content: string, from: number, to: number): string | n
 	let changed = false;
 
 	const engines = pkg.engines as Record<string, string> | undefined;
-	if (engines?.node === `>=${from}.0.0`) {
-		engines.node = `>=${to}.0.0`;
-		changed = true;
+	if (engines?.node && /^>=\d+(?:\.0\.0)?$/.test(engines.node)) {
+		const major = parseInt(engines.node.match(/\d+/)![0]!, 10);
+		if (major === from) {
+			engines.node = `>=${to}.0.0`;
+			changed = true;
+		}
 	}
 
 	for (const field of ["devDependencies", "dependencies"] as const) {


### PR DESCRIPTION
Closes #167

## Summary

`patchPackageJson` used an exact string comparison:

```ts
if (engines?.node === `>=${from}.0.0`) {
```

Values written as `>=22` (no `.0.0` suffix, used in the root `package.json` of `theholocron/configs`) were silently skipped, leaving the root `engines.node` behind after `holocron upgrade node`.

The fix replaces the string equality check with a regex that accepts both `>=N` and `>=N.0.0`, extracts the major, and normalises the output to the full `>=N.0.0` form on write.

## Test plan

- [ ] New test: `"updates engines.node when written without .0.0 suffix (>=20)"` passes
- [ ] All 283 CLI tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->