### PR TITLE
refactor: rename bookkeeping-pr → bookkeeping and add issue trigger

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -954,11 +954,11 @@ describe("runSetup", () => {
 		expect(checkerStep?.status).toBe("ok");
 	});
 
-	it("writes .github/labeler.yml when bookkeeping-pr workflow is configured", async () => {
+	it("writes .github/labeler.yml when bookkeeping workflow is configured", async () => {
 		const written: Record<string, string> = {};
 		const loaded = loadedFrom({
 			name: "demo",
-			workflows: ["lint", "bookkeeping-pr"],
+			workflows: ["lint", "bookkeeping"],
 			providers: { vault: "1password", source: "github" },
 		});
 		const loader = makeLoaderWith(loaded, {
@@ -990,7 +990,7 @@ describe("runSetup", () => {
 		expect(step?.status).toBe("ok");
 	});
 
-	it("does not write .github/labeler.yml when bookkeeping-pr is not configured", async () => {
+	it("does not write .github/labeler.yml when bookkeeping is not configured", async () => {
 		const written: Record<string, string> = {};
 		const loaded = loadedFrom({
 			name: "demo",

--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { ACTIONS, REUSABLE_WORKFLOWS, WORKFLOW_TEMPLATE_PROPERTIES } from "../templates/index.js";
 import { WORKFLOW_TEMPLATES, generateThinCallerContent } from "../commands/setup-workflows.js";
@@ -540,5 +540,27 @@ describe("generateThinCallerContent", () => {
 		const matches = content.match(/secondary-repos:/g);
 		expect(matches).toHaveLength(1);
 		expect(content).toContain("secondary-repos: theholocron/clients");
+	});
+
+	it("emits a console.warn and returns base unchanged when no injection pattern matches", () => {
+		const sentinel = "__test_no_pattern__";
+		WORKFLOW_TEMPLATES[sentinel] = "name: Test\n\njobs:\n  test:\n    uses: some/action@v1\n";
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const result = generateThinCallerContent(sentinel, { key: "val" });
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("could not inject"));
+			expect(result).toBe(WORKFLOW_TEMPLATES[sentinel]);
+		} finally {
+			delete WORKFLOW_TEMPLATES[sentinel];
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("generates bookkeeping thin-caller with issues trigger and secrets: inherit", () => {
+		const content = generateThinCallerContent("bookkeeping");
+		expect(content).toContain("name: Bookkeeping");
+		expect(content).toContain("pull_request:");
+		expect(content).toContain("issues:");
+		expect(content).toContain("secrets: inherit");
 	});
 });

--- a/packages/cli/src/commands/setup-workflows.ts
+++ b/packages/cli/src/commands/setup-workflows.ts
@@ -218,11 +218,15 @@ jobs:
     secrets: inherit
 `,
 
-	"bookkeeping-pr": `\
-name: PR Bookkeeping
+	bookkeeping: `\
+name: Bookkeeping
 
 on: # yamllint disable-line rule:truthy
   pull_request:
+    types:
+      - opened
+      - edited
+  issues:
     types:
       - opened
       - edited
@@ -234,7 +238,7 @@ permissions:
 
 jobs:
   bookkeeping:
-    uses: ${ref("bookkeeping-pr")}
+    uses: ${ref("bookkeeping")}
     secrets: inherit
 `,
 

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -224,8 +224,8 @@ export const STALE_LABELS = [
 
 // ── labeler config template ──────────────────────────────────────────
 // Maps Conventional Commit title prefixes to standard GitHub label names.
-// Written when bookkeeping-pr is in the workflows list; read by the
-// github/issue-labeler action inside the bookkeeping-pr reusable workflow.
+// Written when bookkeeping is in the workflows list; read by the
+// github/issue-labeler action inside the bookkeeping reusable workflow.
 function labelerConfig(): string {
 	return [
 		`# AUTO-GENERATED — do not edit directly.`,
@@ -558,7 +558,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	// ── source: labeler config ───────────────────────────────────────────
 	if (
 		loader.has("source") &&
-		(config.workflows ?? []).map((e) => (typeof e === "string" ? e : e.name)).includes("bookkeeping-pr")
+		(config.workflows ?? []).map((e) => (typeof e === "string" ? e : e.name)).includes("bookkeeping")
 	) {
 		const source = loader.get("source") as Source;
 		steps.push(

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -110,7 +110,7 @@ export interface HolocronConfig {
 	 * Use the object form to pass `with:` inputs to the reusable workflow.
 	 *
 	 * Supported values: "lint" | "test" | "typecheck" | "codeql" | "review" |
-	 *   "release" | "stale" | "greetings" | "dependencies" | "bookkeeping-pr" | "audit"
+	 *   "release" | "stale" | "greetings" | "dependencies" | "bookkeeping" | "audit"
 	 *
 	 * `holocron setup` writes `.github/workflows/<name>.yml` for each entry,
 	 * calling the corresponding `ci-<name>.yml@main` reusable workflow.

--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -116,8 +116,8 @@ jobs:
           CODECOV_TOKEN: \${{ secrets.CODECOV_TOKEN }}
 `,
 
-	"bookkeeping-pr": `\
-name: PR Bookkeeping
+	bookkeeping: `\
+name: Bookkeeping
 
 on: # yamllint disable-line rule:truthy
   workflow_call:
@@ -130,7 +130,7 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   label:
-    name: Add Labels to PRs
+    name: Apply Labels
     permissions:
       contents: read
       issues: write
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:
-      group: bookkeeping-pr-\${{ github.event.pull_request.number }}
+      group: bookkeeping-\${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

- Renames the `bookkeeping-pr` workflow key to `bookkeeping` everywhere (thin caller, reusable template, `setup.ts` labeler gate, `config.ts` JSDoc)
- Extends the thin-caller workflow to also fire on `issues: [opened, edited]` so issue labels are applied alongside PR labels
- Updates the concurrency group to `bookkeeping-${{ pr.number || issue.number }}` to handle both event types
- Renames job/workflow display names from "PR Bookkeeping" / "Add Labels to PRs" to "Bookkeeping" / "Apply Labels"

## Test plan
- [ ] `writes .github/labeler.yml when bookkeeping workflow is configured` passes (key updated from `bookkeeping-pr`)
- [ ] 308 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->