### PR TITLE
fix(sync): remove HOLOCRON_READ_TOKEN from callers until reusable workflow declares it

### DIFF
--- a/.github/workflows/sync-workflow-templates.yml
+++ b/.github/workflows/sync-workflow-templates.yml
@@ -24,4 +24,3 @@ jobs:
         theholocron/utils
     secrets:
       HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
-      HOLOCRON_READ_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN }}

--- a/packages/cli/src/commands/workflows/sync-github.yml
+++ b/packages/cli/src/commands/workflows/sync-github.yml
@@ -22,4 +22,3 @@ jobs:
       secondary-repos: theholocron/.github-private
     secrets:
       HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}
-      HOLOCRON_READ_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN }}


### PR DESCRIPTION
## Summary
Passing `HOLOCRON_READ_TOKEN` to the reusable `sync-github.yml` causes a `startup_failure` — GitHub rejects secrets at workflow startup if the reusable workflow hasn't declared them. The live reusable workflow in `.github-repo` only declares `HOLOCRON_SYNC_TOKEN`.

Remove it from both callers now. Once the sync runs and pushes the updated template (which declares `HOLOCRON_READ_TOKEN` as `required: false`), callers can optionally pass it.