### PR TITLE
docs: add holocron:description markers to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <!-- holocron:description -->
 
-The Holocron CLI — pluggable, capability-based infrastructure orchestrator. This file makes the repo self-hosted: holocron commands work inside it.
+A pluggable, capability-based CLI for spinning up and operating software projects — your own infrastructure-as-tool.
 
 <!-- /holocron:description -->
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 # Holocron
 
-A pluggable, capability-based CLI for spinning up and operating
-software projects — your own infrastructure-as-tool.
+<!-- holocron:description -->
+The Holocron CLI — pluggable, capability-based infrastructure orchestrator. This file makes the repo self-hosted: holocron commands work inside it.
+<!-- /holocron:description -->
 
 > **Status:** Published under the `alpha` dist-tag on npm. APIs, config shape,
 > and CLI surface may shift before stable v2.0.0. The v1.0.0 line at

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 # Holocron
 
 <!-- holocron:description -->
+
 The Holocron CLI — pluggable, capability-based infrastructure orchestrator. This file makes the repo self-hosted: holocron commands work inside it.
+
 <!-- /holocron:description -->
 
 > **Status:** Published under the `alpha` dist-tag on npm. APIs, config shape,

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -4,7 +4,7 @@ import { node } from "@theholocron/holocron-config";
 const { repo, workflows, providers } = node();
 export default defineConfig({
 	description:
-		"The Holocron CLI — pluggable, capability-based infrastructure orchestrator. This file makes the repo self-hosted: holocron commands work inside it.",
+		"A pluggable, capability-based CLI for spinning up and operating software projects — your own infrastructure-as-tool.",
 	repo: {
 		topics: ["automation", "cli", "developer-tools", "holocron", "nodejs", "typescript"],
 		...repo,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@theholocron/holocron",
   "version": "2.0.0-alpha.67",
   "private": true,
-  "description": "Monorepo for the Holocron CLI and its plugins.",
+  "description": "A pluggable, capability-based CLI for spinning up and operating software projects — your own infrastructure-as-tool.",
   "homepage": "https://github.com/theholocron/holocron#readme",
   "bugs": "https://github.com/theholocron/holocron/issues",
   "repository": {


### PR DESCRIPTION
Adds `<!-- holocron:description -->` / `<!-- /holocron:description -->` block so `holocron sync description` can update the text in-place on future runs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/holocron/pull/193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->