### PR TITLE
fix(cli): sync keywords/description without a provider token

### DIFF
--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { resolveConfig } from "../config.js";
+import { AuthError } from "../auth-resolver.js";
 import { runSync } from "../commands/sync.js";
 import type { LoadedConfig } from "../load-config.js";
 import { PluginLoader, type PluginImporter } from "../loader.js";
@@ -478,7 +479,7 @@ describe("runSync", () => {
 			expect(step?.message).toContain("no package.json");
 		});
 
-		it("still writes keywords when loader.load() throws (no provider token)", async () => {
+		it("still writes keywords when loader.load() throws AuthError (no provider token)", async () => {
 			await writeFile(
 				join(tmpDir, "package.json"),
 				JSON.stringify({ name: "demo", keywords: [] }, null, 2) + "\n"
@@ -488,8 +489,14 @@ describe("runSync", () => {
 				repo: { topics: ["cli", "typescript"] },
 				providers: { source: "github" },
 			});
-			// Importer throws — simulates missing provider token.
-			const loader = makeLoaderWith(loaded, {});
+			// Importer throws AuthError — simulates missing provider token.
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": {
+					createPlugin: () => {
+						throw new AuthError("no GitHub token found");
+					},
+				},
+			});
 
 			const report = await runSync({
 				loaded,
@@ -504,6 +511,25 @@ describe("runSync", () => {
 			expect(step?.message).toContain("2 keywords written");
 			const pkg = JSON.parse(await readFile(join(tmpDir, "package.json"), "utf8")) as { keywords: string[] };
 			expect(pkg.keywords).toEqual(["cli", "typescript"]);
+		});
+
+		it("re-throws non-AuthError load failures even for local-only steps", async () => {
+			const loaded = loadedFrom({
+				name: "demo",
+				repo: { topics: ["cli"] },
+				providers: { source: "github" },
+			});
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": {
+					createPlugin: () => {
+						throw new Error("plugin package corrupted");
+					},
+				},
+			});
+
+			await expect(
+				runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["keywords"], print: () => {} })
+			).rejects.toThrow();
 		});
 	});
 

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -477,6 +477,34 @@ describe("runSync", () => {
 			expect(step?.status).toBe("ok");
 			expect(step?.message).toContain("no package.json");
 		});
