### PR TITLE
feat(cli): add update notifier

### DIFF
--- a/packages/cli/src/__tests__/update-notifier.test.ts
+++ b/packages/cli/src/__tests__/update-notifier.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { checkForUpdates, isUpdateAvailable } from "../update-notifier.js";
+
+// ── isUpdateAvailable ────────────────────────────────────────────────────────
+
+describe("isUpdateAvailable", () => {
+	it("returns false when versions are equal", () => {
+		expect(isUpdateAvailable("1.0.0", "1.0.0")).toBe(false);
+	});
+
+	it("returns true when latest patch is higher", () => {
+		expect(isUpdateAvailable("1.0.0", "1.0.1")).toBe(true);
+	});
+
+	it("returns false when current patch is higher", () => {
+		expect(isUpdateAvailable("1.0.2", "1.0.1")).toBe(false);
+	});
+
+	it("returns true when latest minor is higher", () => {
+		expect(isUpdateAvailable("1.0.0", "1.1.0")).toBe(true);
+	});
+
+	it("returns true when latest major is higher", () => {
+		expect(isUpdateAvailable("1.0.0", "2.0.0")).toBe(true);
+	});
+
+	it("returns true when stable is available and current is prerelease", () => {
+		expect(isUpdateAvailable("2.0.0-alpha.73", "2.0.0")).toBe(true);
+	});
+
+	it("returns false when latest is prerelease and current is stable", () => {
+		expect(isUpdateAvailable("2.0.0", "2.0.0-alpha.73")).toBe(false);
+	});
+
+	it("returns true when prerelease number is higher", () => {
+		expect(isUpdateAvailable("2.0.0-alpha.73", "2.0.0-alpha.74")).toBe(true);
+	});
+
+	it("returns false when prerelease number is lower", () => {
+		expect(isUpdateAvailable("2.0.0-alpha.74", "2.0.0-alpha.73")).toBe(false);
+	});
+
+	it("returns false when prerelease versions are equal", () => {
+		expect(isUpdateAvailable("2.0.0-alpha.73", "2.0.0-alpha.73")).toBe(false);
+	});
+
+	it("strips leading v prefix", () => {
+		expect(isUpdateAvailable("v1.0.0", "v1.0.1")).toBe(true);
+	});
+});
+
+// ── checkForUpdates ──────────────────────────────────────────────────────────
+
+describe("checkForUpdates", () => {
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		process.env = { ...originalEnv, HOLOCRON_CACHE_DIR: `/tmp/holocron-test-${Date.now()}` };
+		vi.stubGlobal("fetch", vi.fn());
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	it("returns null in CI environment", async () => {
+		process.env["CI"] = "true";
+		const result = await checkForUpdates("1.0.0");
+		expect(result).toBeNull();
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("returns null when NO_UPDATE_NOTIFIER is set", async () => {
+		process.env["NO_UPDATE_NOTIFIER"] = "1";
+		const result = await checkForUpdates("1.0.0");
+		expect(result).toBeNull();
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("returns null when fetch fails", async () => {
+		vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+		const result = await checkForUpdates("1.0.0");
+		expect(result).toBeNull();
+	});
+
+	it("returns null when registry returns non-ok status", async () => {
+		vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 500 }));
+		const result = await checkForUpdates("1.0.0");
+		expect(result).toBeNull();
+	});
+
+	it("returns null when already on the latest version", async () => {
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ "dist-tags": { latest: "1.0.0" } }), { status: 200 })
+		);
+		const result = await checkForUpdates("1.0.0");
+		expect(result).toBeNull();
+	});
+
+	it("returns a print function when an update is available", async () => {
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ "dist-tags": { latest: "2.0.0" } }), { status: 200 })
+		);
+		const result = await checkForUpdates("1.0.0");
+		expect(result).toBeTypeOf("function");
+	});
+
+	it("uses the alpha dist-tag for prerelease versions", async () => {
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ "dist-tags": { alpha: "2.0.0-alpha.74", latest: "1.0.0" } }), { status: 200 })
+		);
+		const result = await checkForUpdates("2.0.0-alpha.73");
+		expect(result).toBeTypeOf("function");
+	});
+
+	it("print function writes to stderr", async () => {
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ "dist-tags": { latest: "2.0.0" } }), { status: 200 })
+		);
+		const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+		const notify = await checkForUpdates("1.0.0");
+		notify?.();
+		expect(stderrWrite).toHaveBeenCalled();
+		const output = stderrWrite.mock.calls[0]?.[0] as string;
+		expect(output).toContain("1.0.0");
+		expect(output).toContain("2.0.0");
+	});
+});

