### PR TITLE
feat(cli): expressive CLI output — chalk + ora spinners

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,8 @@
     "@napi-rs/keyring": "^1.3.0",
     "@theholocron/github-client": "catalog:",
     "@theholocron/http-client": "catalog:",
+    "chalk": "catalog:",
+    "ora": "catalog:",
     "tsx": "catalog:",
     "yargs": "^18.0.0"
   },

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -286,7 +286,9 @@ describe("runAuthCheck", () => {
 			const { print, lines } = collect();
 			const result = await runAuthCheck({
 				provider: "doppler",
-				importer: async () => ({ verifyToken: async () => ({ ok: true as const, subject: "workplace: acme" }) }),
+				importer: async () => ({
+					verifyToken: async () => ({ ok: true as const, subject: "workplace: acme" }),
+				}),
 				print,
 				showSpinner: false,
 			});

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -253,6 +253,21 @@ describe("runAuthCheck", () => {
 		expect(lines.join("\n")).toMatch(/doppler configure get token/);
 	});
 
+	it("reports fail without hint when the rejected module exports no AUTH_HINT", async () => {
+		store.set("com.theholocron.cli::doppler", "stale");
+		const { print, lines } = collect();
+		const result = await runAuthCheck({
+			provider: "doppler",
+			importer: async () => ({
+				verifyToken: async () => ({ ok: false as const, message: "401 unauthorized" }),
+			}),
+			print,
+		});
+		expect(result.status).toBe("fail");
+		expect(lines.join("\n")).toMatch(/rejected/);
+		expect(lines.join("\n")).not.toMatch(/hint:/);
+	});
+
 	it("reports ok-unverified when the plugin has no verifyToken", async () => {
 		store.set("com.theholocron.cli::custom", "abc");
 		const { print, lines } = collect();
@@ -351,5 +366,16 @@ describe("runAuthList", () => {
 			importer: async () => ({ verifyToken: async () => ({ ok: true as const, subject: "x" }) }),
 		});
 		expect(lines.join("\n")).toMatch(/· ghost/);
+	});
+
+	it("renders a provider line without detail when the subject is empty", async () => {
+		// An empty subject is falsy, so check.message ? ` — ${msg}` : "" takes the "" branch.
+		store.set("com.theholocron.cli::doppler", "dp.pt.abc");
+		const { print, lines } = collect();
+		await runAuthList({
+			print,
+			importer: async () => ({ verifyToken: async () => ({ ok: true as const, subject: "" }) }),
+		});
+		expect(lines.join("\n")).toMatch(/✓ doppler\s*$/m);
 	});
 });

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -106,6 +106,22 @@ describe("runAuthSet", () => {
 		expect(lines.join("\n")).toMatch(/doppler configure get token --plain/);
 	});
 