+
+		it("still writes keywords when loader.load() throws (no provider token)", async () => {
+			await writeFile(
+				join(tmpDir, "package.json"),
+				JSON.stringify({ name: "demo", keywords: [] }, null, 2) + "\n"
+			);
+			const loaded = loadedFrom({
+				name: "demo",
+				repo: { topics: ["cli", "typescript"] },
+				providers: { source: "github" },
+			});
+			// Importer throws — simulates missing provider token.
+			const loader = makeLoaderWith(loaded, {});
+
+			const report = await runSync({
+				loaded,
+				context: { repoRoot: tmpDir },
+				loader,
+				steps: ["keywords"],
+				print: () => {},
+			});
+
+			const step = report.steps.find((s) => s.step === "sync keywords");
+			expect(step?.status).toBe("ok");
+			expect(step?.message).toContain("2 keywords written");
+			const pkg = JSON.parse(await readFile(join(tmpDir, "package.json"), "utf8")) as { keywords: string[] };
+			expect(pkg.keywords).toEqual(["cli", "typescript"]);
+		});
 	});
 
 	it("skips sync description when no description is configured", async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -288,13 +288,13 @@ await yargs(hideBin(process.argv))
 	)
 	.command(
 		"sync [steps..]",
-		"Sync source-level state (labels, properties, topics) from config to the provider",
+		"Sync state from config to the provider and local files (labels, properties, topics, keywords, description)",
 		(y) =>
 			y
 				.positional("steps", {
 					type: "string",
 					array: true,
-					describe: "Steps to run: labels, properties, topics (default: all)",
+					describe: "Steps to run: labels, properties, topics, keywords, description (default: all)",
 				})
 				.option("repo", {
 					type: "string",

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -10,6 +10,9 @@ import type { SetupPrintLine, SetupReport, SetupStepResult } from "./setup.js";
 export const SYNC_STEPS = ["labels", "properties", "topics", "keywords", "description"] as const;
 export type SyncStep = (typeof SYNC_STEPS)[number];
 
+// Steps that write to the local filesystem only — no provider token needed.
+const LOCAL_STEPS = new Set<SyncStep>(["keywords", "description"]);
+
 export interface RunSyncInput {
 	loaded: LoadedConfig;
 	context: RuntimeContext;
@@ -21,12 +24,28 @@ export interface RunSyncInput {
 export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 	const print = input.print ?? ((line: string) => console.log(line));
 	const loader = input.loader ?? new PluginLoader(input.loaded.resolved, input.context);
-	await loader.load();
 
 	const config = input.loaded.resolved;
 	const dryRun = input.context.dryRun ?? false;
 	const requestedSteps = input.steps;
 	const steps: SetupStepResult[] = [];
+
+	// Remote steps (labels, properties, topics) always need a provider token.
+	// Local steps (keywords, description) write to disk and only optionally
+	// push to GitHub. Load plugins eagerly when remote steps are requested;
+	// for local-only runs, attempt a load for the optional GitHub sync but
+	// swallow auth errors so the command works without a token.
+	const needsProvider =
+		!requestedSteps || requestedSteps.some((s) => !LOCAL_STEPS.has(s as SyncStep));
+	if (needsProvider) {
+		await loader.load();
+	} else {
+		try {
+			await loader.load();
+		} catch {
+			// No provider token — local steps still run, GitHub sync skipped.
+		}
+	}
 
 	print(`Holocron sync — ${config.name}${dryRun ? " (dry-run)" : ""}`);
 	print(`  config: ${input.loaded.filepath}`);
@@ -40,6 +59,8 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 			if (requestedSteps !== undefined && !requestedSteps.includes(stepName)) {
 				continue;
 			}
+			// Local steps are handled below, outside this block.
+			if (LOCAL_STEPS.has(stepName)) continue;
 
 			if (stepName === "labels") {
 				if (source.syncLabels) {
@@ -117,61 +138,6 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 				}
 			}
 
-			if (stepName === "keywords") {
-				const topics = config.repo?.topics ?? [];
-				if (topics.length === 0) {
-					steps.push({
-						capability: "source",
-						step: "sync keywords",
-						status: "skip",
-						message: "no topics configured",
-					});
-					print(formatSyncStep(steps[steps.length - 1]!));
-				} else {
-					steps.push(
-						await runSyncStep("source", "sync keywords", dryRun, async () => {
-							const wrote = await writePackageJsonField(input.context.repoRoot, "keywords", topics);
-							return wrote
-								? `${topics.length} keywords written`
-								: `${topics.length} topics (no package.json)`;
-						})
-					);
-					print(formatSyncStep(steps[steps.length - 1]!));
-				}
-			}
-
-			if (stepName === "description") {
-				const description = config.description;
-				if (!description) {
-					steps.push({
-						capability: "source",
-						step: "sync description",
-						status: "skip",
-						message: "no description configured",
-					});
-					print(formatSyncStep(steps[steps.length - 1]!));
-				} else {
-					steps.push(
-						await runSyncStep("source", "sync description", dryRun, async () => {
-							const pkgWrote = await writePackageJsonField(
-								input.context.repoRoot,
-								"description",
-								description
-							);
-							const readmeWrote = await updateReadmeDescription(input.context.repoRoot, description);
-							if (source.syncDescription) {
-								await source.syncDescription(description);
-							}
-							const parts: string[] = [];
-							if (pkgWrote) parts.push("package.json");
-							if (readmeWrote) parts.push("README.md");
-							if (source.syncDescription) parts.push("GitHub");
-							return parts.length > 0 ? parts.join(", ") + " updated" : "description synced";
-						})
-					);
-					print(formatSyncStep(steps[steps.length - 1]!));
-				}
-			}
 		}
 
 		// Report unknown step names
@@ -186,6 +152,74 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 					});
 					print(formatSyncStep(steps[steps.length - 1]!));
 				}
+			}
+		}
+	}
+
+	// ── local-only steps (no provider token required) ──────────────────
+	// keywords and description write to package.json / README.md and
+	// optionally push to GitHub when source is loaded. They run outside
+	// the `if (loader.has("source"))` block so they work without a token.
+
+	for (const stepName of (["keywords", "description"] as const)) {
+		if (requestedSteps !== undefined && !requestedSteps.includes(stepName)) {
+			continue;
+		}
+
+		if (stepName === "keywords") {
+			const topics = config.repo?.topics ?? [];
+			if (topics.length === 0) {
+				steps.push({
+					capability: "local",
+					step: "sync keywords",
+					status: "skip",
+					message: "no topics configured",
+				});
+				print(formatSyncStep(steps[steps.length - 1]!));
+			} else {
+				steps.push(
+					await runSyncStep("local", "sync keywords", dryRun, async () => {
+						const wrote = await writePackageJsonField(input.context.repoRoot, "keywords", topics);
+						return wrote
+							? `${topics.length} keywords written`
+							: `${topics.length} topics (no package.json)`;
+					})
+				);
+				print(formatSyncStep(steps[steps.length - 1]!));
+			}
+		}
+
+		if (stepName === "description") {
+			const description = config.description;
+			if (!description) {
+				steps.push({
+					capability: "local",
+					step: "sync description",
+					status: "skip",
+					message: "no description configured",
+				});
+				print(formatSyncStep(steps[steps.length - 1]!));
+			} else {
+				const source = loader.has("source") ? (loader.get("source") as Source) : null;
+				steps.push(
+					await runSyncStep("local", "sync description", dryRun, async () => {
+						const pkgWrote = await writePackageJsonField(
+							input.context.repoRoot,
+							"description",
+							description
+						);
+						const readmeWrote = await updateReadmeDescription(input.context.repoRoot, description);
+						if (source?.syncDescription) {
+							await source.syncDescription(description);
+						}
+						const parts: string[] = [];
+						if (pkgWrote) parts.push("package.json");
+						if (readmeWrote) parts.push("README.md");
+						if (source?.syncDescription) parts.push("GitHub");
+						return parts.length > 0 ? parts.join(", ") + " updated" : "description synced";
+					})
+				);
+				print(formatSyncStep(steps[steps.length - 1]!));
 			}
 		}
 	}

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -2,6 +2,7 @@ import { access, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { Source } from "../capabilities/index.js";
+import { AuthError } from "../auth-resolver.js";
 import type { LoadedConfig } from "../load-config.js";
 import { PluginLoader, type RuntimeContext } from "../loader.js";
 import { CANONICAL_LABELS, STALE_LABELS } from "./setup.js";
@@ -41,8 +42,11 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 	} else {
 		try {
 			await loader.load();
-		} catch {
-			// No provider token — local steps still run, GitHub sync skipped.
+		} catch (err) {
+			// Only swallow auth errors (missing token). Any other load failure
+			// (bad plugin config, unresolvable package) is re-thrown so the
+			// operator sees it rather than getting a silent GitHub-push miss.
+			if (!(err instanceof AuthError)) throw err;
 		}
 	}
 

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -35,8 +35,7 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 	// push to GitHub. Load plugins eagerly when remote steps are requested;
 	// for local-only runs, attempt a load for the optional GitHub sync but
 	// swallow auth errors so the command works without a token.
