### PR TITLE
feat(setup): classify 403 failures and emit PAT hint after summary

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -8,6 +8,7 @@ import { resolveConfig } from "../config.js";
 import { runSetup, codecovContent } from "../commands/setup.js";
 import type { LoadedConfig } from "../load-config.js";
 import { PluginLoader, type PluginImporter } from "../loader.js";
+import { ProviderApiError } from "../capabilities/index.js";
 
 function loadedFrom(rawConfig: Parameters<typeof resolveConfig>[0]): LoadedConfig {
 	return {
@@ -1316,6 +1317,126 @@ describe("runSetup", () => {
 		const step = report.steps.find((s) => s.step === "sync labels");
 		expect(step?.status).toBe("ok");
 		expect(step?.message).toBe("17 synced");
+	});
+});
+
+// ── 403 reason classification and hint ────────────────────────────────────────
+
+describe("runSetup — 403 handling", () => {
+	const loaded = (() => {
+		const r = resolveConfig({ name: "demo", providers: { source: "github" } });
+		return { resolved: r, filepath: "/tmp/test/holocron.config.json" };
+	})();
+
+	function makeLoaderWithSource(source: Record<string, unknown>): PluginLoader {
+		const importer = vi.fn(async () => ({
+			createPlugin: () => ({
+				name: "gh",
+				capabilities: {
+					source: () => ({ listWorkflowFiles: async () => [], ...source }),
+				},
+			}),
+		}));
+		return new PluginLoader(loaded.resolved, { repoRoot: "/tmp/test" }, importer as unknown as PluginImporter);
+	}
+
+	it("tags a generic 403 as permissions and attaches reason to the step", async () => {
+		const loader = makeLoaderWithSource({
+			enableVulnerabilityAlerts: async () => {
+				throw new ProviderApiError("Must have admin rights to Repository.", 403);
+			},
+		});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		const step = report.steps.find((s) => s.step === "enableVulnerabilityAlerts");
+		expect(step?.status).toBe("fail");
+		expect(step?.reason).toBe("permissions");
+	});
+
+	it("tags a plan-restriction 403 as plan", async () => {
+		const loader = makeLoaderWithSource({
+			enableSecretScanning: async () => {
+				throw new ProviderApiError("GitHub Advanced Security is not enabled for this repository.", 403);
+			},
+		});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		const step = report.steps.find((s) => s.step === "enableSecretScanning");
+		expect(step?.reason).toBe("plan");
+	});
+
+	it("does not set reason for non-403 errors", async () => {
+		const loader = makeLoaderWithSource({
+			enableVulnerabilityAlerts: async () => {
+				throw new Error("network timeout");
+			},
+		});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		const step = report.steps.find((s) => s.step === "enableVulnerabilityAlerts");
+		expect(step?.status).toBe("fail");
+		expect(step?.reason).toBeUndefined();
+	});
+
+	it("emits the PAT hint in output when there is a permissions 403", async () => {
+		const lines: string[] = [];
+		const loader = makeLoaderWithSource({
+			enableVulnerabilityAlerts: async () => {
+				throw new ProviderApiError("Must have admin rights.", 403);
+			},
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: (l) => lines.push(l) });
+
+		const output = lines.join("\n");
+		expect(output).toContain("⚠");
+		expect(output).toContain("insufficient token permissions");
+		expect(output).toContain("personal-access-tokens/new");
+		expect(output).toContain("--token <your-temp-pat>");
+	});
+
+	it("does not emit the hint when all failures are plan restrictions", async () => {
+		const lines: string[] = [];
+		const loader = makeLoaderWithSource({
+			enableSecretScanning: async () => {
+				throw new ProviderApiError("GitHub Advanced Security is not enabled for this repository.", 403);
+			},
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: (l) => lines.push(l) });
+
+		expect(lines.join("\n")).not.toContain("personal-access-tokens/new");
+	});
+
+	it("formatStep includes [permissions] tag in the printed line", async () => {
+		const lines: string[] = [];
+		const loader = makeLoaderWithSource({
+			enableVulnerabilityAlerts: async () => {
+				throw new ProviderApiError("Must have admin rights.", 403);
+			},
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: (l) => lines.push(l) });
+
+		const stepLine = lines.find((l) => l.includes("enableVulnerabilityAlerts"));
+		expect(stepLine).toMatch(/\[permissions\]/);
+	});
+
+	it("formatStep includes [plan restriction] tag for plan 403s", async () => {
+		const lines: string[] = [];
+		const loader = makeLoaderWithSource({
+			enableSecretScanning: async () => {
+				throw new ProviderApiError("GitHub Advanced Security is not enabled for this repository.", 403);
+			},
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: (l) => lines.push(l) });
+
+		const stepLine = lines.find((l) => l.includes("enableSecretScanning"));
+		expect(stepLine).toMatch(/\[plan restriction\]/);
 	});
 });
 

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -838,7 +838,7 @@ async function runStep(
 }
 
 function classify403(err: ProviderApiError): FailReason {
-	const msg = err.message.toLowerCase();
+	const msg = `${err.message} ${String(err.details)}`.toLowerCase();
 	if (
 		msg.includes("advanced security") ||
 		msg.includes("not enabled for this repository") ||

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -425,11 +425,16 @@ export type SetupPrintLine = (line: string) => void;
 
 export type SetupStatus = "ok" | "fail" | "skip" | "dry-run";
 
+/** Why a step failed with HTTP 403. */
+export type FailReason = "permissions" | "plan";
+
 export interface SetupStepResult {
 	capability: string;
 	step: string;
 	status: SetupStatus;
 	message?: string;
+	/** Set when status === "fail" and the error was a 403. */
+	reason?: FailReason;
 }
 
 export interface SetupReport {
@@ -781,6 +786,24 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		}`
 	);
 
+	if (steps.some((s) => s.reason === "permissions")) {
+		print("");
+		print("  ⚠  Some steps failed with 403 (insufficient token permissions).");
+		print("     These operations require a temporary fine-grained PAT with the");
+		print("     following repository permissions:");
+		print("");
+		print("       · Administration          — read and write");
+		print("       · Code scanning alerts    — read and write");
+		print("       · Contents                — read and write");
+		print("       · Secret scanning alerts  — read and write");
+		print("       · Workflows               — read and write");
+		print("       · Metadata                — read (added automatically)");
+		print("");
+		print("     Create one at: https://github.com/settings/personal-access-tokens/new");
+		print("     Then re-run:   holocron setup --token <your-temp-pat>");
+		print("     You can revoke it immediately after setup completes.");
+	}
+
 	return { steps, summary };
 }
 
@@ -801,6 +824,10 @@ async function runStep(
 		if (typeof note === "string") result.message = note;
 		return result;
 	} catch (err) {
+		if (err instanceof ProviderApiError && err.status === 403) {
+			const reason = classify403(err);
+			return { capability, step, status: "fail", message: err.message, reason };
+		}
 		return {
 			capability,
 			step,
@@ -810,8 +837,22 @@ async function runStep(
 	}
 }
 
+function classify403(err: ProviderApiError): FailReason {
+	const msg = err.message.toLowerCase();
+	if (
+		msg.includes("advanced security") ||
+		msg.includes("not enabled for this repository") ||
+		msg.includes("upgrade") ||
+		msg.includes("not available on")
+	) {
+		return "plan";
+	}
+	return "permissions";
+}
+
 function formatStep(step: SetupStepResult): string {
 	const icon = step.status === "ok" ? "✓" : step.status === "fail" ? "✗" : step.status === "dry-run" ? "…" : "·";
+	const tag = step.reason === "permissions" ? " [permissions]" : step.reason === "plan" ? " [plan restriction]" : "";
 	const detail = step.message ? `  (${step.message})` : "";
-	return `    ${icon} ${step.step}${detail}`;
+	return `    ${icon} ${step.step}${tag}${detail}`;
 }


### PR DESCRIPTION
Closes #119

When holocron setup hits a 403, it now classifies it as permissions or plan, tags each failing step line ([permissions] or [plan restriction]), and emits a PAT hint block after the summary when at least one step failed due to insufficient token scope. Plan-restriction 403s suppress the hint.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->