### PR TITLE
fix(sync): declare GH_TOKEN as optional secret in reusable workflows

### DIFF
--- a/packages/cli/src/templates/workflows/release.yml
+++ b/packages/cli/src/templates/workflows/release.yml
@@ -30,6 +30,11 @@ on: # yamllint disable-line rule:truthy
           Fine-grained PAT for read-only GitHub API calls (e.g. resolving git
           committer identity via `gh api user`). Falls back to github.token.
         required: false
+      GH_TOKEN:
+        description: >
+          Generic GitHub token fallback for `gh` CLI calls. Used when
+          HOLOCRON_READ_TOKEN is not set.
+        required: false
 
 jobs:
   release:

--- a/packages/cli/src/templates/workflows/sync-github.yml
+++ b/packages/cli/src/templates/workflows/sync-github.yml
@@ -41,6 +41,11 @@ on: # yamllint disable-line rule:truthy
           Fine-grained PAT for read-only GitHub API calls (e.g. resolving git
           committer identity via `gh api user`). Falls back to HOLOCRON_SYNC_TOKEN.
         required: false
+      GH_TOKEN:
+        description: >
+          Generic GitHub token fallback for `gh` CLI calls. Used when neither
+          HOLOCRON_READ_TOKEN nor HOLOCRON_SYNC_TOKEN is set.
+        required: false
 
 jobs:
   sync:


### PR DESCRIPTION
## Summary
actionlint correctly rejects `secrets.GH_TOKEN` in a `workflow_call` reusable workflow when `GH_TOKEN` isn't declared in the `secrets:` block. Adds it as `required: false` to both `sync-github.yml` and `release.yml` templates so the fallback chain `HOLOCRON_READ_TOKEN || secrets.GH_TOKEN || ...` is valid.