### PR TITLE
fix(setup): enable required_review_thread_resolution in branch ruleset

### DIFF
--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -339,7 +339,7 @@ function buildRulesetPayload(requiredChecks: string[] = []): Record<string, unkn
 				dismiss_stale_reviews_on_push: false,
 				require_code_owner_review: false,
 				require_last_push_approval: false,
-				required_review_thread_resolution: false,
+				required_review_thread_resolution: true,
 			},
 		},
 	];


### PR DESCRIPTION
Part of #82

The `pull_request` rule in `buildRulesetPayload` had `required_review_thread_resolution: false`, allowing PRs to merge with unresolved review comments. Changed to `true` to enforce thread resolution, matching the policy spec in #82.

315 tests pass, no assertions changed (no test was checking this field).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->