+	it("fails without hint when verifyToken rejects and the module exports no AUTH_HINT", async () => {
+		const { print, lines } = collect();
+		const result = await runAuthSet({
+			provider: "doppler",
+			positional: "bad",
+			env: {},
+			importer: async () => ({
+				verifyToken: async () => ({ ok: false as const, message: "401 unauthorized" }),
+			}),
+			print,
+		});
+		expect(result.status).toBe("fail");
+		expect(lines.join("\n")).toMatch(/token rejected/);
+		expect(lines.join("\n")).not.toMatch(/hint:/);
+	});
+
 	it("prints hint + fails when no token supplied", async () => {
 		const { print, lines } = collect();
 		const result = await runAuthSet({

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -279,6 +279,23 @@ describe("runAuthCheck", () => {
 	});
 });
 
+describe("runAuthCheck", () => {
+	describe("showSpinner: false", () => {
+		it("skips the spinner and verifies directly", async () => {
+			store.set("com.theholocron.cli::doppler", "dp.pt.abc");
+			const { print, lines } = collect();
+			const result = await runAuthCheck({
+				provider: "doppler",
+				importer: async () => ({ verifyToken: async () => ({ ok: true as const, subject: "workplace: acme" }) }),
+				print,
+				showSpinner: false,
+			});
+			expect(result.status).toBe("ok");
+			expect(lines.join("\n")).toMatch(/doppler: ok — workplace: acme/);
+		});
+	});
+});
+
 describe("runAuthList", () => {
 	beforeEach(reset);
 
@@ -304,5 +321,17 @@ describe("runAuthList", () => {
 		const joined = lines.join("\n");
 		expect(joined).toMatch(/✓ doppler — workplace: acme/);
 		expect(joined).toMatch(/✗ infisical — expired/);
+	});
+
+	it("renders a skip bullet for a provider whose token cannot be retrieved", async () => {
+		// Empty-string password: findCredentials includes it (listed) but
+		// !("") is true so runAuthCheck returns skip (token treated as absent).
+		store.set("com.theholocron.cli::ghost", "");
+		const { print, lines } = collect();
+		await runAuthList({
+			print,
+			importer: async () => ({ verifyToken: async () => ({ ok: true as const, subject: "x" }) }),
+		});
+		expect(lines.join("\n")).toMatch(/· ghost/);
 	});
 });

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // In-memory keyring simulator — same shape as keyring.test.ts.
 const store = new Map<string, string>();
+// Set to true in a test to make setPassword throw (simulates keyring unavailable).
+let keyringFails = false;
 
 vi.mock("@napi-rs/keyring", () => {
 	class Entry {
@@ -10,6 +12,7 @@ vi.mock("@napi-rs/keyring", () => {
 			this.key = `${service}::${username}`;
 		}
 		setPassword(pw: string): void {
+			if (keyringFails) throw new Error("keyring unavailable");
 			store.set(this.key, pw);
 		}
 		getPassword(): string | null {
@@ -168,6 +171,25 @@ describe("runAuthSet", () => {
 		});
 		expect(result.status).toBe("ok");
 	});
+
+	it("fails when the keyring is unavailable", async () => {
+		keyringFails = true;
+		const { print, lines } = collect();
+		try {
+			const result = await runAuthSet({
+				provider: "doppler",
+				positional: "dp.pt.abc",
+				env: {},
+				importer: async () => ({ verifyToken: async () => ({ ok: true as const, subject: "test" }) }),
+				print,
+			});
+			expect(result.status).toBe("fail");
+			expect(result.message).toBe("keyring unavailable");
+			expect(lines.join("\n")).toMatch(/keyring unavailable/);
+		} finally {
+			keyringFails = false;
+		}
+	});
 });
 
 describe("runAuthUnset", () => {
@@ -277,24 +299,18 @@ describe("runAuthCheck", () => {
 		expect(result.message).toBe("bad string error");
 		expect(lines.join("\n")).toMatch(/cannot verify/);
 	});
-});
 
-describe("runAuthCheck", () => {
-	describe("showSpinner: false", () => {
-		it("skips the spinner and verifies directly", async () => {
-			store.set("com.theholocron.cli::doppler", "dp.pt.abc");
-			const { print, lines } = collect();
-			const result = await runAuthCheck({
-				provider: "doppler",
-				importer: async () => ({
-					verifyToken: async () => ({ ok: true as const, subject: "workplace: acme" }),
-				}),
-				print,
-				showSpinner: false,
-			});
-			expect(result.status).toBe("ok");
-			expect(lines.join("\n")).toMatch(/doppler: ok — workplace: acme/);
+	it("skips the spinner when showSpinner is false", async () => {
+		store.set("com.theholocron.cli::doppler", "dp.pt.abc");
+		const { print, lines } = collect();
+		const result = await runAuthCheck({
+			provider: "doppler",
+			importer: async () => ({ verifyToken: async () => ({ ok: true as const, subject: "workplace: acme" }) }),
+			print,
+			showSpinner: false,
 		});
+		expect(result.status).toBe("ok");
+		expect(lines.join("\n")).toMatch(/doppler: ok — workplace: acme/);
 	});
 });
 

--- a/packages/cli/src/__tests__/progress.test.ts
+++ b/packages/cli/src/__tests__/progress.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("ora", () => {
+	const spinner = { succeed: vi.fn(), fail: vi.fn() };
+	return { default: vi.fn(() => ({ start: () => spinner, ...spinner })) };
+});
+
+import ora from "ora";
+import { withSpinner } from "../ui/progress.js";
+
+describe("withSpinner", () => {
+	describe("non-TTY (isTTY = false)", () => {
+		it("runs fn directly without creating a spinner", async () => {
+			Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+			const fn = vi.fn(async () => 42);
+
+			const result = await withSpinner("label", fn);
+
+			expect(result).toBe(42);
+			expect(ora).not.toHaveBeenCalled();
+		});
+
+		it("propagates errors from fn", async () => {
+			Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+
+			await expect(
+				withSpinner("label", async () => {
+					throw new Error("boom");
+				})
+			).rejects.toThrow("boom");
+		});
+	});
+
+	describe("TTY (isTTY = true)", () => {
+		beforeEach(() => {
+			Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+			vi.mocked(ora).mockClear();
+		});
+
+		afterEach(() => {
+			Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+		});
+
+		it("starts a spinner, calls fn, and marks success", async () => {
+			const fn = vi.fn(async () => "done");
+
+			const result = await withSpinner("doing work", fn);
+
+			expect(result).toBe("done");
+			expect(ora).toHaveBeenCalledWith("doing work");
+			const spinner = vi.mocked(ora).mock.results[0]!.value as { succeed: ReturnType<typeof vi.fn> };
+			expect(spinner.succeed).toHaveBeenCalled();
+		});
+
+		it("marks the spinner failed and re-throws when fn throws", async () => {
+			await expect(
+				withSpinner("doing work", async () => {
+					throw new Error("network error");
+				})
+			).rejects.toThrow("network error");
+
+			const spinner = vi.mocked(ora).mock.results[0]!.value as { fail: ReturnType<typeof vi.fn> };
+			expect(spinner.fail).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -19,6 +19,8 @@
 
 import { resolvePluginPackage } from "../config.js";
 import { deleteToken, getToken, listStoredProviders, setToken } from "../keyring.js";
+import { withSpinner } from "../ui/progress.js";
+import { style } from "../ui/style.js";
 
 // ── Plugin-level export shapes (mirrored on every plugin) ────────────
 
@@ -92,12 +94,12 @@ export async function runAuthSet(input: RunAuthSetInput): Promise<AuthCommandSta
 	const packageName = resolvePluginPackage(provider);
 
 	if (!token) {
-		print(`no token supplied for \`${provider}\`.`);
-		print(`  pass as positional arg: holocron auth set ${provider} <token>`);
-		print(`  or via env: HOLOCRON_${provider.toUpperCase()}_TOKEN / ${provider.toUpperCase()}_TOKEN`);
+		print(style.fail(`no token supplied for \`${provider}\`.`));
+		print(style.hint(`  pass as positional arg: holocron auth set ${provider} <token>`));
+		print(style.hint(`  or via env: HOLOCRON_${provider.toUpperCase()}_TOKEN / ${provider.toUpperCase()}_TOKEN`));
 		const hint = await tryLoadHint(importer, packageName);
 		if (hint) {
-			print(`  hint: ${hint}`);
+			print(style.hint(`  hint: ${hint}`));
 		}
 		return { status: "fail", message: "no token supplied" };
 	}
@@ -109,27 +111,27 @@ export async function runAuthSet(input: RunAuthSetInput): Promise<AuthCommandSta
 		if (typeof module.verifyToken === "function") {
 			const verified = await module.verifyToken(token);
 			if (!verified.ok) {
-				print(`token rejected by ${provider}: ${verified.message}`);
-				if (module.AUTH_HINT) print(`  hint: ${module.AUTH_HINT}`);
+				print(style.fail(`token rejected by ${provider}: ${verified.message}`));
+				if (module.AUTH_HINT) print(style.hint(`  hint: ${module.AUTH_HINT}`));
 				return { status: "fail", message: verified.message };
 			}
 			subject = verified.subject;
 		} else {
-			print(`(${provider} plugin has no verifyToken; storing without verification)`);
+			print(style.warn(`${provider} plugin has no verifyToken; storing without verification`));
 		}
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : String(err);
-		print(`cannot verify token — failed to load ${packageName}: ${msg}`);
-		print(`  storing token anyway; run 'holocron auth check ${provider}' once the plugin is installed`);
+		print(style.warn(`cannot verify token — failed to load ${packageName}: ${msg}`));
+		print(style.hint(`  storing token anyway; run 'holocron auth check ${provider}' once the plugin is installed`));
 	}
 
 	const stored = setToken(provider, token);
 	if (!stored) {
-		print(`keyring unavailable — token not stored. Use env vars instead.`);
+		print(style.fail(`keyring unavailable — token not stored. Use env vars instead.`));
 		return { status: "fail", message: "keyring unavailable" };
 	}
 
-	print(`stored ${provider} token${subject ? ` (${subject})` : ""}`);
+	print(style.success(`stored ${provider} token${subject ? ` (${subject})` : ""}`));
 	return { status: "ok", ...(subject ? { message: subject } : {}) };
 }
 
@@ -142,10 +144,10 @@ export function runAuthUnset(input: RunAuthUnsetInput): AuthCommandStatus {
 	const print = input.print ?? ((l: string) => console.log(l));
 	const removed = deleteToken(input.provider);
 	if (removed) {
-		print(`removed ${input.provider} token`);
+		print(style.success(`removed ${input.provider} token`));
 		return { status: "ok" };
 	}
-	print(`no stored token for ${input.provider}`);
+	print(style.dim(`no stored token for ${input.provider}`));
 	return { status: "skip", message: "nothing to remove" };
 }
 
@@ -162,7 +164,7 @@ export async function runAuthCheck(input: RunAuthCheckInput): Promise<AuthComman
 
 	const token = getToken(provider);
 	if (!token) {
-		print(`no stored token for ${provider}`);
+		print(style.dim(`no stored token for ${provider}`));
 		return { status: "skip", message: "no stored token" };
 	}
 
@@ -170,20 +172,20 @@ export async function runAuthCheck(input: RunAuthCheckInput): Promise<AuthComman
 	try {
 		const module = await importer(packageName);
 		if (typeof module.verifyToken !== "function") {
-			print(`${provider}: token stored (plugin has no verifyToken; can't confirm validity)`);
+			print(style.warn(`${provider}: token stored (plugin has no verifyToken; can't confirm validity)`));
 			return { status: "ok", message: "stored, unverified" };
 		}
-		const verified = await module.verifyToken(token);
+		const verified = await withSpinner(`Verifying ${provider} token…`, () => module.verifyToken!(token));
 		if (verified.ok) {
-			print(`${provider}: ok — ${verified.subject}`);
+			print(style.success(`${provider}: ok — ${verified.subject}`));
 			return { status: "ok", message: verified.subject };
 		}
-		print(`${provider}: rejected — ${verified.message}`);
-		if (module.AUTH_HINT) print(`  hint: ${module.AUTH_HINT}`);
+		print(style.fail(`${provider}: rejected — ${verified.message}`));
+		if (module.AUTH_HINT) print(style.hint(`  hint: ${module.AUTH_HINT}`));
 		return { status: "fail", message: verified.message };
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : String(err);
-		print(`${provider}: cannot verify — ${msg}`);
+		print(style.fail(`${provider}: cannot verify — ${msg}`));
 		return { status: "fail", message: msg };
 	}
 }
@@ -199,15 +201,17 @@ export async function runAuthList(input: RunAuthListInput = {}): Promise<AuthCom
 	const providers = listStoredProviders();
 
 	if (providers.length === 0) {
-		print("no stored tokens.");
-		print("run: holocron auth set <provider> <token>");
+		print(style.dim("no stored tokens."));
+		print(style.hint("run: holocron auth set <provider> <token>"));
 		return { status: "ok", message: "none" };
 	}
 
 	for (const provider of providers.sort()) {
 		const check = await runAuthCheck({ provider, importer, print: () => {} });
-		const icon = check.status === "ok" ? "✓" : check.status === "fail" ? "✗" : "·";
-		print(`  ${icon} ${provider}${check.message ? ` — ${check.message}` : ""}`);
+		const label = `${provider}${check.message ? ` — ${check.message}` : ""}`;
+		if (check.status === "ok") print(`  ${style.success(label)}`);
+		else if (check.status === "fail") print(`  ${style.fail(label)}`);
+		else print(`  ${style.dim(`· ${label}`)}`);
 	}
 	return { status: "ok" };
 }

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -155,6 +155,8 @@ export interface RunAuthCheckInput {
 	provider: string;
 	importer?: AuthImporter;
 	print?: AuthPrint;
+	/** Set to false to suppress the ora spinner (e.g. when called from runAuthList). */
+	showSpinner?: boolean;
 }
 
 export async function runAuthCheck(input: RunAuthCheckInput): Promise<AuthCommandStatus> {
@@ -175,7 +177,10 @@ export async function runAuthCheck(input: RunAuthCheckInput): Promise<AuthComman
 			print(style.warn(`${provider}: token stored (plugin has no verifyToken; can't confirm validity)`));
 			return { status: "ok", message: "stored, unverified" };
 		}
-		const verified = await withSpinner(`Verifying ${provider} token…`, () => module.verifyToken!(token));
+		const verify = () => module.verifyToken!(token);
+		const verified = input.showSpinner !== false
+			? await withSpinner(`Verifying ${provider} token…`, verify)
+			: await verify();
 		if (verified.ok) {
 			print(style.success(`${provider}: ok — ${verified.subject}`));
 			return { status: "ok", message: verified.subject };
@@ -207,7 +212,7 @@ export async function runAuthList(input: RunAuthListInput = {}): Promise<AuthCom
 	}
 
 	for (const provider of providers.sort()) {
-		const check = await runAuthCheck({ provider, importer, print: () => {} });
+		const check = await runAuthCheck({ provider, importer, print: () => {}, showSpinner: false });
 		const label = `${provider}${check.message ? ` — ${check.message}` : ""}`;
 		if (check.status === "ok") print(`  ${style.success(label)}`);
 		else if (check.status === "fail") print(`  ${style.fail(label)}`);

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -178,9 +178,8 @@ export async function runAuthCheck(input: RunAuthCheckInput): Promise<AuthComman
 			return { status: "ok", message: "stored, unverified" };
 		}
 		const verify = () => module.verifyToken!(token);
-		const verified = input.showSpinner !== false
-			? await withSpinner(`Verifying ${provider} token…`, verify)
-			: await verify();
+		const verified =
+			input.showSpinner !== false ? await withSpinner(`Verifying ${provider} token…`, verify) : await verify();
 		if (verified.ok) {
 			print(style.success(`${provider}: ok — ${verified.subject}`));
 			return { status: "ok", message: verified.subject };

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -70,14 +70,12 @@ export async function runDeploy(input: RunDeployInput): Promise<DeployReport> {
 	}
 
 	try {
-		const record = await withSpinner(
-			`Deploying ${input.branch}${input.target ? ` → ${input.target}` : ""}…`,
-			() =>
-				deploy.triggerDeployment({
-					projectId: input.projectId,
-					branch: input.branch,
-					...(input.target ? { target: input.target } : {}),
-				})
+		const record = await withSpinner(`Deploying ${input.branch}${input.target ? ` → ${input.target}` : ""}…`, () =>
+			deploy.triggerDeployment({
+				projectId: input.projectId,
+				branch: input.branch,
+				...(input.target ? { target: input.target } : {}),
+			})
 		);
 		print(`  ${style.success(`${record.status} — ${record.url}`)}`);
 		return { deployment: record, status: "ok" };

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -14,6 +14,8 @@
 import type { Deployment, DeploymentRecord, DeploymentTrigger } from "../capabilities/index.js";
 import type { LoadedConfig } from "../load-config.js";
 import { PluginLoader, type RuntimeContext } from "../loader.js";
+import { withSpinner } from "../ui/progress.js";
+import { style } from "../ui/style.js";
 
 export type DeployPrintLine = (line: string) => void;
 
@@ -45,9 +47,11 @@ export async function runDeploy(input: RunDeployInput): Promise<DeployReport> {
 	const dryRun = input.context.dryRun ?? false;
 
 	print(
-		`Holocron deploy — branch=${input.branch}${
-			input.target ? `, target=${input.target}` : " (preview)"
-		}${dryRun ? " (dry-run)" : ""}`
+		style.header(
+			`Holocron deploy — branch=${input.branch}${
+				input.target ? `, target=${input.target}` : " (preview)"
+			}${dryRun ? " (dry-run)" : ""}`
+		)
 	);
 
 	if (!loader.has("deployment")) {
@@ -61,21 +65,25 @@ export async function runDeploy(input: RunDeployInput): Promise<DeployReport> {
 		const message = `would: ${deploy.providerName}.triggerDeployment(projectId=${input.projectId}, branch=${input.branch}${
 			input.target ? `, target=${input.target}` : ""
 		})`;
-		print(`  … ${message}`);
+		print(`  ${style.dim(`… ${message}`)}`);
 		return { deployment: null, status: "dry-run", message };
 	}
 
 	try {
-		const record = await deploy.triggerDeployment({
-			projectId: input.projectId,
-			branch: input.branch,
-			...(input.target ? { target: input.target } : {}),
-		});
-		print(`  ✓ ${record.status} — ${record.url}`);
+		const record = await withSpinner(
+			`Deploying ${input.branch}${input.target ? ` → ${input.target}` : ""}…`,
+			() =>
+				deploy.triggerDeployment({
+					projectId: input.projectId,
+					branch: input.branch,
+					...(input.target ? { target: input.target } : {}),
+				})
+		);
+		print(`  ${style.success(`${record.status} — ${record.url}`)}`);
 		return { deployment: record, status: "ok" };
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		print(`  ✗ ${message}`);
+		print(`  ${style.fail(message)}`);
 		return { deployment: null, status: "fail", message };
 	}
 }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -17,6 +17,8 @@ import type { Auth, Ci, Issues, Secrets, Source, Vault } from "../capabilities/i
 import { CARDINALITY } from "../capabilities/index.js";
 import type { LoadedConfig } from "../load-config.js";
 import { PluginLoader, type RuntimeContext } from "../loader.js";
+import { withSpinner } from "../ui/progress.js";
+import { style } from "../ui/style.js";
 
 export type DoctorPrintLine = (line: string) => void;
 
@@ -45,13 +47,13 @@ export interface RunDoctorInput {
 export async function runDoctor(input: RunDoctorInput): Promise<DoctorReport> {
 	const print = input.print ?? ((line: string) => console.log(line));
 	const loader = input.loader ?? new PluginLoader(input.loaded.resolved, input.context);
-	await loader.load();
+	await withSpinner("Loading plugins…", () => loader.load());
 
 	const rows: DoctorRow[] = [];
 	const config = input.loaded.resolved;
 
-	print(`Holocron doctor — ${config.name}`);
-	print(`  config: ${input.loaded.filepath}`);
+	print(style.header(`Holocron doctor — ${config.name}`));
+	print(style.dim(`  config: ${input.loaded.filepath}`));
 	print("");
 
 	for (const key of loader.loadedKeys()) {
@@ -83,8 +85,10 @@ export async function runDoctor(input: RunDoctorInput): Promise<DoctorReport> {
 
 	// Render rows
 	for (const row of rows) {
-		const icon = row.status === "ok" ? "✓" : row.status === "fail" ? "✗" : "·";
-		print(`  ${icon} ${pad(row.capability, 14)} via ${pad(row.provider, 14)}  ${row.message}`);
+		const label = `${pad(row.capability, 14)} via ${pad(row.provider, 14)}  ${row.message}`;
+		if (row.status === "ok") print(`  ${style.success(label)}`);
+		else if (row.status === "fail") print(`  ${style.fail(label)}`);
+		else print(`  ${style.dim(`· ${label}`)}`);
 	}
 
 	const summary = rows.reduce(
@@ -95,8 +99,9 @@ export async function runDoctor(input: RunDoctorInput): Promise<DoctorReport> {
 		{ ok: 0, fail: 0, skip: 0 }
 	);
 
+	const summaryLine = `${summary.ok} ok, ${summary.fail} fail, ${summary.skip} skipped`;
 	print("");
-	print(`  ${summary.ok} ok, ${summary.fail} fail, ${summary.skip} skipped`);
+	print(summary.fail > 0 ? style.fail(summaryLine) : style.success(summaryLine));
 
 	return { rows, summary };
 }

--- a/packages/cli/src/commands/secrets-sync.ts
+++ b/packages/cli/src/commands/secrets-sync.ts
@@ -24,6 +24,8 @@
 import type { Deployment, DeploymentTarget, Secrets, Vault } from "../capabilities/index.js";
 import type { LoadedConfig } from "../load-config.js";
 import { PluginLoader, type RuntimeContext } from "../loader.js";
+import { withSpinner } from "../ui/progress.js";
+import { style } from "../ui/style.js";
 
 export type SyncPrintLine = (line: string) => void;
 
@@ -59,13 +61,13 @@ export interface RunSecretsSyncInput {
 export async function runSecretsSync(input: RunSecretsSyncInput): Promise<SyncReport> {
 	const print = input.print ?? ((line: string) => console.log(line));
 	const loader = input.loader ?? new PluginLoader(input.loaded.resolved, input.context);
-	await loader.load();
+	await withSpinner("Loading plugins…", () => loader.load());
 
 	const dryRun = input.context.dryRun ?? false;
 	const targets = input.targets ?? (["production", "preview"] as DeploymentTarget[]);
 
-	print(`Holocron secrets sync — environment ${input.environmentId}${dryRun ? " (dry-run)" : ""}`);
-	print(`  vault: ${vaultProviderName(loader)}`);
+	print(style.header(`Holocron secrets sync — environment ${input.environmentId}${dryRun ? " (dry-run)" : ""}`));
+	print(style.dim(`  vault: ${vaultProviderName(loader)}`));
 	print("");
 
 	// ── Read the vault ─────────────────────────────────────────────────
@@ -75,9 +77,11 @@ export async function runSecretsSync(input: RunSecretsSyncInput): Promise<SyncRe
 			`vault provider (${vault.providerName}) does not implement readEnvironment — sync needs bulk env reads`
 		);
 	}
-	const envVars = await vault.readEnvironment(input.environmentId);
+	const envVars = await withSpinner(`Reading vault environment ${input.environmentId}…`, () =>
+		vault.readEnvironment!(input.environmentId)
+	);
 	const keys = Object.keys(envVars).sort();
-	print(`  → read ${keys.length} keys from vault`);
+	print(style.step(`read ${keys.length} keys from vault`));
 	print("");
 
 	const rows: SyncRow[] = [];
@@ -85,7 +89,7 @@ export async function runSecretsSync(input: RunSecretsSyncInput): Promise<SyncRe
 	// ── Push to `secrets` (CI/Actions secrets) ─────────────────────────
 	if (loader.has("secrets")) {
 		const secrets = loader.get("secrets") as Secrets;
-		print("  → secrets (repo scope)");
+		print(style.step("secrets (repo scope)"));
 		for (const key of keys) {
 			rows.push(
 				await runRow(`secrets:${secrets.providerName}`, "scope=repo", key, dryRun, async () => {
@@ -100,7 +104,7 @@ export async function runSecretsSync(input: RunSecretsSyncInput): Promise<SyncRe
 	if (loader.has("deployment")) {
 		const deploy = loader.get("deployment") as Deployment;
 		if (!input.projectId) {
-			print("  → deployment");
+			print(style.step("deployment"));
 			const row: SyncRow = {
 				destination: `deployment:${deploy.providerName}`,
 				scope: "no projectId",
@@ -112,7 +116,7 @@ export async function runSecretsSync(input: RunSecretsSyncInput): Promise<SyncRe
 			print(formatRow(row));
 		} else {
 			for (const target of targets) {
-				print(`  → deployment (target=${target})`);
+				print(style.step(`deployment (target=${target})`));
 				for (const key of keys) {
 					rows.push(
 						await runRow(`deployment:${deploy.providerName}`, `target=${target}`, key, dryRun, async () => {
@@ -137,11 +141,10 @@ export async function runSecretsSync(input: RunSecretsSyncInput): Promise<SyncRe
 	);
 
 	print("");
-	print(
-		`  ${summary.ok} ok, ${summary.fail} fail, ${summary.skip} skipped${
-			dryRun ? `, ${summary.dryRun} would-do` : ""
-		}`
-	);
+	const summaryLine = `${summary.ok} ok, ${summary.fail} fail, ${summary.skip} skipped${
+		dryRun ? `, ${summary.dryRun} would-do` : ""
+	}`;
+	print(summary.fail > 0 ? style.fail(summaryLine) : style.success(summaryLine));
 
 	return { rows, summary };
 }
@@ -173,9 +176,12 @@ async function runRow(
 }
 
 function formatRow(row: SyncRow): string {
-	const icon = row.status === "ok" ? "✓" : row.status === "fail" ? "✗" : row.status === "dry-run" ? "…" : "·";
-	const detail = row.message ? `  (${row.message})` : "";
-	return `    ${icon} ${row.key}${detail}`;
+	const detail = row.message ? style.dim(`  (${row.message})`) : "";
+	const label = `${row.key}${detail}`;
+	if (row.status === "ok") return `    ${style.success(label)}`;
+	if (row.status === "fail") return `    ${style.fail(label)}`;
+	if (row.status === "dry-run") return `    ${style.dim(`… ${label}`)}`;
+	return `    ${style.dim(`· ${label}`)}`;
 }
 
 function vaultProviderName(loader: PluginLoader): string {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -23,6 +23,8 @@ import { join } from "node:path";
 
 import type { Auth, Deployment, Environments, RepoSettings, Source, Tooling, Vault } from "../capabilities/index.js";
 import { ProviderApiError } from "../capabilities/index.js";
+import { withSpinner } from "../ui/progress.js";
+import { style } from "../ui/style.js";
 import type { LoadedConfig } from "../load-config.js";
 import { PluginLoader, type RuntimeContext } from "../loader.js";
 import {
@@ -427,7 +429,7 @@ export interface RunSetupInput {
 export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	const print = input.print ?? ((line: string) => console.log(line));
 	const loader = input.loader ?? new PluginLoader(input.loaded.resolved, input.context);
-	await loader.load();
+	await withSpinner("Loading plugins…", () => loader.load());
 
 	const config = input.loaded.resolved;
 	const dryRun = input.context.dryRun ?? false;
@@ -435,14 +437,14 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	const repo = config.repo;
 	const effectivePreset = repo?.protection;
 
-	print(`Holocron setup — ${config.name}${dryRun ? " (dry-run)" : ""}`);
-	print(`  config: ${input.loaded.filepath}`);
+	print(style.header(`Holocron setup — ${config.name}${dryRun ? " (dry-run)" : ""}`));
+	print(style.dim(`  config: ${input.loaded.filepath}`));
 	print("");
 
 	// ── source: security toggles + repo policy ──────────────────────────
 	if (loader.has("source")) {
 		const source = loader.get("source") as Source;
-		print("  → source");
+		print(style.step("source"));
 		for (const method of [
 			"enableVulnerabilityAlerts",
 			"enableAutomatedSecurityFixes",
@@ -508,7 +510,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	const workflows = config.workflows;
 	if (loader.has("source") && workflows && workflows.length > 0) {
 		const source = loader.get("source") as Source;
-		print("  → workflows");
+		print(style.step("workflows"));
 		for (const entry of workflows) {
 			const name = typeof entry === "string" ? entry : entry.name;
 			const withOverrides = typeof entry === "object" ? entry.with : undefined;
@@ -631,7 +633,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	// ── environments ────────────────────────────────────────────────────
 	if (loader.has("environments")) {
 		const envs = loader.get("environments") as Environments;
-		print("  → environments");
+		print(style.step("environments"));
 		for (const envName of ["staging", "production"]) {
 			steps.push(
 				await runStep("environments", `upsert ${envName}`, dryRun, async () => {
@@ -645,7 +647,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	// ── deployment: ensure project ──────────────────────────────────────
 	if (loader.has("deployment")) {
 		const deploy = loader.get("deployment") as Deployment;
-		print("  → deployment");
+		print(style.step("deployment"));
 		steps.push(
 			await runStep("deployment", `ensureProject ${config.name}`, dryRun, async () => {
 				await deploy.ensureProject({ name: config.name });
@@ -657,7 +659,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	// ── auth: ensure webhook app (optional method) ──────────────────────
 	if (loader.has("auth")) {
 		const auth = loader.get("auth") as Auth;
-		print("  → auth");
+		print(style.step("auth"));
 		if (auth.ensureWebhookApp) {
 			steps.push(
 				await runStep("auth", "ensureWebhookApp", dryRun, async () => {
@@ -680,7 +682,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	// ── vault: bootstrap project + configs, then read-only probe ───────
 	if (loader.has("vault")) {
 		const vault = loader.get("vault") as Vault;
-		print("  → vault");
+		print(style.step("vault"));
 
 		// ensureProject — providers that have a top-level container.
 		if (vault.ensureProject) {
@@ -731,7 +733,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	// ── tooling: sync each (many cardinality) ───────────────────────────
 	if (loader.has("tooling")) {
 		const tools = loader.get("tooling") as Tooling[];
-		print("  → tooling");
+		print(style.step("tooling"));
 		for (const tool of tools) {
 			steps.push(
 				await runStep("tooling", `${tool.providerName}.sync`, dryRun, async () => {
@@ -754,28 +756,27 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	);
 
 	print("");
-	print(
-		`  ${summary.ok} ok, ${summary.fail} fail, ${summary.skip} skipped${
-			dryRun ? `, ${summary.dryRun} would-do` : ""
-		}`
-	);
+	const summaryLine = `  ${summary.ok} ok, ${summary.fail} fail, ${summary.skip} skipped${
+		dryRun ? `, ${summary.dryRun} would-do` : ""
+	}`;
+	print(summary.fail > 0 ? style.fail(summaryLine.trim()) : style.success(summaryLine.trim()));
 
 	if (steps.some((s) => s.reason === "permissions")) {
 		print("");
-		print("  ⚠  Some steps failed with 403 (insufficient token permissions).");
-		print("     These operations require a temporary fine-grained PAT with the");
-		print("     following repository permissions:");
+		print(style.warn("Some steps failed with 403 (insufficient token permissions)."));
+		print(style.hint("     These operations require a temporary fine-grained PAT with the"));
+		print(style.hint("     following repository permissions:"));
 		print("");
-		print("       · Administration          — read and write");
-		print("       · Code scanning alerts    — read and write");
-		print("       · Contents                — read and write");
-		print("       · Secret scanning alerts  — read and write");
-		print("       · Workflows               — read and write");
-		print("       · Metadata                — read (added automatically)");
+		print(style.hint("       · Administration          — read and write"));
+		print(style.hint("       · Code scanning alerts    — read and write"));
+		print(style.hint("       · Contents                — read and write"));
+		print(style.hint("       · Secret scanning alerts  — read and write"));
+		print(style.hint("       · Workflows               — read and write"));
+		print(style.hint("       · Metadata                — read (added automatically)"));
 		print("");
-		print("     Create one at: https://github.com/settings/personal-access-tokens/new");
-		print("     Then re-run:   holocron setup --token <your-temp-pat>");
-		print("     You can revoke it immediately after setup completes.");
+		print(style.hint("     Create one at: https://github.com/settings/personal-access-tokens/new"));
+		print(style.hint("     Then re-run:   holocron setup --token <your-temp-pat>"));
+		print(style.hint("     You can revoke it immediately after setup completes."));
 	}
 
 	return { steps, summary };
@@ -831,8 +832,11 @@ function classify403(err: ProviderApiError): FailReason {
 }
 
 function formatStep(step: SetupStepResult): string {
-	const icon = step.status === "ok" ? "✓" : step.status === "fail" ? "✗" : step.status === "dry-run" ? "…" : "·";
 	const tag = step.reason === "permissions" ? " [permissions]" : step.reason === "plan" ? " [plan restriction]" : "";
-	const detail = step.message ? `  (${step.message})` : "";
-	return `    ${icon} ${step.step}${tag}${detail}`;
+	const detail = step.message ? style.dim(`  (${step.message})`) : "";
+	const label = `${step.step}${tag}${detail}`;
+	if (step.status === "ok") return `    ${style.success(label)}`;
+	if (step.status === "fail") return `    ${style.fail(label)}`;
+	if (step.status === "dry-run") return `    ${style.dim(`… ${label}`)}`;
+	return `    ${style.dim(`· ${label}`)}`;
 }

--- a/packages/cli/src/ui/progress.ts
+++ b/packages/cli/src/ui/progress.ts
@@ -1,0 +1,20 @@
+import ora from "ora";
+
+/**
+ * Runs `fn`, showing an ora spinner for its duration in TTY environments.
+ * In non-TTY environments (CI, pipes, tests) the spinner is skipped entirely.
+ */
+export async function withSpinner<T>(label: string, fn: () => Promise<T>): Promise<T> {
+	if (!process.stdout.isTTY) {
+		return fn();
+	}
+	const spinner = ora(label).start();
+	try {
+		const result = await fn();
+		spinner.succeed();
+		return result;
+	} catch (err) {
+		spinner.fail();
+		throw err;
+	}
+}

--- a/packages/cli/src/ui/style.ts
+++ b/packages/cli/src/ui/style.ts
@@ -1,0 +1,11 @@
+import chalk from "chalk";
+
+export const style = {
+	success: (msg: string) => `${chalk.green("✓")} ${msg}`,
+	warn: (msg: string) => `${chalk.yellow("⚠")} ${msg}`,
+	fail: (msg: string) => `${chalk.red("✗")} ${msg}`,
+	step: (msg: string) => `${chalk.cyan("→")} ${msg}`,
+	hint: (msg: string) => chalk.dim(msg),
+	dim: (msg: string) => chalk.dim(msg),
+	header: (msg: string) => chalk.bold(msg),
+};

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
 	plugins: [...(base.plugins ?? []), rawYml()],
 	test: {
 		...base.test,
+		// Override any FORCE_COLOR set by the outer environment (e.g. CI sets
+		// FORCE_COLOR=1). Tests assert on plain-text strings without ANSI codes.
+		env: { ...base.test?.env, FORCE_COLOR: "0" },
 		coverage: {
 			...base.test?.coverage,
 			exclude: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ catalogs:
     '@vitest/eslint-plugin':
       specifier: ^1.6.23
       version: 1.6.23
+    chalk:
+      specifier: ^5.4.1
+      version: 5.6.2
     eslint:
       specifier: ^10.7.0
       version: 10.7.0
@@ -72,6 +75,9 @@ catalogs:
     globals:
       specifier: ^17.7.0
       version: 17.7.0
+    ora:
+      specifier: ^8.2.0
+      version: 8.2.0
     tsdown:
       specifier: ^0.22.3
       version: 0.22.3
@@ -206,6 +212,12 @@ importers:
       '@theholocron/http-client':
         specifier: ^0.11.3
         version: 0.11.3
+      chalk:
+        specifier: 'catalog:'
+        version: 5.6.2
+      ora:
+        specifier: 'catalog:'
+        version: 8.2.0
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
@@ -3476,6 +3488,10 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
+
   log-symbols@7.0.1:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
     engines: {node: '>=18'}
@@ -3772,6 +3788,10 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
 
   ora@9.4.1:
     resolution: {integrity: sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==}
@@ -4247,6 +4267,10 @@ packages:
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
 
   stdin-discarder@0.3.2:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
@@ -7644,6 +7668,11 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
+
   log-symbols@7.0.1:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -7898,6 +7927,18 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
 
   ora@9.4.1:
     dependencies:
@@ -8464,6 +8505,8 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@4.2.0: {}
+
+  stdin-discarder@0.2.2: {}
 
   stdin-discarder@0.3.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,8 @@ catalog:
   eslint: ^10.7.0
   eslint-plugin-n: ^18.2.2
   globals: ^17.7.0
+  chalk: ^5.4.1
+  ora: ^8.2.0
   tsdown: ^0.22.3
   tsx: ^4.22.4
   vitest: ^4.1.10


### PR DESCRIPTION
## Summary

- Adds `packages/cli/src/ui/style.ts` with typed chalk helpers: `success()`, `warn()`, `fail()`, `step()`, `hint()`, `dim()`, `header()`
- Adds `packages/cli/src/ui/progress.ts` with `withSpinner(label, fn)` wrapping ora; no-ops silently in non-TTY environments (CI, pipes, tests)
- Migrates `holocron setup`, `holocron doctor`, `holocron secrets sync`, `holocron deploy`, and `holocron auth check/set/unset/list` to use both

## What changed

**Color-coded output** — section headers are bold, step icons are green/red/yellow/dim instead of plain text symbols.

**Spinners during async I/O** — plugin loading, vault environment reads, deployment triggers, and token verification now show an ora spinner while they run. The spinner disappears cleanly when done (✔) or fails (✖), then normal step-by-step output follows.

**Non-TTY safe** — `withSpinner` checks `process.stdout.isTTY` before creating a spinner, so test output remains clean and CI logs stay free of ANSI noise.

## Test plan

- [x] `pnpm --filter @theholocron/cli test` — 325 tests pass (no new failures, no spinner noise in test output)
- [x] `pnpm --filter @theholocron/cli typecheck` — clean
- [x] `pnpm --filter @theholocron/cli lint` — clean

Closes: #114
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->