### PR TITLE
ci(release): use GH_TOKEN for semantic-release git push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             pnpm exec semantic-release --dry-run


### PR DESCRIPTION
## Summary

Swaps `GITHUB_TOKEN` for `GH_TOKEN` (org-level PAT) in the Release step so
`@semantic-release/git` can push the `chore(release): X.Y.Z [skip ci]` version
bump commit back to `main` without being blocked by branch protection.

`GITHUB_TOKEN` runs as `github-actions[bot]`, which has no bypass in the branch
ruleset. `GH_TOKEN` is a PAT belonging to an admin account that has the Maintain
bypass. This unblocks the `v2.0.0` stable release.

## Follow-up

- Add this pattern to the holocron release workflow template so new repos pick
  it up automatically via `holocron setup`
- Track in theholocron/.github#25 automation work (flip sync-github to main)