-	const needsProvider =
-		!requestedSteps || requestedSteps.some((s) => !LOCAL_STEPS.has(s as SyncStep));
+	const needsProvider = !requestedSteps || requestedSteps.some((s) => !LOCAL_STEPS.has(s as SyncStep));
 	if (needsProvider) {
 		await loader.load();
 	} else {
@@ -137,7 +136,6 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 					print(formatSyncStep(steps[steps.length - 1]!));
 				}
 			}
-
 		}
 
 		// Report unknown step names
@@ -161,7 +159,7 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 	// optionally push to GitHub when source is loaded. They run outside
 	// the `if (loader.has("source"))` block so they work without a token.
 
-	for (const stepName of (["keywords", "description"] as const)) {
+	for (const stepName of ["keywords", "description"] as const) {
 		if (requestedSteps !== undefined && !requestedSteps.includes(stepName)) {
 			continue;
 		}


### PR DESCRIPTION
## Problem

`holocron sync keywords description` threw an `AuthError` immediately because `loader.load()` ran unconditionally, even though both steps only write to local files (`package.json`, `README.md`) and don't need a GitHub token. The yargs help text also only listed `labels/properties/topics`, hiding the two newer steps.

## Fix

- **Skip plugin loading** when only local-only steps (`keywords`, `description`) are requested. The load is attempted anyway (so `source.syncDescription` still pushes to GitHub when a token is available), but auth errors are swallowed — local writes always run.
- **Move `keywords` and `description` out** of the `if (loader.has("source"))` block into a separate local-steps loop.
- **Update the yargs description and `steps` describe** to list all five steps.

## Test plan

- [x] `pnpm --filter @theholocron/cli typecheck` — clean
- [x] `pnpm --filter @theholocron/cli test` — 335 tests pass (including the existing `syncDescription` test that verifies GitHub push still happens when source is loaded)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->