### PR TITLE
fix(cli): drop script name prefix from command list in help output

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -50,8 +50,8 @@ function tokenContext(rawTokens: string[] | undefined): ParsedTokenArgs | null {
 const updateCheckPromise = checkForUpdates(CLI_VERSION);
 
 await yargs(hideBin(process.argv))
-	.scriptName("holocron")
-	.usage("$0 <command> [options]")
+	.scriptName("")
+	.usage("holocron <command> [options]")
 	// ── global options (apply to every subcommand) ──────────────────────
 	.option("dry-run", {
 		type: "boolean",


### PR DESCRIPTION
## Summary

- Sets `.scriptName("")` and hardcodes `"holocron"` only in `.usage()`, so the `Commands:` list shows bare subcommand names (`version`, `clone`, `setup` …) instead of repeating `holocron` before each one
- Matches the convention used by `git`, `npm`, `pnpm`, and `gh`

## Test plan

- [ ] `holocron --help` shows commands without the `holocron ` prefix in the list