### PR TITLE
fix(clone): disable no-control-regex for intentional security check

### DIFF
--- a/packages/cli/src/commands/clone.ts
+++ b/packages/cli/src/commands/clone.ts
@@ -8,6 +8,7 @@ import { style } from "../ui/style.js";
 function encodeTokenForGitHttpAuth(token: string): string {
 	const trimmed = token.trim();
 	if (!trimmed) throw new Error("empty token");
+	// eslint-disable-next-line no-control-regex
 	if (/[\u0000-\u001F\u007F\s]/.test(trimmed)) {
 		throw new Error("token contains whitespace or control characters");
 	}


### PR DESCRIPTION
The `no-control-regex` rule also flags Unicode escape sequences like `\u0000-\u001F`. The regex is intentional — it guards against tokens with control characters being embedded in git URLs. Suppress the rule for that line.