### PR TITLE
feat: add turbo pipeline with inputs, outputs, and task ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   "author": "Newton Koumantzelis",
   "type": "module",
   "scripts": {
-    "build": "pnpm -r --filter './packages/*' build",
+    "audit": "knip",
+    "build": "turbo run build",
     "format": "prettier --write .",
     "holocron": "tsx packages/cli/src/cli.ts",
-    "audit": "knip",
-    "lint": "pnpm -r --filter './packages/*' lint",
-    "test": "pnpm -r --filter './packages/*' test",
-    "test:coverage": "pnpm -r --filter './packages/*' test:coverage",
-    "typecheck": "pnpm -r --filter './packages/*' typecheck"
+    "lint": "turbo run lint",
+    "test": "turbo run test",
+    "test:coverage": "turbo run test:coverage",
+    "typecheck": "turbo run typecheck"
   },
   "devDependencies": {
     "@commitlint/types": "^19.5.0",
@@ -56,6 +56,7 @@
     "prettier": "^3.9.3",
     "semantic-release": "^25.0.5",
     "tsdown": "^0.22.3",
+    "turbo": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
     "typescript-eslint": "^8.62.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ catalogs:
     tsx:
       specifier: ^4.22.4
       version: 4.22.4
+    turbo:
+      specifier: ^2.10.5
+      version: 2.10.5
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
@@ -200,6 +203,9 @@ importers:
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
+      turbo:
+        specifier: 'catalog:'
+        version: 2.10.5
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -2118,6 +2124,36 @@ packages:
         optional: true
       playwright:
         optional: true
+
+  '@turbo/darwin-64@2.10.5':
+    resolution: {integrity: sha512-ENvPwy3x5yS7MwNYHeWjqOBXkwIMp39Pd+/zXC6PoiNzF8EIvvLZOZZ+ny6L9x4WgS5vxUii2LM5gM+zjPdnWw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.10.5':
+    resolution: {integrity: sha512-rqROo9zsF/P9RqsdtbLD1nFJicjSrYyvQ9kNJC38AbxA3pAs6VAlATvtvOFx7bqOv6vicf20SP9kF33avJjy2w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.10.5':
+    resolution: {integrity: sha512-RoSSiNFUxi27zLJuM9F6GyWWjHgLch9t6nwD6K0FkXRirZkTLlzIj6IhFnK8H9++nefLtdFqylE4vGjZAv6AAA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.10.5':
+    resolution: {integrity: sha512-4ZComcpzmHGmVynQqvvi+iZOSq/tBvY1SltXB8g4NZRsrA01W8E+yRL8RNM+PLoyWsrCnJa8xa+DkWkv+xg4iQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.10.5':
+    resolution: {integrity: sha512-eL2Iyj4DbMINq1Sr1w0iAi6nAiZOF16KSlRGwCJpVh+IWZeY33MAsLHVOBMj1xoFtncVJXclCVpTPL2nBoYkFg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.10.5':
+    resolution: {integrity: sha512-sog+wP+8YSJrdWZ/rUJg8xghVTrwoG+BrSlDQpnK5fzSgJHn1INRWXbVWRH0d3vX8dBI01E3yxXRre9Dn+OXQA==}
+    cpu: [arm64]
+    os: [win32]
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -4779,6 +4815,10 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
+  turbo@2.10.5:
+    resolution: {integrity: sha512-07Y/C7OUp23l4P92PJoYtFNbHjLhftrZH5Ce7dbczS4kX2Re+wtbXvZLoxn/pUtzgsQaRCBaRuZPJp4zmAn0WQ==}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -6242,6 +6282,24 @@ snapshots:
       vitest: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+
+  '@turbo/darwin-64@2.10.5':
+    optional: true
+
+  '@turbo/darwin-arm64@2.10.5':
+    optional: true
+
+  '@turbo/linux-64@2.10.5':
+    optional: true
+
+  '@turbo/linux-arm64@2.10.5':
+    optional: true
+
+  '@turbo/windows-64@2.10.5':
+    optional: true
+
+  '@turbo/windows-arm64@2.10.5':
+    optional: true
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -9261,6 +9319,15 @@ snapshots:
       fsevents: 2.3.3
 
   tunnel@0.0.6: {}
+
+  turbo@2.10.5:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.10.5
+      '@turbo/darwin-arm64': 2.10.5
+      '@turbo/linux-64': 2.10.5
+      '@turbo/linux-arm64': 2.10.5
+      '@turbo/windows-64': 2.10.5
+      '@turbo/windows-arm64': 2.10.5
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,7 @@ catalog:
   chalk: ^5.4.1
   ora: ^8.2.0
   tsdown: ^0.22.3
+  turbo: ^2.10.5
   tsx: ^4.22.4
   vitest: ^4.1.10
   '@vitest/coverage-v8': ^4.1.10

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "globalDependencies": ["pnpm-workspace.yaml", "tsconfig.json"],
+  "tasks": {
+    "build": {
+      "inputs": ["src/**", "tsdown.config.ts", "tsconfig.json", "package.json"],
+      "outputs": ["dist/**"],
+      "dependsOn": ["^build"]
+    },
+    "lint": {
+      "inputs": ["src/**", "eslint.config.ts", "eslint.config.js"],
+      "outputs": []
+    },
+    "test": {
+      "inputs": ["src/**", "vitest.config.ts", "package.json"],
+      "outputs": [],
+      "dependsOn": ["^build"]
+    },
+    "test:coverage": {
+      "inputs": ["src/**", "vitest.config.ts", "package.json"],
+      "outputs": ["coverage/**"],
+      "dependsOn": ["build"]
+    },
+    "typecheck": {
+      "inputs": ["src/**", "tsconfig.json"],
+      "outputs": [],
+      "dependsOn": ["^build"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Creates `turbo.json` — holocron had no turbo config at all despite having `.turbo/cache/` present. Root scripts were using `pnpm -r --filter './packages/*'`, bypassing turbo's cache entirely.
- Adds `turbo: ^2.10.5` to `pnpm-workspace.yaml` catalog and `devDependencies`.
- Switches root scripts (`build`, `lint`, `test`, `test:coverage`, `typecheck`) to `turbo run` — `audit`, `format`, and `holocron` remain as-is (not per-package tasks).

**Pipeline configuration:**
- `build`: `inputs: [src/**, tsdown.config.ts, tsconfig.json, package.json]`, `outputs: [dist/**]`, `dependsOn: ["^build"]` — all `holocron-plugin-*` packages have `@theholocron/cli` as a `devDependencies: "workspace:*"` dep; turbo sees this edge and correctly builds cli before plugins.
- `test` and `typecheck`: `dependsOn: ["^build"]` — vitest resolves workspace imports through `dist/`; tsc needs upstream `.d.mts` declarations.
- `test:coverage`: `dependsOn: ["build"]`, `outputs: [coverage/**]`.
- `lint`: no `dependsOn`.
- `globalDependencies: [pnpm-workspace.yaml, tsconfig.json]` — catalog bumps invalidate all caches.
- `cli-utils` has no `build` script (private, v1 carryover) — turbo silently skips missing tasks.

**Note:** The `turborepo` skill bump (`@theholocron/skills` version + `holocron.config.ts` entry + `holocron setup`) will follow in a separate commit once `theholocron/skills#6` merges and publishes.

## Test plan

- [x] `pnpm turbo run build --dry` resolves all 10 packages with correct `inputs`, `outputs`, and `dependsOn: ["^build"]`
- [ ] CI green on PR
- [ ] After merge: run `pnpm build` twice — second run should show `>>> FULL TURBO`