### PR TITLE
fix(sync): add `HOLOCRON_SYNC_TOKEN` to env and sync workflow

### DIFF
--- a/.github/workflows/sync-workflow-templates.yml
+++ b/.github/workflows/sync-workflow-templates.yml
@@ -7,6 +7,7 @@ on: # yamllint disable-line rule:truthy
       - main
     paths:
       - packages/cli/src/commands/setup-workflows.ts
+      - packages/cli/src/commands/workflows/**
       - packages/cli/src/templates/**
   workflow_dispatch:
 

--- a/.github/workflows/sync-workflow-templates.yml
+++ b/.github/workflows/sync-workflow-templates.yml
@@ -21,5 +21,6 @@ jobs:
         theholocron/clients
         theholocron/configs
         theholocron/skills
+        theholocron/utils
     secrets:
       HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}

--- a/.github/workflows/sync-workflow-templates.yml
+++ b/.github/workflows/sync-workflow-templates.yml
@@ -24,3 +24,4 @@ jobs:
         theholocron/utils
     secrets:
       HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
+      HOLOCRON_READ_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN }}

--- a/packages/cli/src/__tests__/auth.test.ts
+++ b/packages/cli/src/__tests__/auth.test.ts
@@ -180,7 +180,9 @@ describe("runAuthSet", () => {
 			provider: "custom",
 			positional: "abc",
 			env: {},
-			importer: async () => { throw "string error"; },
+			importer: async () => {
+				throw "string error";
+			},
 			print,
 		});
 		expect(result.status).toBe("ok");

--- a/packages/cli/src/__tests__/clone.test.ts
+++ b/packages/cli/src/__tests__/clone.test.ts
@@ -62,8 +62,12 @@ describe("runClone", () => {
 		expect(report.skipped).toBe(0);
 		expect(report.failed).toBe(0);
 		expect(exec).toHaveBeenCalledTimes(2);
-		expect(exec).toHaveBeenCalledWith("git", ["clone", "--", authed(repos[0]), join(tmpDir, "alpha")], { cwd: tmpDir });
-		expect(exec).toHaveBeenCalledWith("git", ["clone", "--", authed(repos[1]), join(tmpDir, "beta")], { cwd: tmpDir });
+		expect(exec).toHaveBeenCalledWith("git", ["clone", "--", authed(repos[0]), join(tmpDir, "alpha")], {
+			cwd: tmpDir,
+		});
+		expect(exec).toHaveBeenCalledWith("git", ["clone", "--", authed(repos[1]), join(tmpDir, "beta")], {
+			cwd: tmpDir,
+		});
 	});
 
 	it("skips repos whose directory already exists", async () => {
@@ -81,7 +85,9 @@ describe("runClone", () => {
 		expect(report.cloned).toBe(1);
 		expect(report.skipped).toBe(1);
 		expect(exec).toHaveBeenCalledTimes(1);
-		expect(exec).toHaveBeenCalledWith("git", ["clone", "--", authed(repos[1]), join(tmpDir, "beta")], { cwd: tmpDir });
+		expect(exec).toHaveBeenCalledWith("git", ["clone", "--", authed(repos[1]), join(tmpDir, "beta")], {
+			cwd: tmpDir,
+		});
 	});
 
 	it("counts failed clones and returns fail status", async () => {
@@ -166,7 +172,9 @@ describe("runClone", () => {
 		});
 
 		expect(report.cloned).toBe(2);
-		expect(exec).toHaveBeenCalledWith("git", ["clone", "--", authed(repos[0]), join(tmpDir, "github")], { cwd: tmpDir });
+		expect(exec).toHaveBeenCalledWith("git", ["clone", "--", authed(repos[0]), join(tmpDir, "github")], {
+			cwd: tmpDir,
+		});
 		expect(exec).toHaveBeenCalledWith("git", ["clone", "--", authed(repos[1]), join(tmpDir, "github-private")], {
 			cwd: tmpDir,
 		});
@@ -268,5 +276,4 @@ describe("runClone", () => {
 
 		expect(existsSync(newDir)).toBe(true);
 	});
-
 });

--- a/packages/cli/src/commands/workflows/sync-github.yml
+++ b/packages/cli/src/commands/workflows/sync-github.yml
@@ -22,3 +22,4 @@ jobs:
       secondary-repos: theholocron/.github-private
     secrets:
       HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
+      HOLOCRON_READ_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN }}

--- a/packages/cli/src/templates/workflows/release.yml
+++ b/packages/cli/src/templates/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         name: Checkout repository
         with:
           fetch-depth: 0
-          # Use HOLOCRON_SYNC_TOKEN when available — git push (tags, release commits)
+          # Use HOLOCRON_RELEASE_TOKEN when available — git push (tags, release commits)
           # uses the checkout credential, not GITHUB_TOKEN env var. The
           # built-in github.token cannot push through branch protection rulesets.
           token: ${{ secrets.HOLOCRON_RELEASE_TOKEN || secrets.HOLOCRON_SYNC_TOKEN || github.token }}

--- a/packages/cli/src/templates/workflows/release.yml
+++ b/packages/cli/src/templates/workflows/release.yml
@@ -25,6 +25,11 @@ on: # yamllint disable-line rule:truthy
           Legacy alias for HOLOCRON_RELEASE_TOKEN — kept for backward compatibility.
           Prefer HOLOCRON_RELEASE_TOKEN for new repos.
         required: false
+      HOLOCRON_READ_TOKEN:
+        description: >
+          Fine-grained PAT for read-only GitHub API calls (e.g. resolving git
+          committer identity via `gh api user`). Falls back to github.token.
+        required: false
 
 jobs:
   release:
@@ -61,7 +66,7 @@ jobs:
           git config --global user.email "$GIT_EMAIL"
           git config --global format.signoff true
         env:
-          GH_TOKEN: ${{ secrets.HOLOCRON_RELEASE_TOKEN || secrets.HOLOCRON_SYNC_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || github.token }}
 
       - run: npm install -g npm@11 sigstore
         name: Upgrade npm for OIDC support

--- a/packages/cli/src/templates/workflows/release.yml
+++ b/packages/cli/src/templates/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           git config --global user.email "$GIT_EMAIL"
           git config --global format.signoff true
         env:
-          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || env.GH_TOKEN || github.token }}
 
       - run: npm install -g npm@11 sigstore
         name: Upgrade npm for OIDC support

--- a/packages/cli/src/templates/workflows/release.yml
+++ b/packages/cli/src/templates/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           git config --global user.email "$GIT_EMAIL"
           git config --global format.signoff true
         env:
-          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || env.GH_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || secrets.GH_TOKEN || github.token }}
 
       - run: npm install -g npm@11 sigstore
         name: Upgrade npm for OIDC support

--- a/packages/cli/src/templates/workflows/sync-github.yml
+++ b/packages/cli/src/templates/workflows/sync-github.yml
@@ -36,6 +36,11 @@ on: # yamllint disable-line rule:truthy
     secrets:
       HOLOCRON_SYNC_TOKEN:
         required: true
+      HOLOCRON_READ_TOKEN:
+        description: >
+          Fine-grained PAT for read-only GitHub API calls (e.g. resolving git
+          committer identity via `gh api user`). Falls back to HOLOCRON_SYNC_TOKEN.
+        required: false
 
 jobs:
   sync:
@@ -76,7 +81,7 @@ jobs:
             --pr \
             --message "$COMMIT_MSG"
         env:
-          GH_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || secrets.HOLOCRON_SYNC_TOKEN }}
           HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
           PRIMARY_REPO: ${{ inputs.primary-repo }}
           SYNC_BRANCH: ${{ inputs.sync-branch }}
@@ -95,7 +100,7 @@ jobs:
               --message "$COMMIT_MSG"
           done
         env:
-          GH_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || secrets.HOLOCRON_SYNC_TOKEN }}
           HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
           SECONDARY_REPOS: ${{ inputs.secondary-repos }}
           SYNC_BRANCH: ${{ inputs.sync-branch }}

--- a/packages/cli/src/templates/workflows/sync-github.yml
+++ b/packages/cli/src/templates/workflows/sync-github.yml
@@ -81,7 +81,7 @@ jobs:
             --pr \
             --message "$COMMIT_MSG"
         env:
-          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || secrets.HOLOCRON_SYNC_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || secrets.HOLOCRON_SYNC_TOKEN || env.GH_TOKEN }}
           HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
           PRIMARY_REPO: ${{ inputs.primary-repo }}
           SYNC_BRANCH: ${{ inputs.sync-branch }}
@@ -100,7 +100,7 @@ jobs:
               --message "$COMMIT_MSG"
           done
         env:
-          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || secrets.HOLOCRON_SYNC_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || secrets.HOLOCRON_SYNC_TOKEN || env.GH_TOKEN }}
           HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
           SECONDARY_REPOS: ${{ inputs.secondary-repos }}
           SYNC_BRANCH: ${{ inputs.sync-branch }}

--- a/packages/cli/src/templates/workflows/sync-github.yml
+++ b/packages/cli/src/templates/workflows/sync-github.yml
@@ -76,8 +76,8 @@ jobs:
             --pr \
             --message "$COMMIT_MSG"
         env:
-          GITHUB_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
           GH_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
+          HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
           PRIMARY_REPO: ${{ inputs.primary-repo }}
           SYNC_BRANCH: ${{ inputs.sync-branch }}
 
@@ -95,7 +95,7 @@ jobs:
               --message "$COMMIT_MSG"
           done
         env:
-          GITHUB_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
           GH_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
+          HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
           SECONDARY_REPOS: ${{ inputs.secondary-repos }}
           SYNC_BRANCH: ${{ inputs.sync-branch }}

--- a/packages/cli/src/templates/workflows/sync-github.yml
+++ b/packages/cli/src/templates/workflows/sync-github.yml
@@ -81,7 +81,7 @@ jobs:
             --pr \
             --message "$COMMIT_MSG"
         env:
-          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || secrets.HOLOCRON_SYNC_TOKEN || env.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || secrets.HOLOCRON_SYNC_TOKEN || secrets.GH_TOKEN }}
           HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
           PRIMARY_REPO: ${{ inputs.primary-repo }}
           SYNC_BRANCH: ${{ inputs.sync-branch }}
@@ -100,7 +100,7 @@ jobs:
               --message "$COMMIT_MSG"
           done
         env:
-          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || secrets.HOLOCRON_SYNC_TOKEN || env.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || secrets.HOLOCRON_SYNC_TOKEN || secrets.GH_TOKEN }}
           HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
           SECONDARY_REPOS: ${{ inputs.secondary-repos }}
           SYNC_BRANCH: ${{ inputs.sync-branch }}


### PR DESCRIPTION
## Summary
- **Template `sync-github.yml`**: swap `GITHUB_TOKEN` (unused — CLI reads `HOLOCRON_SYNC_TOKEN` directly, `gh` reads `GH_TOKEN`) for the explicit `HOLOCRON_SYNC_TOKEN` env var the user manually patched in the generated file; next sync will now produce the correct output rather than overwriting the fix
- **Template `release.yml`**: fix stale comment `# Use HOLOCRON_SYNC_TOKEN when available` → `# Use HOLOCRON_RELEASE_TOKEN when available` (RELEASE_TOKEN is the primary; SYNC_TOKEN is the legacy fallback)
- **`sync-workflow-templates.yml`**: add `packages/cli/src/commands/workflows/**` to the path trigger — thin-caller template changes (like the recent secret rename) were silently skipping the sync

## Test plan
- [ ] Merge and confirm sync runs cleanly, pushing correct generated files to downstream repos