### PR TITLE
feat(cli): add per-plugin --token disambiguation for multi-plugin commands

### DIFF
--- a/packages/cli/src/__tests__/loader.test.ts
+++ b/packages/cli/src/__tests__/loader.test.ts
@@ -157,6 +157,96 @@ describe("PluginLoader — single cardinality", () => {
 		expect(capturedAtSource.dryRun).toBe(true);
 		expect(capturedAtSource.cliToken).toBe("cli-pat-xxx");
 	});
+
+	it("routes cliTokens[provider] to the matching plugin as cliToken", async () => {
+		const capturedAtVault: Record<string, unknown> = {};
+		const capturedAtSource: Record<string, unknown> = {};
+		const config = resolveConfig({
+			name: "demo",
+			providers: { vault: "1password", source: "github" },
+		});
+		const importer = vi.fn(async (pkg: string) => {
+			if (pkg === "@theholocron/holocron-plugin-1password") {
+				return {
+					createPlugin: (opts: Record<string, unknown>) => {
+						Object.assign(capturedAtVault, opts);
+						return { name: "1p", capabilities: { vault: () => ({}) } };
+					},
+				};
+			}
+			return {
+				createPlugin: (opts: Record<string, unknown>) => {
+					Object.assign(capturedAtSource, opts);
+					return { name: "gh", capabilities: { source: () => ({}) } };
+				},
+			};
+		});
+		const loader = new PluginLoader(
+			config,
+			{ repoRoot: "/tmp", cliTokens: { github: "ghp_specific", "1password": "op_specific" } },
+			importer as unknown as PluginImporter
+		);
+		await loader.load();
+		expect(capturedAtSource.cliToken).toBe("ghp_specific");
+		expect(capturedAtVault.cliToken).toBe("op_specific");
+	});
+
+	it("falls back to bare cliToken for plugins without a matching cliTokens entry", async () => {
+		const capturedAtVault: Record<string, unknown> = {};
+		const capturedAtSource: Record<string, unknown> = {};
+		const config = resolveConfig({
+			name: "demo",
+			providers: { vault: "1password", source: "github" },
+		});
+		const importer = vi.fn(async (pkg: string) => {
+			if (pkg === "@theholocron/holocron-plugin-1password") {
+				return {
+					createPlugin: (opts: Record<string, unknown>) => {
+						Object.assign(capturedAtVault, opts);
+						return { name: "1p", capabilities: { vault: () => ({}) } };
+					},
+				};
+			}
+			return {
+				createPlugin: (opts: Record<string, unknown>) => {
+					Object.assign(capturedAtSource, opts);
+					return { name: "gh", capabilities: { source: () => ({}) } };
+				},
+			};
+		});
+		const loader = new PluginLoader(
+			config,
+			{ repoRoot: "/tmp", cliToken: "bare-fallback", cliTokens: { github: "ghp_specific" } },
+			importer as unknown as PluginImporter
+		);
+		await loader.load();
+		// github gets its keyed token
+		expect(capturedAtSource.cliToken).toBe("ghp_specific");
+		// 1password falls back to the bare token
+		expect(capturedAtVault.cliToken).toBe("bare-fallback");
+	});
+
+	it("never forwards cliTokens map to plugins", async () => {
+		const capturedAtSource: Record<string, unknown> = {};
+		const config = resolveConfig({
+			name: "demo",
+			providers: { source: "github" },
+		});
+		const importer = vi.fn(async () => ({
+			createPlugin: (opts: Record<string, unknown>) => {
+				Object.assign(capturedAtSource, opts);
+				return { name: "gh", capabilities: { source: () => ({}) } };
+			},
+		}));
+		const loader = new PluginLoader(
+			config,
+			{ repoRoot: "/tmp", cliTokens: { github: "ghp_specific" } },
+			importer as unknown as PluginImporter
+		);
+		await loader.load();
+		expect(capturedAtSource.cliToken).toBe("ghp_specific");
+		expect(capturedAtSource.cliTokens).toBeUndefined();
+	});
 });
 
 describe("PluginLoader — repo defaults", () => {

--- a/packages/cli/src/__tests__/token-args.test.ts
+++ b/packages/cli/src/__tests__/token-args.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { TokenParseError, parseTokenArgs } from "../token-args.js";
+
+describe("parseTokenArgs", () => {
+	it("returns empty object for empty array", () => {
+		expect(parseTokenArgs([])).toEqual({});
+	});
+
+	it("bare value → { cliToken }", () => {
+		expect(parseTokenArgs(["ghp_xxx"])).toEqual({ cliToken: "ghp_xxx" });
+	});
+
+	it("keyed value → { cliTokens }", () => {
+		expect(parseTokenArgs(["github=ghp_xxx"])).toEqual({
+			cliTokens: { github: "ghp_xxx" },
+		});
+	});
+
+	it("two keyed values → { cliTokens } with both entries", () => {
+		expect(parseTokenArgs(["github=ghp_xxx", "vercel=v_yyy"])).toEqual({
+			cliTokens: { github: "ghp_xxx", vercel: "v_yyy" },
+		});
+	});
+
+	it("keyed + bare → both fields populated", () => {
+		expect(parseTokenArgs(["github=ghp_xxx", "fallback_tok"])).toEqual({
+			cliToken: "fallback_tok",
+			cliTokens: { github: "ghp_xxx" },
+		});
+	});
+
+	it("splits on first = only — value may contain =", () => {
+		expect(parseTokenArgs(["neon=base64==padding=="])).toEqual({
+			cliTokens: { neon: "base64==padding==" },
+		});
+	});
+
+	it("throws for two bare values", () => {
+		expect(() => parseTokenArgs(["abc", "def"])).toThrow(TokenParseError);
+		expect(() => parseTokenArgs(["abc", "def"])).toThrow(/only one bare/);
+	});
+
+	it("throws for empty vendor (=value)", () => {
+		expect(() => parseTokenArgs(["=ghp_xxx"])).toThrow(TokenParseError);
+		expect(() => parseTokenArgs(["=ghp_xxx"])).toThrow(/vendor name must not be empty/);
+	});
+
+	it("throws for whitespace-only vendor", () => {
+		expect(() => parseTokenArgs([" =ghp_xxx"])).toThrow(TokenParseError);
+		expect(() => parseTokenArgs([" =ghp_xxx"])).toThrow(/vendor name must not be empty/);
+	});
+
+	it("throws for vendor with internal whitespace", () => {
+		expect(() => parseTokenArgs(["git hub=ghp_xxx"])).toThrow(TokenParseError);
+		expect(() => parseTokenArgs(["git hub=ghp_xxx"])).toThrow(/whitespace/);
+	});
+
+	it("throws for empty value (vendor=)", () => {
+		expect(() => parseTokenArgs(["github="])).toThrow(TokenParseError);
+		expect(() => parseTokenArgs(["github="])).toThrow(/token value must not be empty/);
+	});
+
+	it("TokenParseError has the correct name", () => {
+		expect(new TokenParseError("x").name).toBe("TokenParseError");
+	});
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -433,7 +433,10 @@ await yargs(hideBin(process.argv))
 			if (!parsed) return;
 			const token = outputDir
 				? "no-token-needed"
-				: (parsed.cliTokens?.["github"] ?? parsed.cliToken ?? process.env.GITHUB_TOKEN ?? process.env.HOLOCRON_GITHUB_TOKEN);
+				: (parsed.cliTokens?.["github"] ??
+					parsed.cliToken ??
+					process.env.GITHUB_TOKEN ??
+					process.env.HOLOCRON_GITHUB_TOKEN);
 			if (!token) {
 				console.error("sync-github: GitHub token required — pass --token or set GITHUB_TOKEN");
 				process.exitCode = 1;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -23,10 +23,26 @@ import { runSetup } from "./commands/setup.js";
 import { runSkillsInstall, runSkillsRemove, runSkillsUpdate } from "./commands/skills.js";
 import { runSync } from "./commands/sync.js";
 import { loadConfig } from "./load-config.js";
+import { TokenParseError, parseTokenArgs, type ParsedTokenArgs } from "./token-args.js";
 
 const { version: CLI_VERSION } = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8")) as {
 	version: string;
 };
+
+/** Parses --token values and returns the context spread, or null on parse error (exits with code 1). */
+function tokenContext(rawTokens: string[] | undefined): ParsedTokenArgs | null {
+	if (!rawTokens?.length) return {};
+	try {
+		return parseTokenArgs(rawTokens);
+	} catch (err) {
+		if (err instanceof TokenParseError) {
+			console.error(`--token: ${err.message}`);
+			process.exitCode = 1;
+			return null;
+		}
+		throw err;
+	}
+}
 
 await yargs(hideBin(process.argv))
 	.scriptName("holocron")
@@ -41,9 +57,12 @@ await yargs(hideBin(process.argv))
 	})
 	.option("token", {
 		type: "string",
+		array: true,
 		describe:
-			"Vendor token passed to plugins as `cliToken`, taking precedence over env vars. " +
-			"Unambiguous for single-plugin commands; for multi-plugin flows pass per-vendor env vars instead.",
+			"Vendor token override for plugins. " +
+			"Bare form: --token <value> (fallback for all plugins, single-plugin commands). " +
+			"Keyed form: --token vendor=value (targets a specific provider; repeat for each). " +
+			"Example: --token github=ghp_xxx --token vercel=v_yyy",
 	})
 	.option("cwd", {
 		type: "string",
@@ -68,6 +87,8 @@ await yargs(hideBin(process.argv))
 				describe: 'Repo coords ("owner/name"). Defaults to plugin-specific resolution.',
 			}),
 		async (argv) => {
+			const tokens = tokenContext(argv.token);
+			if (!tokens) return;
 			const loaded = await loadConfig(argv.cwd);
 			const report = await runDoctor({
 				loaded,
@@ -75,7 +96,7 @@ await yargs(hideBin(process.argv))
 					repoRoot: argv.cwd,
 					dryRun: argv.dryRun,
 					...(argv.repo ? { repo: argv.repo } : {}),
-					...(argv.token ? { cliToken: argv.token } : {}),
+					...tokens,
 				},
 			});
 			if (report.summary.fail > 0) {
@@ -92,6 +113,8 @@ await yargs(hideBin(process.argv))
 				describe: 'Repo coords ("owner/name"). Defaults to plugin-specific resolution.',
 			}),
 		async (argv) => {
+			const tokens = tokenContext(argv.token);
+			if (!tokens) return;
 			const loaded = await loadConfig(argv.cwd);
 			const report = await runSetup({
 				loaded,
@@ -99,7 +122,7 @@ await yargs(hideBin(process.argv))
 					repoRoot: argv.cwd,
 					dryRun: argv.dryRun,
 					...(argv.repo ? { repo: argv.repo } : {}),
-					...(argv.token ? { cliToken: argv.token } : {}),
+					...tokens,
 				},
 			});
 			if (report.summary.fail > 0) {
@@ -187,6 +210,8 @@ await yargs(hideBin(process.argv))
 					describe: 'Scope: "repo" (default), "env=<name>", or "org=<name>"',
 				}),
 		async (argv) => {
+			const tokens = tokenContext(argv.token);
+			if (!tokens) return;
 			const scopeArg = argv.scope as string;
 			const scope = parseScope(scopeArg);
 			const report = await runSecretSet({
@@ -194,7 +219,7 @@ await yargs(hideBin(process.argv))
 				context: {
 					repoRoot: argv.cwd,
 					dryRun: argv.dryRun,
-					...(argv.token ? { cliToken: argv.token } : {}),
+					...tokens,
 				},
 				name: argv.name as string,
 				...(argv.value ? { value: argv.value as string } : {}),
@@ -227,13 +252,15 @@ await yargs(hideBin(process.argv))
 					describe: "Deployment targets to sync to. Defaults to production + preview.",
 				}),
 		async (argv) => {
+			const tokens = tokenContext(argv.token);
+			if (!tokens) return;
 			const loaded = await loadConfig(argv.cwd);
 			const report = await runSecretsSync({
 				loaded,
 				context: {
 					repoRoot: argv.cwd,
 					dryRun: argv.dryRun,
-					...(argv.token ? { cliToken: argv.token } : {}),
+					...tokens,
 				},
 				environmentId: argv.environmentId as string,
 				...(argv.projectId ? { projectId: argv.projectId } : {}),
@@ -265,13 +292,15 @@ await yargs(hideBin(process.argv))
 					describe: "Named environment to deploy into. Omit for a branch preview.",
 				}),
 		async (argv) => {
+			const tokens = tokenContext(argv.token);
+			if (!tokens) return;
 			const loaded = await loadConfig(argv.cwd);
 			const report = await runDeploy({
 				loaded,
 				context: {
 					repoRoot: argv.cwd,
 					dryRun: argv.dryRun,
-					...(argv.token ? { cliToken: argv.token } : {}),
+					...tokens,
 				},
 				projectId: argv.projectId as string,
 				branch: argv.branch as string,
@@ -352,6 +381,8 @@ await yargs(hideBin(process.argv))
 					describe: 'Repo coords ("owner/name"). Defaults to plugin-specific resolution.',
 				}),
 		async (argv) => {
+			const tokens = tokenContext(argv.token);
+			if (!tokens) return;
 			const loaded = await loadConfig(argv.cwd);
 			const report = await runSync({
 				loaded,
@@ -359,7 +390,7 @@ await yargs(hideBin(process.argv))
 					repoRoot: argv.cwd,
 					dryRun: argv.dryRun,
 					...(argv.repo ? { repo: argv.repo } : {}),
-					...(argv.token ? { cliToken: argv.token } : {}),
+					...tokens,
 				},
 				...(argv.steps && argv.steps.length > 0 ? { steps: argv.steps as string[] } : {}),
 			});
@@ -398,9 +429,11 @@ await yargs(hideBin(process.argv))
 				}),
 		async (argv) => {
 			const outputDir = argv["output-dir"] as string | undefined;
+			const parsed = tokenContext(argv.token);
+			if (!parsed) return;
 			const token = outputDir
 				? "no-token-needed"
-				: (argv.token ?? process.env.GITHUB_TOKEN ?? process.env.HOLOCRON_GITHUB_TOKEN);
+				: (parsed.cliTokens?.["github"] ?? parsed.cliToken ?? process.env.GITHUB_TOKEN ?? process.env.HOLOCRON_GITHUB_TOKEN);
 			if (!token) {
 				console.error("sync-github: GitHub token required — pass --token or set GITHUB_TOKEN");
 				process.exitCode = 1;

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -150,8 +150,7 @@ export class PluginLoader {
 		if (isPluginModule(mod)) {
 			// Resolve the effective token for this specific plugin.
 			// cliTokens[provider] wins over the bare cliToken fallback.
-			const effectiveToken =
-				this.context.cliTokens?.[tuple.provider] ?? this.context.cliToken;
+			const effectiveToken = this.context.cliTokens?.[tuple.provider] ?? this.context.cliToken;
 
 			// Precedence (later wins): project-level defaults from config →
 			// runtime context (CLI flags: --repo, --token) → per-plugin

--- a/packages/cli/src/loader.ts
+++ b/packages/cli/src/loader.ts
@@ -49,13 +49,17 @@ export interface RuntimeContext {
 	 */
 	dryRun?: boolean;
 	/**
-	 * Token passed via `--token <value>`. Plugins pick this up as
-	 * `cliToken` in their auth resolution, taking precedence over env
-	 * vars. For multi-plugin commands the same token is passed to every
-	 * plugin (acceptable when one is in play; tracked at #79 for
-	 * proper disambiguation later).
+	 * Token passed via bare `--token <value>`. Used as fallback for all
+	 * plugins when no matching entry exists in `cliTokens`.
 	 */
 	cliToken?: string;
+	/**
+	 * Per-provider tokens from `--token vendor=value` pairs. The loader
+	 * routes each entry to the matching plugin (by `tuple.provider`) as
+	 * its `cliToken`, falling back to `cliToken` for unmatched providers.
+	 * Plugins never receive this map — they always see a single `cliToken`.
+	 */
+	cliTokens?: Record<string, string>;
 }
 
 /**
@@ -144,12 +148,20 @@ export class PluginLoader {
 
 		// Plugin package: exports createPlugin(opts) → { capabilities }
 		if (isPluginModule(mod)) {
+			// Resolve the effective token for this specific plugin.
+			// cliTokens[provider] wins over the bare cliToken fallback.
+			const effectiveToken =
+				this.context.cliTokens?.[tuple.provider] ?? this.context.cliToken;
+
 			// Precedence (later wins): project-level defaults from config →
-			// runtime context (CLI flags: --repo, --token) → tuple options
-			// (per-plugin overrides in holocron.config.json).
+			// runtime context (CLI flags: --repo, --token) → per-plugin
+			// resolved token → tuple options (per-plugin overrides in config).
+			// cliTokens is explicitly cleared so the map never reaches plugins.
 			const plugin = mod.createPlugin({
 				...this.projectDefaults(),
 				...this.context,
+				...(effectiveToken !== undefined ? { cliToken: effectiveToken } : {}),
+				cliTokens: undefined,
 				...tuple.options,
 			});
 			const factory = plugin.capabilities[key];

--- a/packages/cli/src/token-args.ts
+++ b/packages/cli/src/token-args.ts
@@ -1,0 +1,68 @@
+export class TokenParseError extends Error {
+	override name = "TokenParseError";
+}
+
+export interface ParsedTokenArgs {
+	/** Set when a bare (unkeyed) --token value was passed. Used as fallback for all plugins. */
+	cliToken?: string;
+	/** Set when one or more vendor=value pairs were passed. */
+	cliTokens?: Record<string, string>;
+}
+
+/**
+ * Converts raw --token CLI values into a typed result.
+ *
+ * Bare form:   --token ghp_xxx            → { cliToken: "ghp_xxx" }
+ * Keyed form:  --token github=ghp_xxx     → { cliTokens: { github: "ghp_xxx" } }
+ * Mixed:       --token github=ghp_xxx --token v_yyy
+ *                                         → { cliToken: "v_yyy", cliTokens: { github: "ghp_xxx" } }
+ *
+ * Values may contain "=" (e.g. base64 strings) — only the first "=" is treated as a separator.
+ */
+export function parseTokenArgs(tokens: string[]): ParsedTokenArgs {
+	if (tokens.length === 0) return {};
+
+	const cliTokens: Record<string, string> = {};
+	const bare: string[] = [];
+
+	for (const raw of tokens) {
+		const eqIdx = raw.indexOf("=");
+
+		if (eqIdx === -1) {
+			bare.push(raw);
+			continue;
+		}
+
+		const vendor = raw.slice(0, eqIdx);
+		const value = raw.slice(eqIdx + 1);
+
+		if (vendor.trim() === "") {
+			throw new TokenParseError(
+				`invalid --token value "${raw}": vendor name must not be empty`,
+			);
+		}
+		if (/\s/.test(vendor)) {
+			throw new TokenParseError(
+				`invalid --token value "${raw}": vendor name must not contain whitespace`,
+			);
+		}
+		if (value === "") {
+			throw new TokenParseError(
+				`invalid --token value "${raw}": token value must not be empty`,
+			);
+		}
+
+		cliTokens[vendor] = value;
+	}
+
+	if (bare.length > 1) {
+		throw new TokenParseError(
+			`only one bare --token value is allowed; got ${bare.length.toString()} — use vendor=value form for multiple tokens`,
+		);
+	}
+
+	const result: ParsedTokenArgs = {};
+	if (bare.length === 1) result.cliToken = bare[0];
+	if (Object.keys(cliTokens).length > 0) result.cliTokens = cliTokens;
+	return result;
+}

--- a/packages/cli/src/token-args.ts
+++ b/packages/cli/src/token-args.ts
@@ -37,19 +37,13 @@ export function parseTokenArgs(tokens: string[]): ParsedTokenArgs {
 		const value = raw.slice(eqIdx + 1);
 
 		if (vendor.trim() === "") {
-			throw new TokenParseError(
-				`invalid --token value "${raw}": vendor name must not be empty`,
-			);
+			throw new TokenParseError(`invalid --token value "${raw}": vendor name must not be empty`);
 		}
 		if (/\s/.test(vendor)) {
-			throw new TokenParseError(
-				`invalid --token value "${raw}": vendor name must not contain whitespace`,
-			);
+			throw new TokenParseError(`invalid --token value "${raw}": vendor name must not contain whitespace`);
 		}
 		if (value === "") {
-			throw new TokenParseError(
-				`invalid --token value "${raw}": token value must not be empty`,
-			);
+			throw new TokenParseError(`invalid --token value "${raw}": token value must not be empty`);
 		}
 
 		cliTokens[vendor] = value;
@@ -57,7 +51,7 @@ export function parseTokenArgs(tokens: string[]): ParsedTokenArgs {
 
 	if (bare.length > 1) {
 		throw new TokenParseError(
-			`only one bare --token value is allowed; got ${bare.length.toString()} — use vendor=value form for multiple tokens`,
+			`only one bare --token value is allowed; got ${bare.length.toString()} — use vendor=value form for multiple tokens`
 		);
 	}
 


### PR DESCRIPTION
## Summary

- Makes `--token` repeatable and adds a `vendor=value` keyed form so multi-plugin commands like `setup` can receive different tokens per provider
- Bare `--token value` still works as a fallback for all plugins (backwards-compatible)
- Keyed form: `--token github=ghp_xxx --token vercel=v_yyy` — each token routes only to its matching plugin

## How it works

`parseTokenArgs` (new `token-args.ts`) converts the raw array into `{ cliToken?, cliTokens? }`. `PluginLoader.loadOne()` resolves the effective token per plugin via `cliTokens[tuple.provider] ?? cliToken` and passes it as a single `cliToken` — plugins never see the map.

`sync-github` is updated separately since it consumes a raw token string directly rather than via `RuntimeContext`.

## Examples

```sh
# unchanged — bare token is fallback for all plugins
holocron sync --token ghp_xxx

# new — each token routes to its provider
holocron setup --token github=ghp_xxx --token vercel=v_yyy

# mixed — github gets keyed token, all others get bare fallback
holocron setup --token github=ghp_xxx --token op_fallback

# parse error — surfaces cleanly
holocron setup --token github=ghp_xxx --token another_bare
# → --token: only one bare --token value is allowed...
```

Closes #79

## Test plan

- [ ] `pnpm --filter @theholocron/cli typecheck` passes
- [ ] `pnpm --filter @theholocron/cli test` passes (411 tests, including 12 new token-args tests and 4 new loader routing tests)
- [ ] `pnpm run audit` passes (knip clean)