### PR TITLE
fix(cli): skip writing codecov.yml when no packages and no existing file

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -203,7 +203,7 @@ describe("runSetup", () => {
 
 		expect(called).toBe(false); // mutators never ran
 		const sourceSteps = report.steps.filter((s) => s.capability === "source");
-		expect(sourceSteps.every((s) => s.status === "dry-run")).toBe(true);
+		expect(sourceSteps.every((s) => s.status === "dry-run" || s.status === "skip")).toBe(true);
 		// Vault list still runs (read-only) even in dry-run.
 		expect(report.steps.find((s) => s.capability === "vault")?.status).toBe("ok");
 	});
@@ -1771,7 +1771,7 @@ describe("setup: write codecov.yml", () => {
 		expect(step?.message).toBe("2 components");
 	});
 
-	it("writes codecov.yml with empty components when packages/ is absent", async () => {
+	it("skips writing codecov.yml when packages/ is absent and no existing file", async () => {
 		const written: Record<string, string> = {};
 		const loader = makeLoaderWithSource(tmpDir, {
 			writeRepoFile: async (path: string, content: string) => {
@@ -1785,7 +1785,37 @@ describe("setup: write codecov.yml", () => {
 
 		const report = await runSetup({ loaded, context: { repoRoot: tmpDir }, loader, print: () => {} });
 
-		expect(written["codecov.yml"]).toContain("individual_components:");
+		expect(written["codecov.yml"]).toBeUndefined();
+		const step = report.steps.find((s) => s.step === "write codecov.yml");
+		expect(step?.status).toBe("skip");
+		expect(step?.message).toBe("no packages and no existing codecov.yml");
+	});
+
+	it("merges existing codecov.yml even when packages/ is absent", async () => {
+		const existingCodecov = [
+			"codecov:",
+			"  require_ci_to_pass: true",
+			"",
+			"component_management:",
+			"  individual_components: []",
+			"",
+		].join("\n");
+		await writeFile(join(tmpDir, "codecov.yml"), existingCodecov);
+
+		const written: Record<string, string> = {};
+		const loader = makeLoaderWithSource(tmpDir, {
+			writeRepoFile: async (path: string, content: string) => {
+				written[path] = content;
+			},
+		});
+		const loaded: LoadedConfig = {
+			resolved: resolveConfig({ name: "demo", providers: { source: "github" } }),
+			filepath: join(tmpDir, "holocron.config.json"),
+		};
+
+		const report = await runSetup({ loaded, context: { repoRoot: tmpDir }, loader, print: () => {} });
+
+		expect(written["codecov.yml"]).toBeDefined();
 		const step = report.steps.find((s) => s.step === "write codecov.yml");
 		expect(step?.status).toBe("ok");
 		expect(step?.message).toBe("no components");

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -589,17 +589,28 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			})
 		);
 		print(formatStep(steps[steps.length - 1]!));
-		steps.push(
-			await runStep("source", "write codecov.yml", dryRun, async () => {
-				const packages = await readWorkspacePackages(input.context.repoRoot);
-				const existing = await readFile(join(input.context.repoRoot, "codecov.yml"), "utf8").catch(() => null);
-				const content =
-					existing != null ? mergeCodecovComponents(existing, packages) : codecovContent(packages);
-				await source.writeRepoFile("codecov.yml", content);
-				return packages.length > 0 ? `${packages.length} components` : "no components";
-			})
-		);
-		print(formatStep(steps[steps.length - 1]!));
+		{
+			const packages = await readWorkspacePackages(input.context.repoRoot);
+			const existing = await readFile(join(input.context.repoRoot, "codecov.yml"), "utf8").catch(() => null);
+			if (packages.length === 0 && existing == null) {
+				steps.push({
+					capability: "source",
+					step: "write codecov.yml",
+					status: "skip",
+					message: "no packages and no existing codecov.yml",
+				});
+			} else {
+				steps.push(
+					await runStep("source", "write codecov.yml", dryRun, async () => {
+						const content =
+							existing != null ? mergeCodecovComponents(existing, packages) : codecovContent(packages);
+						await source.writeRepoFile("codecov.yml", content);
+						return packages.length > 0 ? `${packages.length} components` : "no components";
+					})
+				);
+			}
+			print(formatStep(steps[steps.length - 1]!));
+		}
 
 		if (source.syncLabels) {
 			steps.push(


### PR DESCRIPTION
## Summary

- Moves the `readWorkspacePackages` and existing-file check outside `runStep` so the step can be skipped before any write is attempted
- Emits a `skip` step (instead of writing a file with empty components) when there are no workspace packages **and** no existing `codecov.yml`
- Existing merge behavior is unchanged — if a `codecov.yml` already exists, it still runs `mergeCodecovComponents` even when the package list is empty

## Test plan

- [ ] `skips writing codecov.yml when packages/ is absent and no existing file` — new test, verifies skip status and no file written
- [ ] `merges existing codecov.yml even when packages/ is absent` — new test, verifies merge still runs when file exists with no packages
- [ ] `dry-run reports dry-run status without calling mutators` — updated assertion to allow `skip` alongside `dry-run` (skipped steps are also non-mutating)
- [ ] All 371 tests pass

Closes: #203