### PR TITLE
ci: add skills repo to workflow sync targets

### DIFF
--- a/.github/workflows/sync-workflow-templates.yml
+++ b/.github/workflows/sync-workflow-templates.yml
@@ -17,7 +17,8 @@ jobs:
       primary-repo: theholocron/.github
       secondary-repos: |
         theholocron/.github-private
-        theholocron/configs
         theholocron/clients
+        theholocron/configs
+        theholocron/skills
     secrets:
       SYNC_TOKEN: ${{ secrets.SYNC_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `theholocron/skills` to the `secondary-repos` list in `sync-workflow-templates.yml`
- Also sorts the list alphabetically (`.github-private`, `clients`, `configs`, `skills`)

When workflow templates change in `holocron`, the sync job will now push updated thin callers to `skills` alongside the other repos.