### PR TITLE
feat(ci): switch Codecov uploads to OIDC authentication

### DIFF
--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -2,15 +2,13 @@ name: Test
 
 on: # yamllint disable-line rule:truthy
   workflow_call:
-    secrets:
-      CODECOV_TOKEN:
-        required: false
 
 jobs:
   unit:
     name: Run tests and collect coverage
     permissions:
       contents: read
+      id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -28,11 +26,11 @@ jobs:
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         name: Upload coverage to Codecov
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
 
       - uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: '**/test-report.junit.xml'


### PR DESCRIPTION
## Summary

- Removes `CODECOV_TOKEN` secret from the reusable `test` workflow
- Adds `id-token: write` permission to the unit test job
- Switches both `codecov-action` and `test-results-action` to `use_oidc: true`

## Notes

Codecov's dashboard must be configured to trust GitHub OIDC tokens for this to work — no other code changes needed once that's done.

The `audit` workflow's `CODECOV_TOKEN` is intentionally left in place; it's used for bundle stats upload (separate concern, not yet switched).

## Test plan

- [ ] Merge and trigger a test run — confirm coverage uploads succeed without the token secret set
- [ ] Verify Codecov OIDC is enabled in the org/repo settings on the Codecov dashboard