### PR TITLE
fix: add id-token: write to test workflow caller template

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:

--- a/packages/cli/src/commands/workflows/test.yml
+++ b/packages/cli/src/commands/workflows/test.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

The reusable `test.yml` in `.github` was updated (sync #66) to use Codecov OIDC (`use_oidc: true`) instead of a token, adding `id-token: write` to its job permissions. GitHub does not inherit `id-token: write` through `secrets: inherit` — the calling workflow must grant it explicitly. The thin caller template was missing this permission, causing `startup_failure` on all repos using it.

- Adds `id-token: write` to `permissions` in `packages/cli/src/commands/workflows/test.yml`

Companion fixes already open in consumer repos: theholocron/configs#301, theholocron/clients (fix/test-oidc-permissions).

## Test plan

- [ ] CI passes on this PR
- [ ] After merge + sync, consumer repos pick up the fix automatically via `holocron setup`