### PR TITLE
feat(cli): add clone command to mirror org repos into a sibling directory

### DIFF
--- a/packages/cli/src/__tests__/clone.test.ts
+++ b/packages/cli/src/__tests__/clone.test.ts
@@ -149,6 +149,22 @@ describe("runClone", () => {
 		expect(report.message).toMatch(/403/);
 	});
 
+	it("strips leading dot from repo name so hidden repos are visible in Finder", async () => {
+		const repos = [makeRepo(".github"), makeRepo(".github-private")];
+		const report = await runClone({
+			org: "test-org",
+			dir: tmpDir,
+			token: "tok",
+			fetch: makeFetch(repos),
+			exec,
+			print,
+		});
+
+		expect(report.cloned).toBe(2);
+		expect(exec).toHaveBeenCalledWith("git", ["clone", repos[0].ssh_url, join(tmpDir, "github")], { cwd: tmpDir });
+		expect(exec).toHaveBeenCalledWith("git", ["clone", repos[1].ssh_url, join(tmpDir, "github-private")], { cwd: tmpDir });
+	});
+
 	it("paginates through multiple pages of repos", async () => {
 		const page1 = [makeRepo("alpha")];
 		const page2 = [makeRepo("beta")];

--- a/packages/cli/src/__tests__/clone.test.ts
+++ b/packages/cli/src/__tests__/clone.test.ts
@@ -162,7 +162,9 @@ describe("runClone", () => {
 
 		expect(report.cloned).toBe(2);
 		expect(exec).toHaveBeenCalledWith("git", ["clone", repos[0].ssh_url, join(tmpDir, "github")], { cwd: tmpDir });
-		expect(exec).toHaveBeenCalledWith("git", ["clone", repos[1].ssh_url, join(tmpDir, "github-private")], { cwd: tmpDir });
+		expect(exec).toHaveBeenCalledWith("git", ["clone", repos[1].ssh_url, join(tmpDir, "github-private")], {
+			cwd: tmpDir,
+		});
 	});
 
 	it("paginates through multiple pages of repos", async () => {

--- a/packages/cli/src/__tests__/clone.test.ts
+++ b/packages/cli/src/__tests__/clone.test.ts
@@ -1,0 +1,182 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runClone } from "../commands/clone.js";
+
+function makeRepo(name: string, org = "test-org") {
+	return {
+		name,
+		full_name: `${org}/${name}`,
+		ssh_url: `git@github.com:${org}/${name}.git`,
+		archived: false,
+	};
+}
+
+function makeFetch(repos: ReturnType<typeof makeRepo>[]): typeof globalThis.fetch {
+	return vi.fn().mockResolvedValue({
+		ok: true,
+		json: async () => repos,
+		headers: { get: () => null },
+	}) as unknown as typeof globalThis.fetch;
+}
+
+describe("runClone", () => {
+	let tmpDir: string;
+	const lines: string[] = [];
+	const print = (line: string) => lines.push(line);
+	const exec = vi.fn(() => ({ status: 0 }));
+
+	beforeEach(async () => {
+		tmpDir = await mkdtemp(join(tmpdir(), "holocron-clone-test-"));
+		lines.length = 0;
+		exec.mockReset();
+		exec.mockReturnValue({ status: 0 });
+	});
+
+	afterEach(async () => {
+		await rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("clones all repos into the target directory", async () => {
+		const repos = [makeRepo("alpha"), makeRepo("beta")];
+		const report = await runClone({
+			org: "test-org",
+			dir: tmpDir,
+			token: "tok",
+			fetch: makeFetch(repos),
+			exec,
+			print,
+		});
+
+		expect(report.status).toBe("ok");
+		expect(report.cloned).toBe(2);
+		expect(report.skipped).toBe(0);
+		expect(report.failed).toBe(0);
+		expect(exec).toHaveBeenCalledTimes(2);
+		expect(exec).toHaveBeenCalledWith("git", ["clone", repos[0].ssh_url, join(tmpDir, "alpha")], { cwd: tmpDir });
+		expect(exec).toHaveBeenCalledWith("git", ["clone", repos[1].ssh_url, join(tmpDir, "beta")], { cwd: tmpDir });
+	});
+
+	it("skips repos whose directory already exists", async () => {
+		await mkdir(join(tmpDir, "alpha"));
+		const repos = [makeRepo("alpha"), makeRepo("beta")];
+		const report = await runClone({
+			org: "test-org",
+			dir: tmpDir,
+			token: "tok",
+			fetch: makeFetch(repos),
+			exec,
+			print,
+		});
+
+		expect(report.cloned).toBe(1);
+		expect(report.skipped).toBe(1);
+		expect(exec).toHaveBeenCalledTimes(1);
+		expect(exec).toHaveBeenCalledWith("git", ["clone", repos[1].ssh_url, join(tmpDir, "beta")], { cwd: tmpDir });
+	});
+
+	it("counts failed clones and returns fail status", async () => {
+		exec.mockReturnValue({ status: 128 });
+		const repos = [makeRepo("alpha")];
+		const report = await runClone({
+			org: "test-org",
+			dir: tmpDir,
+			token: "tok",
+			fetch: makeFetch(repos),
+			exec,
+			print,
+		});
+
+		expect(report.status).toBe("fail");
+		expect(report.failed).toBe(1);
+		expect(report.cloned).toBe(0);
+	});
+
+	it("dry-run does not call exec and reports cloned count", async () => {
+		const repos = [makeRepo("alpha"), makeRepo("beta")];
+		const report = await runClone({
+			org: "test-org",
+			dir: tmpDir,
+			token: "tok",
+			dryRun: true,
+			fetch: makeFetch(repos),
+			exec,
+			print,
+		});
+
+		expect(report.status).toBe("dry-run");
+		expect(report.cloned).toBe(2);
+		expect(exec).not.toHaveBeenCalled();
+	});
+
+	it("defaults target dir to ~/Code/<org>", async () => {
+		const repos: ReturnType<typeof makeRepo>[] = [];
+		const report = await runClone({
+			org: "my-org",
+			token: "tok",
+			dryRun: true,
+			fetch: makeFetch(repos),
+			exec,
+			print,
+		});
+
+		expect(report.status).toBe("dry-run");
+		expect(lines[0]).toContain(join(homedir(), "Code", "my-org"));
+	});
+
+	it("returns fail when the GitHub API call errors", async () => {
+		const badFetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 403,
+			statusText: "Forbidden",
+			headers: { get: () => null },
+		}) as unknown as typeof globalThis.fetch;
+
+		const report = await runClone({
+			org: "test-org",
+			dir: tmpDir,
+			token: "tok",
+			fetch: badFetch,
+			exec,
+			print,
+		});
+
+		expect(report.status).toBe("fail");
+		expect(report.message).toMatch(/403/);
+	});
+
+	it("paginates through multiple pages of repos", async () => {
+		const page1 = [makeRepo("alpha")];
+		const page2 = [makeRepo("beta")];
+		const nextUrl = "https://api.github.com/orgs/test-org/repos?page=2";
+
+		const paginatedFetch = vi
+			.fn()
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => page1,
+				headers: { get: (h: string) => (h === "link" ? `<${nextUrl}>; rel="next"` : null) },
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => page2,
+				headers: { get: () => null },
+			}) as unknown as typeof globalThis.fetch;
+
+		const report = await runClone({
+			org: "test-org",
+			dir: tmpDir,
+			token: "tok",
+			fetch: paginatedFetch,
+			exec,
+			print,
+		});
+
+		expect(paginatedFetch).toHaveBeenCalledTimes(2);
+		expect(report.cloned).toBe(2);
+	});
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,6 +10,7 @@ import { stdin, stdout } from "node:process";
 import type { CapabilityKey } from "./capabilities/index.js";
 import { CARDINALITY } from "./capabilities/index.js";
 import { runAuthCheck, runAuthList, runAuthSet, runAuthUnset } from "./commands/auth.js";
+import { runClone } from "./commands/clone.js";
 import { NewError, runNew } from "./commands/new.js";
 import { runDeploy } from "./commands/deploy.js";
 import { runDoctor } from "./commands/doctor.js";
@@ -80,6 +81,42 @@ await yargs(hideBin(process.argv))
 		() => {},
 		() => {
 			console.log(`holocron ${CLI_VERSION}`);
+		}
+	)
+	.command(
+		"clone",
+		"Clone all repos in a GitHub org as siblings under a single directory",
+		(y) =>
+			y
+				.option("org", {
+					type: "string",
+					demandOption: true,
+					describe: "GitHub org to clone (e.g., theholocron)",
+				})
+				.option("dir", {
+					type: "string",
+					describe: "Parent directory to clone into (default: ~/Code/<org>)",
+				}),
+		async (argv) => {
+			const tokens = tokenContext(argv.token);
+			if (!tokens) return;
+			const token =
+				tokens.cliTokens?.["github"] ??
+				tokens.cliToken ??
+				process.env.GITHUB_TOKEN ??
+				process.env.HOLOCRON_GITHUB_TOKEN;
+			if (!token) {
+				console.error("clone: GitHub token required — pass --token or set GITHUB_TOKEN");
+				process.exitCode = 1;
+				return;
+			}
+			const report = await runClone({
+				org: argv.org,
+				token,
+				dryRun: argv.dryRun,
+				...(argv.dir ? { dir: argv.dir } : {}),
+			});
+			if (report.status === "fail") process.exitCode = 1;
 		}
 	)
 	.command(

--- a/packages/cli/src/commands/clone.ts
+++ b/packages/cli/src/commands/clone.ts
@@ -100,7 +100,9 @@ export async function runClone(input: RunCloneInput): Promise<CloneReport> {
 	let failed = 0;
 
 	for (const repo of repos) {
-		const dest = join(targetDir, repo.name);
+		// Strip leading dot so hidden repos (e.g. .github) are visible in Finder.
+		const dirName = repo.name.startsWith(".") ? repo.name.slice(1) : repo.name;
+		const dest = join(targetDir, dirName);
 
 		if (existsSync(dest)) {
 			print(style.dim(`  skip   ${repo.full_name}`));

--- a/packages/cli/src/commands/clone.ts
+++ b/packages/cli/src/commands/clone.ts
@@ -129,7 +129,13 @@ export async function runClone(input: RunCloneInput): Promise<CloneReport> {
 	}
 
 	const summary = `${cloned} cloned, ${skipped} skipped, ${failed} failed`;
-	print(dryRun ? style.dim(`\n  dry-run: ${summary}`) : failed > 0 ? style.fail(`\n  ${summary}`) : style.success(`\n  ${summary}`));
+	print(
+		dryRun
+			? style.dim(`\n  dry-run: ${summary}`)
+			: failed > 0
+				? style.fail(`\n  ${summary}`)
+				: style.success(`\n  ${summary}`)
+	);
 
 	return {
 		status: dryRun ? "dry-run" : failed > 0 ? "fail" : "ok",

--- a/packages/cli/src/commands/clone.ts
+++ b/packages/cli/src/commands/clone.ts
@@ -1,0 +1,138 @@
+import { existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { style } from "../ui/style.js";
+
+interface GitHubRepo {
+	name: string;
+	full_name: string;
+	ssh_url: string;
+	archived: boolean;
+}
+
+type ExecFn = (cmd: string, args: string[], opts: { cwd: string }) => { status: number | null };
+
+export interface RunCloneInput {
+	org: string;
+	/** Parent directory to clone into. Defaults to ~/Code/<org>. */
+	dir?: string;
+	token: string;
+	dryRun?: boolean;
+	fetch?: typeof globalThis.fetch;
+	exec?: ExecFn;
+	print?: (line: string) => void;
+}
+
+export interface CloneReport {
+	status: "ok" | "fail" | "dry-run";
+	cloned: number;
+	skipped: number;
+	failed: number;
+	message?: string;
+}
+
+async function listOrgRepos(org: string, token: string, fetchFn: typeof globalThis.fetch): Promise<GitHubRepo[]> {
+	const repos: GitHubRepo[] = [];
+	let url: string | null = `https://api.github.com/orgs/${org}/repos?per_page=100&type=all`;
+
+	while (url) {
+		const res = await fetchFn(url, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github+json",
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+		});
+
+		if (!res.ok) {
+			throw new Error(`GitHub API ${res.status}: ${res.statusText} — check that the token has org:read scope`);
+		}
+
+		repos.push(...((await res.json()) as GitHubRepo[]));
+
+		const link = res.headers.get("link");
+		const next = link?.match(/<([^>]+)>;\s*rel="next"/);
+		url = next ? next[1] : null;
+	}
+
+	return repos;
+}
+
+export async function runClone(input: RunCloneInput): Promise<CloneReport> {
+	const print = input.print ?? ((line: string) => console.log(line));
+	const fetchFn = input.fetch ?? globalThis.fetch;
+	const dryRun = input.dryRun ?? false;
+	const targetDir = resolve(input.dir ?? join(homedir(), "Code", input.org));
+	const exec: ExecFn =
+		input.exec ??
+		((cmd, args, opts) => {
+			const r = spawnSync(cmd, args, { cwd: opts.cwd, stdio: "inherit" });
+			return { status: r.status };
+		});
+
+	print(style.header(`Holocron clone — org=${input.org} → ${targetDir}${dryRun ? " (dry-run)" : ""}`));
+
+	if (!existsSync(targetDir)) {
+		if (dryRun) {
+			print(style.dim(`  would create ${targetDir}`));
+		} else {
+			mkdirSync(targetDir, { recursive: true });
+		}
+	}
+
+	let repos: GitHubRepo[];
+	try {
+		repos = await listOrgRepos(input.org, input.token, fetchFn);
+	} catch (err) {
+		return {
+			status: "fail",
+			cloned: 0,
+			skipped: 0,
+			failed: 0,
+			message: err instanceof Error ? err.message : String(err),
+		};
+	}
+
+	let cloned = 0;
+	let skipped = 0;
+	let failed = 0;
+
+	for (const repo of repos) {
+		const dest = join(targetDir, repo.name);
+
+		if (existsSync(dest)) {
+			print(style.dim(`  skip   ${repo.full_name}`));
+			skipped++;
+			continue;
+		}
+
+		if (dryRun) {
+			print(style.dim(`  would clone ${repo.full_name} → ${dest}`));
+			cloned++;
+			continue;
+		}
+
+		print(style.step(`  clone  ${repo.full_name}`));
+		const result = exec("git", ["clone", repo.ssh_url, dest], { cwd: targetDir });
+
+		if (result.status !== 0) {
+			print(style.fail(`  failed ${repo.full_name}`));
+			failed++;
+		} else {
+			print(style.success(`  cloned ${repo.name}`));
+			cloned++;
+		}
+	}
+
+	const summary = `${cloned} cloned, ${skipped} skipped, ${failed} failed`;
+	print(dryRun ? style.dim(`\n  dry-run: ${summary}`) : failed > 0 ? style.fail(`\n  ${summary}`) : style.success(`\n  ${summary}`));
+
+	return {
+		status: dryRun ? "dry-run" : failed > 0 ? "fail" : "ok",
+		cloned,
+		skipped,
+		failed,
+	};
+}


### PR DESCRIPTION
## Summary

- Adds `holocron clone --org <org> [--dir <dir>]` command
- Lists all repos in the org via the GitHub API (paginated, uses `--token` / `GITHUB_TOKEN`)
- Clones each repo with `git clone` (SSH URL) into `<dir>/<repo-name>`
- `--dir` defaults to `~/Code/<org>`, enforcing the sibling layout that agent `@` imports rely on (e.g. `@../github-private/AGENTS.md`)
- Skips repos whose local directory already exists
- Supports `--dry-run`

## Test plan

- [x] 7 unit tests: clone, skip existing, fail handling, dry-run, default dir, API error, pagination
- [ ] Manual: `holocron clone --org theholocron --dry-run` lists all repos with target paths