### PR TITLE
ci(release): use RELEASE_TOKEN for semantic-release git push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             pnpm exec semantic-release --dry-run

--- a/packages/cli/src/templates/workflows/release.yml
+++ b/packages/cli/src/templates/workflows/release.yml
@@ -13,11 +13,17 @@ on: # yamllint disable-line rule:truthy
         required: false
         default: true
     secrets:
+      RELEASE_TOKEN:
+        description: >
+          Fine-grained PAT (Contents + Issues + Pull requests: write) owned by
+          an admin. Required when the default branch is protected by a ruleset —
+          github.token cannot push through rulesets, but an admin PAT can.
+          Takes priority over SYNC_TOKEN. Falls back to github.token.
+        required: false
       SYNC_TOKEN:
         description: >
-          Optional PAT with Contents write access. Required when the default
-          branch is protected by a ruleset — github.token cannot push through
-          rulesets, but a PAT with admin bypass can. Falls back to github.token.
+          Legacy alias for RELEASE_TOKEN — kept for backward compatibility.
+          Prefer RELEASE_TOKEN for new repos.
         required: false
 
 jobs:
@@ -42,7 +48,7 @@ jobs:
           # Use SYNC_TOKEN when available — git push (tags, release commits)
           # uses the checkout credential, not GITHUB_TOKEN env var. The
           # built-in github.token cannot push through branch protection rulesets.
-          token: ${{ secrets.SYNC_TOKEN || github.token }}
+          token: ${{ secrets.RELEASE_TOKEN || secrets.SYNC_TOKEN || github.token }}
 
       - uses: theholocron/.github/.github/actions/setup@main
         name: Setup
@@ -55,7 +61,7 @@ jobs:
           git config --global user.email "$GIT_EMAIL"
           git config --global format.signoff true
         env:
-          GH_TOKEN: ${{ secrets.SYNC_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.SYNC_TOKEN || github.token }}
 
       - run: npm install -g npm@11 sigstore
         name: Upgrade npm for OIDC support
@@ -71,9 +77,9 @@ jobs:
       - run: npx semantic-release
         name: Release
         env:
-          # Prefer SYNC_TOKEN (a PAT with Contents write) when available —
-          # the built-in github.token cannot push to protected default branches
-          # because rulesets block non-PAT pushes. Falls back to github.token
-          # for repos without branch protection.
-          GITHUB_TOKEN: ${{ secrets.SYNC_TOKEN || github.token }}
+          # Prefer RELEASE_TOKEN (fine-grained PAT, Contents+Issues+PRs write,
+          # owned by an admin with ruleset bypass) so @semantic-release/git can
+          # push the version-bump commit through branch protection. Falls back to
+          # SYNC_TOKEN (legacy) then github.token for unprotected repos.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.SYNC_TOKEN || github.token }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Switches the Release step in both the live workflow and the reusable template from `GH_TOKEN`/`SYNC_TOKEN` to `RELEASE_TOKEN` — a fine-grained PAT (Contents + Issues + Pull requests: write) owned by an admin account, which has bypass rights in the branch ruleset
- Template now accepts `RELEASE_TOKEN` as the primary secret with `SYNC_TOKEN` as a backward-compatible fallback, so consumer repos (`clients`, `configs`, etc.) can adopt it incrementally
- Unblocks the `v2.0.0` stable release — `@semantic-release/git` can now push the version-bump commit through main branch protection

## Why not `GITHUB_TOKEN`

`GITHUB_TOKEN` runs as `github-actions[bot]`, which is not in the branch ruleset bypass list and can't be added via the API (GitHub only exposes it through the UI for this org). A fine-grained PAT from an admin account inherits the admin's bypass rights.

## Follow-up

- Consumer repos (`clients`, `configs`, `skills`) should be updated to pass `RELEASE_TOKEN` through their thin caller workflows as `holocron setup` runs pick them up