### PR TITLE
docs: update repo layout and vault plugin references for doppler/infisical

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,8 +127,7 @@ not object destructuring.
   `stubFetch` (REST plugins) or `stubSpawn` (CLI plugins) — both
   ported from rando-id/rando.id `__tests__/helpers.ts`. Per-plugin
   coverage floor: 90%+ lines on the auth + REST/shell + capability
-  surface. The `cli-utils` package is `private: true` (v1 carryover);
-  its typecheck is a no-op.
+  surface.
 - **Don't call `expect(...).toThrow()` twice on the same stubbed call.**
   The stub queue advances per call; second invocation gets the default
   empty response. For multi-property error checks use the `.catch` capture
@@ -184,7 +183,7 @@ not object destructuring.
   `alpha`. Docs, chore, ci, test are safe on either.
 - **semantic-release on push to main or alpha.** Walks Conventional
   Commits since the last tag on the branch's channel, computes the
-  next version, bumps all 7 public packages in lockstep via
+  next version, bumps all 9 public packages in lockstep via
   `scripts/bump-versions.mjs`, publishes via OIDC, creates a GitHub
   Release, commits `CHANGELOG.md`.
 - **npm Trusted Publishing.** OIDC token exchange at publish time —
@@ -202,14 +201,15 @@ publish-initial` (chicken-and-egg: trusted publishing needs the
 ```
 packages/
   cli/                            — @theholocron/cli                       (binary + runtime + 14 capability interfaces)
-  cli-utils/                      — @theholocron/cli-utils                 (PRIVATE — v1 carryover)
   holocron-plugin-github/         — source / ci / secrets / environments / issues
   holocron-plugin-vercel/         — deployment
   holocron-plugin-neon/           — storage
   holocron-plugin-clerk/          — auth (+ parseWebhook utility)
   holocron-plugin-1password/      — vault (CLI shell-out — only non-REST plugin)
+  holocron-plugin-doppler/        — vault (REST)
+  holocron-plugin-infisical/      — vault (REST)
   holocron-plugin-postman/        — tooling
-holocron.config.json              — this repo's own config (self-hosted)
+holocron.config.ts                — this repo's own config (self-hosted)
 .notes/                           — design specs (draft → proposed → approved → archived)
 .claude/skills/holocron-skill-plugin/ — scaffolding skill for new plugins
 .github/workflows/                — ci.yml (PR), release.yml (main), codeql.yml, etc.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@ A pluggable, capability-based CLI for spinning up and operating software project
 
 <!-- prettier-ignore -->
 ```bash
-# 1. Install the CLI + the two plugins you'll always need
+# 1. Install the CLI + the source plugin and a vault plugin
 npm  i -g @theholocron/cli@alpha
-pnpm add -D @theholocron/holocron-plugin-github@alpha \
-      @theholocron/holocron-plugin-1password@alpha
+pnpm add -D @theholocron/holocron-plugin-github@alpha
+
+# Vault — pick one: 1password, doppler, or infisical
+pnpm add -D @theholocron/holocron-plugin-doppler@alpha
+# or: pnpm add -D @theholocron/holocron-plugin-1password@alpha
+# or: pnpm add -D @theholocron/holocron-plugin-infisical@alpha
 
 ```
 
@@ -138,14 +142,15 @@ vault (1Password)
 ```
 packages/
   cli/                            — @theholocron/cli                       (binary + capability runtime)
-  cli-utils/                      — @theholocron/cli-utils                 (prompts, openers, shell helpers — private; v1 carryover)
   holocron-plugin-github/         — @theholocron/holocron-plugin-github    (source, ci, secrets, environments, issues)
   holocron-plugin-vercel/         — @theholocron/holocron-plugin-vercel    (deployment)
   holocron-plugin-neon/           — @theholocron/holocron-plugin-neon      (storage)
   holocron-plugin-clerk/          — @theholocron/holocron-plugin-clerk     (auth)
-  holocron-plugin-1password/      — @theholocron/holocron-plugin-1password (vault)
+  holocron-plugin-1password/      — @theholocron/holocron-plugin-1password (vault — CLI shell-out)
+  holocron-plugin-doppler/        — @theholocron/holocron-plugin-doppler   (vault — REST)
+  holocron-plugin-infisical/      — @theholocron/holocron-plugin-infisical (vault — REST)
   holocron-plugin-postman/        — @theholocron/holocron-plugin-postman   (tooling)
-holocron.config.json              — this repo's own holocron config (self-hosted)
+holocron.config.ts                — this repo's own holocron config (self-hosted)
 .notes/                           — design specs (draft → proposed → approved)
 .claude/skills/holocron-plugin.md — scaffolding skill for new plugins
 
@@ -153,7 +158,7 @@ holocron.config.json              — this repo's own holocron config (self-host
 
 ## Self-hosting
 
-This repo carries its own `holocron.config.json` so holocron commands
+This repo carries its own `holocron.config.ts` so holocron commands
 work inside it, and publishes its own packages via npm Trusted
 Publishing (OIDC — no stored `NPM_TOKEN`). Setup + new-package
 bootstrap live in [`docs/self-hosting.md`](./docs/self-hosting.md).

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A pluggable, capability-based CLI for spinning up and operating software project
 > archive under the `v1.0.0` git tag. Design in
 > [`.notes/archive/tech-architecture.spec.md`](./.notes/archive/tech-architecture.spec.md)
 > (tracked in [#74](https://github.com/theholocron/holocron/issues/74)).
+
 ## Quickstart
 
 <!-- prettier-ignore -->

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A pluggable, capability-based CLI for spinning up and operating software project
 > archive under the `v1.0.0` git tag. Design in
 > [`.notes/archive/tech-architecture.spec.md`](./.notes/archive/tech-architecture.spec.md)
 > (tracked in [#74](https://github.com/theholocron/holocron/issues/74)).
-
 ## Quickstart
 
 <!-- prettier-ignore -->

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -74,7 +74,7 @@ In the npm web UI, for each `@theholocron/*` package:
     - **Workflow filename**: `release.yml`
     - **Environment** (optional): leave blank
 
-Currently configured (as of v2.0.0-alpha.0):
+Currently configured:
 
 - `@theholocron/cli`
 - `@theholocron/holocron-plugin-github`
@@ -82,6 +82,8 @@ Currently configured (as of v2.0.0-alpha.0):
 - `@theholocron/holocron-plugin-neon`
 - `@theholocron/holocron-plugin-clerk`
 - `@theholocron/holocron-plugin-1password`
+- `@theholocron/holocron-plugin-doppler`
+- `@theholocron/holocron-plugin-infisical`
 - `@theholocron/holocron-plugin-postman`
 
 If npm's UI exposes org-level Trusted Publishers in the future, one


### PR DESCRIPTION
## Summary

- Removes stale `cli-utils/` entry from repo layout tables in `README.md` and `AGENTS.md` (package no longer exists)
- Adds `holocron-plugin-doppler` and `holocron-plugin-infisical` to all repo layout tables and the Trusted Publisher list in `docs/self-hosting.md`
- Updates vault section in the quickstart to present all three vault options (doppler, 1password, infisical) instead of hardcoding 1password
- Updates `holocron.config.json` → `holocron.config.ts` references (this repo uses the TS format)
- Fixes the "7 public packages" count in `AGENTS.md` → 9
- Removes stale `cli-utils` mention from the Quality test-patterns section in `AGENTS.md`