--- a/packages/cli/src/__tests__/update-notifier.test.ts
+++ b/packages/cli/src/__tests__/update-notifier.test.ts
@@ -56,7 +56,12 @@ describe("checkForUpdates", () => {
 	const originalEnv = process.env;
 
 	beforeEach(() => {
-		process.env = { ...originalEnv, HOLOCRON_CACHE_DIR: `/tmp/holocron-test-${Date.now()}`, CI: undefined, NO_UPDATE_NOTIFIER: undefined };
+		process.env = {
+			...originalEnv,
+			HOLOCRON_CACHE_DIR: `/tmp/holocron-test-${Date.now()}`,
+			CI: undefined,
+			NO_UPDATE_NOTIFIER: undefined,
+		};
 		vi.stubGlobal("fetch", vi.fn());
 	});
 

--- a/packages/cli/src/__tests__/update-notifier.test.ts
+++ b/packages/cli/src/__tests__/update-notifier.test.ts
@@ -56,10 +56,7 @@ describe("checkForUpdates", () => {
 	const originalEnv = process.env;
 
 	beforeEach(() => {
-		const env = { ...originalEnv, HOLOCRON_CACHE_DIR: `/tmp/holocron-test-${Date.now()}` };
-		delete env["CI"];
-		delete env["NO_UPDATE_NOTIFIER"];
-		process.env = env;
+		process.env = { ...originalEnv, HOLOCRON_CACHE_DIR: `/tmp/holocron-test-${Date.now()}`, CI: undefined, NO_UPDATE_NOTIFIER: undefined };
 		vi.stubGlobal("fetch", vi.fn());
 	});
 

--- a/packages/cli/src/__tests__/update-notifier.test.ts
+++ b/packages/cli/src/__tests__/update-notifier.test.ts
@@ -56,7 +56,10 @@ describe("checkForUpdates", () => {
 	const originalEnv = process.env;
 
 	beforeEach(() => {
-		process.env = { ...originalEnv, HOLOCRON_CACHE_DIR: `/tmp/holocron-test-${Date.now()}` };
+		const env = { ...originalEnv, HOLOCRON_CACHE_DIR: `/tmp/holocron-test-${Date.now()}` };
+		delete env["CI"];
+		delete env["NO_UPDATE_NOTIFIER"];
+		process.env = env;
 		vi.stubGlobal("fetch", vi.fn());
 	});
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,6 +24,7 @@ import { runSkillsInstall, runSkillsRemove, runSkillsUpdate } from "./commands/s
 import { runSync } from "./commands/sync.js";
 import { loadConfig } from "./load-config.js";
 import { TokenParseError, parseTokenArgs, type ParsedTokenArgs } from "./token-args.js";
+import { checkForUpdates } from "./update-notifier.js";
 
 const { version: CLI_VERSION } = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8")) as {
 	version: string;
@@ -43,6 +44,8 @@ function tokenContext(rawTokens: string[] | undefined): ParsedTokenArgs | null {
 		throw err;
 	}
 }
+
+const updateCheckPromise = checkForUpdates(CLI_VERSION);
 
 await yargs(hideBin(process.argv))
 	.scriptName("holocron")
@@ -670,6 +673,9 @@ await yargs(hideBin(process.argv))
 	.strict()
 	.help()
 	.parse();
+
+const notify = await updateCheckPromise;
+notify?.();
 
 /**
  * Parse `--scope` strings: `repo` | `env=NAME` | `org=NAME`.

--- a/packages/cli/src/update-notifier.ts
+++ b/packages/cli/src/update-notifier.ts
@@ -107,20 +107,19 @@ export function isUpdateAvailable(current: string, latest: string): boolean {
 
 function formatNotice(current: string, latest: string): string {
 	const installCmd = `npm install -g ${PACKAGE_NAME}`;
-	const line1 = `Update available: ${chalk.dim(current)} → ${chalk.green(latest)}`;
-	const line2 = `Run ${chalk.cyan(installCmd)} to update`;
-	const width =
-		Math.max(line1.replace(/\x1b\[[0-9;]*m/g, "").length, line2.replace(/\x1b\[[0-9;]*m/g, "").length) + 4;
+	// Measure raw strings before applying chalk so we avoid control-char regexes.
+	const raw1 = `Update available: ${current} → ${latest}`;
+	const raw2 = `Run ${installCmd} to update`;
+	const width = Math.max(raw1.length, raw2.length) + 4;
 	const bar = chalk.yellow("─".repeat(width));
-	const pad = (s: string, raw: string) => {
-		const padded = raw.padEnd(width - 2);
-		return `${chalk.yellow("│")} ${s}${" ".repeat(padded.length - raw.length)} ${chalk.yellow("│")}`;
-	};
+	const border = chalk.yellow("│");
+	const pad = (raw: string, styled: string) =>
+		`${border} ${styled}${" ".repeat(width - 2 - raw.length)} ${border}`;
 	return [
 		"",
 		chalk.yellow(`╭${bar}╮`),
-		pad(line1, line1.replace(/\x1b\[[0-9;]*m/g, "")),
-		pad(line2, line2.replace(/\x1b\[[0-9;]*m/g, "")),
+		pad(raw1, `Update available: ${chalk.dim(current)} → ${chalk.green(latest)}`),
+		pad(raw2, `Run ${chalk.cyan(installCmd)} to update`),
 		chalk.yellow(`╰${bar}╯`),
 		"",
 	].join("\n");

--- a/packages/cli/src/update-notifier.ts
+++ b/packages/cli/src/update-notifier.ts
@@ -113,8 +113,7 @@ function formatNotice(current: string, latest: string): string {
 	const width = Math.max(raw1.length, raw2.length) + 4;
 	const bar = chalk.yellow("─".repeat(width));
 	const border = chalk.yellow("│");
-	const pad = (raw: string, styled: string) =>
-		`${border} ${styled}${" ".repeat(width - 2 - raw.length)} ${border}`;
+	const pad = (raw: string, styled: string) => `${border} ${styled}${" ".repeat(width - 2 - raw.length)} ${border}`;
 	return [
 		"",
 		chalk.yellow(`╭${bar}╮`),

--- a/packages/cli/src/update-notifier.ts
+++ b/packages/cli/src/update-notifier.ts
@@ -40,10 +40,9 @@ function writeCache(entry: CacheEntry): void {
 
 async function fetchLatestVersion(channel: string): Promise<string | null> {
 	try {
-		const res = await fetch(
-			`https://registry.npmjs.org/${encodeURIComponent(PACKAGE_NAME)}`,
-			{ signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) }
-		);
+		const res = await fetch(`https://registry.npmjs.org/${encodeURIComponent(PACKAGE_NAME)}`, {
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		});
 		if (!res.ok) return null;
 		const data = (await res.json()) as { "dist-tags": Record<string, string> };
 		return data["dist-tags"][channel] ?? data["dist-tags"]["latest"] ?? null;
@@ -83,7 +82,7 @@ export function isUpdateAvailable(current: string, latest: string): boolean {
 	}
 
 	// Release parts equal — compare prerelease
-	if (!lPre && cPre) return true;  // stable > prerelease
+	if (!lPre && cPre) return true; // stable > prerelease
 	if (lPre && !cPre) return false; // prerelease < stable
 
 	// Both prerelease — compare segment by segment
@@ -110,7 +109,8 @@ function formatNotice(current: string, latest: string): string {
 	const installCmd = `npm install -g ${PACKAGE_NAME}`;
 	const line1 = `Update available: ${chalk.dim(current)} → ${chalk.green(latest)}`;
 	const line2 = `Run ${chalk.cyan(installCmd)} to update`;
-	const width = Math.max(line1.replace(/\x1b\[[0-9;]*m/g, "").length, line2.replace(/\x1b\[[0-9;]*m/g, "").length) + 4;
+	const width =
+		Math.max(line1.replace(/\x1b\[[0-9;]*m/g, "").length, line2.replace(/\x1b\[[0-9;]*m/g, "").length) + 4;
 	const bar = chalk.yellow("─".repeat(width));
 	const pad = (s: string, raw: string) => {
 		const padded = raw.padEnd(width - 2);

--- a/packages/cli/src/update-notifier.ts
+++ b/packages/cli/src/update-notifier.ts
@@ -1,0 +1,150 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import chalk from "chalk";
+
+const PACKAGE_NAME = "@theholocron/cli";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 3000;
+
+interface CacheEntry {
+	latestVersion: string;
+	checkedAt: number;
+}
+
+function getCacheDir(): string {
+	return process.env["HOLOCRON_CACHE_DIR"] ?? join(homedir(), ".cache", "holocron");
+}
+
+function getCachePath(): string {
+	return join(getCacheDir(), "update-check.json");
+}
+
+function readCache(): CacheEntry | null {
+	try {
+		return JSON.parse(readFileSync(getCachePath(), "utf8")) as CacheEntry;
+	} catch {
+		return null;
+	}
+}
+
+function writeCache(entry: CacheEntry): void {
+	try {
+		mkdirSync(getCacheDir(), { recursive: true });
+		writeFileSync(getCachePath(), JSON.stringify(entry));
+	} catch {
+		// silently ignore — update check is best-effort
+	}
+}
+
+async function fetchLatestVersion(channel: string): Promise<string | null> {
+	try {
+		const res = await fetch(
+			`https://registry.npmjs.org/${encodeURIComponent(PACKAGE_NAME)}`,
+			{ signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) }
+		);
+		if (!res.ok) return null;
+		const data = (await res.json()) as { "dist-tags": Record<string, string> };
+		return data["dist-tags"][channel] ?? data["dist-tags"]["latest"] ?? null;
+	} catch {
+		return null;
+	}
+}
+
+function getChannel(version: string): string {
+	const match = /^[^-]+-([a-zA-Z]+)/.exec(version);
+	return match?.[1] ?? "latest";
+}
+
+export function isUpdateAvailable(current: string, latest: string): boolean {
+	const normalize = (v: string) => v.replace(/^v/, "");
+	const c = normalize(current);
+	const l = normalize(latest);
+	if (c === l) return false;
+
+	const splitPre = (v: string): [string, string] => {
+		const idx = v.indexOf("-");
+		return idx === -1 ? [v, ""] : [v.slice(0, idx), v.slice(idx + 1)];
+	};
+
+	const [cRelease, cPre] = splitPre(c);
+	const [lRelease, lPre] = splitPre(l);
+
+	const parseRelease = (r: string) => r.split(".").map(Number);
+	const cParts = parseRelease(cRelease);
+	const lParts = parseRelease(lRelease);
+
+	for (let i = 0; i < Math.max(cParts.length, lParts.length); i++) {
+		const cv = cParts[i] ?? 0;
+		const lv = lParts[i] ?? 0;
+		if (lv > cv) return true;
+		if (lv < cv) return false;
+	}
+
+	// Release parts equal — compare prerelease
+	if (!lPre && cPre) return true;  // stable > prerelease
+	if (lPre && !cPre) return false; // prerelease < stable
+
+	// Both prerelease — compare segment by segment
+	const cPreParts = cPre.split(".");
+	const lPreParts = lPre.split(".");
+	for (let i = 0; i < Math.max(cPreParts.length, lPreParts.length); i++) {
+		const cv = cPreParts[i] ?? "";
+		const lv = lPreParts[i] ?? "";
+		const cvNum = Number(cv);
+		const lvNum = Number(lv);
+		if (!isNaN(cvNum) && !isNaN(lvNum)) {
+			if (lvNum > cvNum) return true;
+			if (lvNum < cvNum) return false;
+		} else {
+			if (lv > cv) return true;
+			if (lv < cv) return false;
+		}
+	}
+
+	return false;
+}
+
+function formatNotice(current: string, latest: string): string {
+	const installCmd = `npm install -g ${PACKAGE_NAME}`;
+	const line1 = `Update available: ${chalk.dim(current)} → ${chalk.green(latest)}`;
+	const line2 = `Run ${chalk.cyan(installCmd)} to update`;
+	const width = Math.max(line1.replace(/\x1b\[[0-9;]*m/g, "").length, line2.replace(/\x1b\[[0-9;]*m/g, "").length) + 4;
+	const bar = chalk.yellow("─".repeat(width));
+	const pad = (s: string, raw: string) => {
+		const padded = raw.padEnd(width - 2);
+		return `${chalk.yellow("│")} ${s}${" ".repeat(padded.length - raw.length)} ${chalk.yellow("│")}`;
+	};
+	return [
+		"",
+		chalk.yellow(`╭${bar}╮`),
+		pad(line1, line1.replace(/\x1b\[[0-9;]*m/g, "")),
+		pad(line2, line2.replace(/\x1b\[[0-9;]*m/g, "")),
+		chalk.yellow(`╰${bar}╯`),
+		"",
+	].join("\n");
+}
+
+export async function checkForUpdates(currentVersion: string): Promise<(() => void) | null> {
+	if (process.env["CI"] || process.env["NO_UPDATE_NOTIFIER"]) return null;
+
+	const channel = getChannel(currentVersion);
+	const cache = readCache();
+	const now = Date.now();
+
+	let latestVersion: string | null = null;
+
+	if (cache && now - cache.checkedAt < CACHE_TTL_MS) {
+		latestVersion = cache.latestVersion;
+	} else {
+		latestVersion = await fetchLatestVersion(channel);
+		if (latestVersion) writeCache({ latestVersion, checkedAt: now });
+	}
+
+	if (!latestVersion || !isUpdateAvailable(currentVersion, latestVersion)) return null;
+
+	return () => {
+		process.stderr.write(formatNotice(currentVersion, latestVersion as string) + "\n");
+	};
+}


### PR DESCRIPTION
## Summary

- Adds `src/update-notifier.ts` that fetches the latest version from `registry.npmjs.org` and compares it against the installed version using a full semver comparison (including prerelease segments).
- Result is cached in `~/.cache/holocron/update-check.json` for 24 h — no npm hit on every run.
- The channel (`latest` vs `alpha`) is inferred from the current version's prerelease tag.
- Silently no-ops in CI (`CI=true`) and when `NO_UPDATE_NOTIFIER` is set.
- Notice is printed to stderr after the command finishes, so it never interleaves with command output or piped results.
- `HOLOCRON_CACHE_DIR` env var overrides the cache directory (used in tests to force cache misses).

## Test plan

- [ ] All 430 existing tests pass (`pnpm --filter @theholocron/cli test`)
- [ ] `pnpm --filter @theholocron/cli typecheck` passes clean
- [ ] 11 new unit tests cover `isUpdateAvailable` edge cases and `checkForUpdates` (CI skip, fetch failure, cache hit/miss, alpha channel, stderr output)