### PR TITLE
fix(review): switch Reviewdog reporter to github-pr-annotations

### DIFF
--- a/packages/cli/src/templates/workflows/review.yml
+++ b/packages/cli/src/templates/workflows/review.yml
@@ -21,7 +21,6 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      checks: write
       pull-requests: write
 
     steps:
@@ -69,7 +68,7 @@ jobs:
       - name: Gitleaks (secrets)
         uses: reviewdog/action-gitleaks@2b7b5685e3e3eecddab5d30cfa04f18123031421 # v1
         with:
-          reporter: github-pr-check
+          reporter: github-pr-annotations
           tool_name: "Review / gitleaks"
           gitleaks_flags: --log-opts=${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
 
@@ -77,7 +76,7 @@ jobs:
         if: ${{ hashFiles('yamllint.config.yml') != '' }}
         uses: reviewdog/action-yamllint@b5f7217d8c815ae374d1d55840d5e569d82f01f0 # v1
         with:
-          reporter: github-pr-check
+          reporter: github-pr-annotations
           tool_name: "Review / yamllint"
           yamllint_flags: -c ${{ github.workspace }}/yamllint.config.yml ${{ github.workspace }}
 
@@ -85,7 +84,7 @@ jobs:
         if: ${{ hashFiles('.github/workflows/*.yml', '.github/workflows/*.yaml') != '' }}
         uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1
         with:
-          reporter: github-pr-check
+          reporter: github-pr-annotations
           tool_name: "Review / actionlint"
 
       #
@@ -96,7 +95,7 @@ jobs:
         if: steps.detect.outputs.eslint == 'true'
         uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1.34.0
         with:
-          reporter: github-pr-check
+          reporter: github-pr-annotations
           tool_name: "Review / eslint"
           eslint_flags: .
 
@@ -104,7 +103,7 @@ jobs:
         if: steps.detect.outputs.tsconfig == 'true'
         uses: EPMatt/reviewdog-action-tsc@63d923a3c5b4497671940b8874f58a404e2351b5 # v1
         with:
-          reporter: github-pr-check
+          reporter: github-pr-annotations
           tool_name: "Review / tsc"
 
       #
@@ -115,7 +114,7 @@ jobs:
         if: steps.detect.outputs.shell == 'true'
         uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1
         with:
-          reporter: github-pr-check
+          reporter: github-pr-annotations
           tool_name: "Review / shellcheck"
           fail_level: none
 
@@ -127,7 +126,7 @@ jobs:
         if: steps.detect.outputs.docker == 'true'
         uses: reviewdog/action-hadolint@1b2cfa6ba72072ad35158d7ff3aa49bbdc03506d # v1
         with:
-          reporter: github-pr-check
+          reporter: github-pr-annotations
           tool_name: "Review / hadolint"
           fail_level: none
 
@@ -149,5 +148,5 @@ jobs:
         if: steps.detect.outputs.markdown == 'true'
         uses: reviewdog/action-alex@347481655add010a2ae302df34b57c9bcfa0d6e4 # v1
         with:
-          reporter: github-pr-check
+          reporter: github-pr-annotations
           tool_name: "Review / alex"


### PR DESCRIPTION
## Summary

- Replaces `reporter: github-pr-check` with `reporter: github-pr-annotations` across all Reviewdog steps in the review workflow template
- Removes `checks: write` permission, which was only needed to create Check Runs
- Leaves `reporter: github-code-suggestions` on the dotenv-linter step unchanged

## Why

`github-pr-check` creates standalone GitHub Check Runs without specifying a `check_suite_id`. GitHub auto-assigns each run to the most recently created suite for that commit. When `Build` and `Review` workflows run concurrently on the same commit, Check Runs created by Reviewdog get attributed to whichever suite was created last — producing the random `Build / Review / …` mislabeling in the PR Checks UI.

`github-pr-annotations` writes annotations directly to the current workflow job via the Actions runner output, so there is no suite-assignment race.

This also aligns the implementation with the workflow's own stated intent: _"ReviewDog is the annotation layer — posts inline PR diff annotations."_

## Test plan

- [ ] Merge and sync to `theholocron/.github` via `sync-workflow-templates`
- [ ] Open a test PR in any consuming repo with both `Build` and `Review` workflows active
- [ ] Confirm Reviewdog findings appear as inline annotations on the `Review / Review PRs` job rather than as separate `Build / Review / …` check cards