### PR TITLE
fix(bookkeeping): restrict labeler to pull_request events only

### DIFF
--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -556,10 +556,10 @@ describe("generateThinCallerContent", () => {
 		}
 	});
 
-	it("generates bookkeeping thin-caller with both pull_request and issues triggers", () => {
+	it("generates bookkeeping thin-caller with pull_request trigger only", () => {
 		const content = generateThinCallerContent("bookkeeping");
 		expect(content).toContain("pull_request:");
-		expect(content).toContain("issues:");
+		expect(content).not.toContain("issues:");
 		expect(content).toContain("secrets: inherit");
 	});
 });

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -227,6 +227,8 @@ export const STALE_LABELS = [
 // Maps Conventional Commit title prefixes to standard GitHub label names.
 // Written when bookkeeping is in the workflows list; read by the
 // github/issue-labeler action inside the bookkeeping reusable workflow.
+// Only applied to pull requests (CC-style regexes don't suit free-form
+// issue titles; sync-labels would strip manually applied labels on issues).
 function labelerConfig(): string {
 	return [
 		`# AUTO-GENERATED — do not edit directly.`,

--- a/packages/cli/src/commands/workflows/bookkeeping.yml
+++ b/packages/cli/src/commands/workflows/bookkeeping.yml
@@ -5,14 +5,9 @@ on: # yamllint disable-line rule:truthy
     types:
       - opened
       - edited
-  issues:
-    types:
-      - opened
-      - edited
 
 permissions:
   contents: read
-  issues: write
   pull-requests: write
 
 jobs:

--- a/packages/cli/src/templates/workflows/bookkeeping.yml
+++ b/packages/cli/src/templates/workflows/bookkeeping.yml
@@ -14,7 +14,6 @@ jobs:
     name: Apply Labels
     permissions:
       contents: read
-      issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -28,7 +27,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
-        if: ${{ hashFiles(inputs.configuration-path || '.github/labeler.yml') != '' }}
+        if: ${{ github.event_name == 'pull_request' && hashFiles(inputs.configuration-path || '.github/labeler.yml') != '' }}
         # v3.4 bundles Node 20; allow it to run under Actions' current default.
         env:
           ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true


### PR DESCRIPTION
## Summary

- The bookkeeping workflow was triggering `github/issue-labeler` on `issues` events with `sync-labels: 1`, but `.github/labeler.yml` only contains Conventional Commit title regexes that suit PR titles, not free-form issue titles
- With no regex matching, `sync-labels` silently stripped every manually applied label on each issue edit
- Remove the `issues:` trigger from the thin caller template and drop the unused `issues: write` permission
- Add a `github.event_name == 'pull_request'` guard to the labeler step in the reusable workflow as defense in depth

## Test plan

- [ ] Confirm the generated caller no longer includes `issues:` trigger or `issues: write` permission after `holocron setup`
- [ ] Open a PR with a `feat:` title — `enhancement` label is applied automatically
- [ ] Open a PR with a `fix:` title — `bug` label is applied automatically
- [ ] Edit an issue title — no labels are stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->