### PR TITLE
feat(cli): add Sentry telemetry with command tracing and opt-out

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@napi-rs/keyring": "^1.3.0",
+    "@sentry/node": "catalog:",
     "@theholocron/github-client": "catalog:clients",
     "@theholocron/http-client": "catalog:clients",
     "chalk": "catalog:",

--- a/packages/cli/src/__tests__/telemetry.test.ts
+++ b/packages/cli/src/__tests__/telemetry.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@sentry/node", () => ({
+	init: vi.fn(),
+	setTag: vi.fn(),
+	startInactiveSpan: vi.fn(() => ({ setStatus: vi.fn(), end: vi.fn() })),
+	captureException: vi.fn(),
+	close: vi.fn().mockResolvedValue(undefined),
+}));
+
+import * as Sentry from "@sentry/node";
+
+import { captureException, flush, init, startCommand } from "../telemetry.js";
+
+type MockSpan = { setStatus: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+
+function lastSpan(): MockSpan {
+	const results = vi.mocked(Sentry.startInactiveSpan).mock.results;
+	return results[results.length - 1]?.value as MockSpan;
+}
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+	process.env = { ...originalEnv, NO_HOLOCRON_TELEMETRY: undefined, CI: undefined };
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	process.env = originalEnv;
+});
+
+// ── opt-out ──────────────────────────────────────────────────────────────────
+
+describe("when NO_HOLOCRON_TELEMETRY is set", () => {
+	beforeEach(() => {
+		process.env["NO_HOLOCRON_TELEMETRY"] = "1";
+	});
+
+	it("init: skips Sentry.init", () => {
+		init("1.0.0");
+		expect(Sentry.init).not.toHaveBeenCalled();
+	});
+
+	it("startCommand: returns a no-op and skips span creation", () => {
+		const finish = startCommand("setup");
+		expect(Sentry.startInactiveSpan).not.toHaveBeenCalled();
+		expect(() => finish(true)).not.toThrow();
+	});
+
+	it("captureException: skips Sentry.captureException", () => {
+		captureException(new Error("boom"));
+		expect(Sentry.captureException).not.toHaveBeenCalled();
+	});
+
+	it("flush: skips Sentry.close", async () => {
+		await flush();
+		expect(Sentry.close).not.toHaveBeenCalled();
+	});
+});
+
+// ── init ─────────────────────────────────────────────────────────────────────
+
+describe("init", () => {
+	it("calls Sentry.init with release and tracesSampleRate", () => {
+		init("1.2.3");
+		expect(Sentry.init).toHaveBeenCalledWith(
+			expect.objectContaining({
+				release: "holocron@1.2.3",
+				tracesSampleRate: 1.0,
+			})
+		);
+	});
+
+	it("sets environment to 'ci' when CI is set", () => {
+		process.env["CI"] = "true";
+		init("1.0.0");
+		expect(Sentry.init).toHaveBeenCalledWith(expect.objectContaining({ environment: "ci" }));
+	});
+
+	it("sets environment to 'local' when CI is not set", () => {
+		init("1.0.0");
+		expect(Sentry.init).toHaveBeenCalledWith(expect.objectContaining({ environment: "local" }));
+	});
+
+	it("sets os, node, and ci tags", () => {
+		init("1.0.0");
+		expect(Sentry.setTag).toHaveBeenCalledWith("os", process.platform);
+		expect(Sentry.setTag).toHaveBeenCalledWith("node", process.version);
+		expect(Sentry.setTag).toHaveBeenCalledWith("ci", "false");
+	});
+
+	it("sets ci tag to 'true' when CI env is set", () => {
+		process.env["CI"] = "true";
+		init("1.0.0");
+		expect(Sentry.setTag).toHaveBeenCalledWith("ci", "true");
+	});
+});
+
+// ── startCommand ─────────────────────────────────────────────────────────────
+
+describe("startCommand", () => {
+	it("starts a span with command name and op", () => {
+		startCommand("setup");
+		expect(Sentry.startInactiveSpan).toHaveBeenCalledWith(
+			expect.objectContaining({ name: "setup", op: "holocron.command", forceTransaction: true })
+		);
+	});
+
+	it("sets the command tag", () => {
+		startCommand("deploy main");
+		expect(Sentry.setTag).toHaveBeenCalledWith("command", "deploy main");
+	});
+
+	it("finish(true) sets ok status (code 1) and ends span", () => {
+		const finish = startCommand("setup");
+		finish(true);
+		const span = lastSpan();
+		expect(span.setStatus).toHaveBeenCalledWith({ code: 1 });
+		expect(span.end).toHaveBeenCalled();
+	});
+
+	it("finish(false) sets error status (code 2) and ends span", () => {
+		const finish = startCommand("setup");
+		finish(false);
+		const span = lastSpan();
+		expect(span.setStatus).toHaveBeenCalledWith({ code: 2 });
+		expect(span.end).toHaveBeenCalled();
+	});
+});
+
+// ── captureException ─────────────────────────────────────────────────────────
+
+describe("captureException", () => {
+	it("forwards the error to Sentry", () => {
+		const err = new Error("something broke");
+		captureException(err);
+		expect(Sentry.captureException).toHaveBeenCalledWith(err);
+	});
+});
+
+// ── flush ────────────────────────────────────────────────────────────────────
+
+describe("flush", () => {
+	it("calls Sentry.close with a 2000ms timeout", async () => {
+		await flush();
+		expect(Sentry.close).toHaveBeenCalledWith(2_000);
+	});
+});
+
+// ── scrubError (via beforeSend) ───────────────────────────────────────────────
+
+describe("scrubError", () => {
+	function getBeforeSend() {
+		init("1.0.0");
+		const options = vi.mocked(Sentry.init).mock.calls[0]?.[0] as {
+			beforeSend: (event: object, hint: object) => object;
+		};
+		return options.beforeSend;
+	}
+
+	it("redacts ghp_ tokens", () => {
+		const scrub = getBeforeSend();
+		const result = scrub({ message: "auth failed with ghp_abc123XYZ" }, {});
+		expect(JSON.stringify(result)).not.toContain("ghp_abc123");
+		expect(JSON.stringify(result)).toContain("[REDACTED]");
+	});
+
+	it("redacts SCREAMING_SNAKE_TOKEN= patterns", () => {
+		const scrub = getBeforeSend();
+		const result = scrub({ message: "GITHUB_TOKEN=ghs_secret456" }, {});
+		expect(JSON.stringify(result)).not.toContain("ghs_secret456");
+		expect(JSON.stringify(result)).toContain("[REDACTED]");
+	});
+
+	it("leaves non-token content intact", () => {
+		const scrub = getBeforeSend();
+		const result = scrub({ message: "config not found at ./holocron.config.ts" }, {});
+		expect(JSON.stringify(result)).toContain("config not found");
+	});
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -27,6 +27,7 @@ import { runUpgradeNode } from "./commands/upgrade-node.js";
 import { loadConfig } from "./load-config.js";
 import { type ParsedTokenArgs, parseTokenArgs, TokenParseError } from "./token-args.js";
 import { checkForUpdates } from "./update-notifier.js";
+import { captureException, flush, init, startCommand } from "./telemetry.js";
 
 const resolveCloneToken = createFeatureResolver({ envName: "HOLOCRON_READ_TOKEN", keyringKey: "github.read" });
 const resolveSyncToken = createFeatureResolver({ envName: "HOLOCRON_SYNC_TOKEN", keyringKey: "github.sync" });
@@ -50,9 +51,17 @@ function tokenContext(rawTokens: string[] | undefined): ParsedTokenArgs | null {
 	}
 }
 
+init(CLI_VERSION);
 const updateCheckPromise = checkForUpdates(CLI_VERSION);
 
+let finishCommand: (ok: boolean) => void = () => {};
+
+try {
 await yargs(hideBin(process.argv))
+	.middleware((argv) => {
+		const name = (argv._ as string[]).slice(0, 2).join(" ") || "unknown";
+		finishCommand = startCommand(name);
+	})
 	.scriptName("")
 	.usage("holocron <command> [options]")
 	// ── global options (apply to every subcommand) ──────────────────────
@@ -800,9 +809,15 @@ await yargs(hideBin(process.argv))
 	.strict()
 	.help()
 	.parse();
+} catch (err) {
+	captureException(err);
+	if (!process.exitCode) process.exitCode = 1;
+}
 
+finishCommand(!process.exitCode);
 const notify = await updateCheckPromise;
 notify?.();
+await flush();
 
 /**
  * Parse `--scope` strings: `repo` | `env=NAME` | `org=NAME`.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -57,758 +57,758 @@ const updateCheckPromise = checkForUpdates(CLI_VERSION);
 let finishCommand: (ok: boolean) => void = () => {};
 
 try {
-await yargs(hideBin(process.argv))
-	.middleware((argv) => {
-		const name = (argv._ as string[]).slice(0, 2).join(" ") || "unknown";
-		finishCommand = startCommand(name);
-	})
-	.scriptName("")
-	.usage("holocron <command> [options]")
-	// ── global options (apply to every subcommand) ──────────────────────
-	.option("dry-run", {
-		type: "boolean",
-		default: false,
-		describe:
-			"Print what would be mutated without calling capability mutators. " +
-			"Commands branch on this; read-only commands ignore it.",
-	})
-	.option("token", {
-		type: "string",
-		array: true,
-		describe:
-			"Vendor token override for plugins. " +
-			"Bare form: --token <value> (fallback for all plugins, single-plugin commands). " +
-			"Keyed form: --token vendor=value (targets a specific provider; repeat for each). " +
-			"Example: --token github=ghp_xxx --token vercel=v_yyy",
-	})
-	.option("cwd", {
-		type: "string",
-		default: process.cwd(),
-		describe: "Directory to search for holocron.config.json",
-	})
-	// ── commands ────────────────────────────────────────────────────────
-	.command(
-		"version",
-		"Print the CLI version",
-		() => {},
-		() => {
-			console.log(`holocron ${CLI_VERSION}`);
-		}
-	)
-	.command(
-		"clone",
-		"Clone all repos in a GitHub org as siblings under a single directory",
-		(y) =>
-			y
-				.option("org", {
-					type: "string",
-					demandOption: true,
-					describe: "GitHub org to clone (e.g., theholocron)",
-				})
-				.option("dir", {
-					type: "string",
-					describe: "Parent directory to clone into (default: ~/Code/<org>)",
-				}),
-		async (argv) => {
-			const tokens = tokenContext(argv.token);
-			if (!tokens) return;
-			let token: string;
-			try {
-				token = resolveCloneToken({ cliToken: tokens.cliTokens?.["github"] ?? tokens.cliToken });
-			} catch (err) {
-				console.error(`clone: ${err instanceof AuthError ? err.message : String(err)}`);
-				process.exitCode = 1;
-				return;
+	await yargs(hideBin(process.argv))
+		.middleware((argv) => {
+			const name = (argv._ as string[]).slice(0, 2).join(" ") || "unknown";
+			finishCommand = startCommand(name);
+		})
+		.scriptName("")
+		.usage("holocron <command> [options]")
+		// ── global options (apply to every subcommand) ──────────────────────
+		.option("dry-run", {
+			type: "boolean",
+			default: false,
+			describe:
+				"Print what would be mutated without calling capability mutators. " +
+				"Commands branch on this; read-only commands ignore it.",
+		})
+		.option("token", {
+			type: "string",
+			array: true,
+			describe:
+				"Vendor token override for plugins. " +
+				"Bare form: --token <value> (fallback for all plugins, single-plugin commands). " +
+				"Keyed form: --token vendor=value (targets a specific provider; repeat for each). " +
+				"Example: --token github=ghp_xxx --token vercel=v_yyy",
+		})
+		.option("cwd", {
+			type: "string",
+			default: process.cwd(),
+			describe: "Directory to search for holocron.config.json",
+		})
+		// ── commands ────────────────────────────────────────────────────────
+		.command(
+			"version",
+			"Print the CLI version",
+			() => {},
+			() => {
+				console.log(`holocron ${CLI_VERSION}`);
 			}
-			const report = await runClone({
-				org: argv.org,
-				token,
-				dryRun: argv.dryRun,
-				...(argv.dir ? { dir: argv.dir } : {}),
-			});
-			if (report.status === "fail") process.exitCode = 1;
-		}
-	)
-	.command(
-		"doctor",
-		"Load the config and run a smoke check against every provider",
-		(y) =>
-			y.option("repo", {
-				type: "string",
-				describe: 'Repo coords ("owner/name"). Defaults to plugin-specific resolution.',
-			}),
-		async (argv) => {
-			const tokens = tokenContext(argv.token);
-			if (!tokens) return;
-			const loaded = await loadConfig(argv.cwd);
-			const report = await runDoctor({
-				loaded,
-				context: {
-					repoRoot: argv.cwd,
+		)
+		.command(
+			"clone",
+			"Clone all repos in a GitHub org as siblings under a single directory",
+			(y) =>
+				y
+					.option("org", {
+						type: "string",
+						demandOption: true,
+						describe: "GitHub org to clone (e.g., theholocron)",
+					})
+					.option("dir", {
+						type: "string",
+						describe: "Parent directory to clone into (default: ~/Code/<org>)",
+					}),
+			async (argv) => {
+				const tokens = tokenContext(argv.token);
+				if (!tokens) return;
+				let token: string;
+				try {
+					token = resolveCloneToken({ cliToken: tokens.cliTokens?.["github"] ?? tokens.cliToken });
+				} catch (err) {
+					console.error(`clone: ${err instanceof AuthError ? err.message : String(err)}`);
+					process.exitCode = 1;
+					return;
+				}
+				const report = await runClone({
+					org: argv.org,
+					token,
 					dryRun: argv.dryRun,
-					...(argv.repo ? { repo: argv.repo } : {}),
-					...tokens,
-				},
-			});
-			if (report.summary.fail > 0) {
-				process.exitCode = 1;
+					...(argv.dir ? { dir: argv.dir } : {}),
+				});
+				if (report.status === "fail") process.exitCode = 1;
 			}
-		}
-	)
-	.command(
-		"setup",
-		"Apply infra setup actions across every configured capability",
-		(y) =>
-			y.option("repo", {
-				type: "string",
-				describe: 'Repo coords ("owner/name"). Defaults to plugin-specific resolution.',
-			}),
-		async (argv) => {
-			const tokens = tokenContext(argv.token);
-			if (!tokens) return;
-			const loaded = await loadConfig(argv.cwd);
-			const report = await runSetup({
-				loaded,
-				context: {
-					repoRoot: argv.cwd,
-					dryRun: argv.dryRun,
-					...(argv.repo ? { repo: argv.repo } : {}),
-					...tokens,
-				},
-			});
-			if (report.summary.fail > 0) {
-				process.exitCode = 1;
-			}
-		}
-	)
-	.command(
-		"skills",
-		"Manage agent skills from the @theholocron/skills registry",
-		(y) =>
-			y
-				.command(
-					"install",
-					"Copy skills from @theholocron/skills into .agents/ with agent symlinks",
-					() => {},
-					async (argv) => {
-						const loaded = await loadConfig(argv.cwd);
-						await runSkillsInstall({ loaded, context: { repoRoot: argv.cwd, dryRun: argv.dryRun } });
-					}
-				)
-				.command(
-					"remove [names..]",
-					"Remove installed skills via npx skills remove",
-					(yy) =>
-						yy.positional("names", {
-							type: "string",
-							array: true,
-							describe: "Skill name(s) to remove (omit to remove all installed skills)",
-						}),
-					(argv) => {
-						const report = runSkillsRemove({
-							context: { repoRoot: argv.cwd, dryRun: argv.dryRun },
-							...(argv.names?.length ? { names: argv.names as string[] } : {}),
-						});
-						if (report.status === "fail") process.exitCode = 1;
-					}
-				)
-				.command(
-					"update [name]",
-					"Update installed skills to their latest upstream versions via npx skills update",
-					(yy) =>
-						yy.positional("name", {
-							type: "string",
-							describe: "Skill name to update (omit to update all installed skills)",
-						}),
-					(argv) => {
-						const report = runSkillsUpdate({
-							context: { repoRoot: argv.cwd, dryRun: argv.dryRun },
-							...(argv.name ? { name: argv.name as string } : {}),
-						});
-						if (report.status === "fail") process.exitCode = 1;
-					}
-				)
-				.demandCommand(1, "Run `holocron skills --help` to see available skills subcommands."),
-		() => {}
-	)
-	.command(
-		"secret set <name> [value]",
-		"Set a single secret via the configured `secrets` capability",
-		(y) =>
-			y
-				.positional("name", {
-					type: "string",
-					demandOption: true,
-					describe: "Secret name (e.g., NPM_TOKEN)",
-				})
-				.positional("value", {
-					type: "string",
-					describe:
-						"Secret value (positional). If omitted, sources from --from-stdin, --from-env, or env var matching <name>.",
-				})
-				.option("from-stdin", {
-					type: "boolean",
-					default: false,
-					describe: "Read the secret value from stdin",
-				})
-				.option("from-env", {
-					type: "string",
-					describe: "Read the secret value from the named env var (otherwise: env var matching <name>)",
-				})
-				.option("scope", {
-					type: "string",
-					default: "repo",
-					describe: 'Scope: "repo" (default), "env=<name>", or "org=<name>"',
-				}),
-		async (argv) => {
-			const tokens = tokenContext(argv.token);
-			if (!tokens) return;
-			const scopeArg = argv.scope as string;
-			const scope = parseScope(scopeArg);
-			const report = await runSecretSet({
-				loaded: await loadConfig(argv.cwd),
-				context: {
-					repoRoot: argv.cwd,
-					dryRun: argv.dryRun,
-					...tokens,
-				},
-				name: argv.name as string,
-				...(argv.value ? { value: argv.value as string } : {}),
-				...(argv.fromStdin ? { fromStdin: true } : {}),
-				...(argv.fromEnv ? { fromEnv: argv.fromEnv as string } : {}),
-				scope,
-			});
-			if (report.status === "fail") {
-				process.exitCode = 1;
-			}
-		}
-	)
-	.command(
-		"secrets sync <environmentId>",
-		"Read a vault environment + fan KEY=VALUEs out to secrets + deployment env vars",
-		(y) =>
-			y
-				.positional("environmentId", {
-					type: "string",
-					demandOption: true,
-					describe: "Vault environment id to read (1P Environment id, etc.)",
-				})
-				.option("project-id", {
-					type: "string",
-					describe: "Deployment project id (e.g., Vercel prj_*). Required when deployment is loaded.",
-				})
-				.option("target", {
-					type: "array",
-					default: ["production", "preview"] as Array<"development" | "preview" | "production">,
-					describe: "Deployment targets to sync to. Defaults to production + preview.",
-				}),
-		async (argv) => {
-			const tokens = tokenContext(argv.token);
-			if (!tokens) return;
-			const loaded = await loadConfig(argv.cwd);
-			const report = await runSecretsSync({
-				loaded,
-				context: {
-					repoRoot: argv.cwd,
-					dryRun: argv.dryRun,
-					...tokens,
-				},
-				environmentId: argv.environmentId as string,
-				...(argv.projectId ? { projectId: argv.projectId } : {}),
-				targets: argv.target as Array<"development" | "preview" | "production">,
-			});
-			if (report.summary.fail > 0) {
-				process.exitCode = 1;
-			}
-		}
-	)
-	.command(
-		"deploy <branch>",
-		"Trigger a deployment via the configured `deployment` capability",
-		(y) =>
-			y
-				.positional("branch", {
-					type: "string",
-					demandOption: true,
-					describe: "Git branch to deploy",
-				})
-				.option("project-id", {
-					type: "string",
-					demandOption: true,
-					describe: "Deployment project id (e.g., Vercel prj_*)",
-				})
-				.option("target", {
-					type: "string",
-					choices: ["production", "staging"] as const,
-					describe: "Named environment to deploy into. Omit for a branch preview.",
-				}),
-		async (argv) => {
-			const tokens = tokenContext(argv.token);
-			if (!tokens) return;
-			const loaded = await loadConfig(argv.cwd);
-			const report = await runDeploy({
-				loaded,
-				context: {
-					repoRoot: argv.cwd,
-					dryRun: argv.dryRun,
-					...tokens,
-				},
-				projectId: argv.projectId as string,
-				branch: argv.branch as string,
-				...(argv.target ? { target: argv.target as "production" | "staging" } : {}),
-			});
-			if (report.status === "fail") {
-				process.exitCode = 1;
-			}
-		}
-	)
-	.command(
-		"npm",
-		"npm-related monorepo utilities",
-		(y) =>
-			y
-				.command(
-					"bump-versions <new-version>",
-					"Bump all non-private package versions in lockstep (semantic-release prepareCmd)",
-					(yy) =>
-						yy.positional("new-version", {
-							type: "string",
-							demandOption: true,
-							describe: "Version to set (e.g., 4.2.0 or 2.0.0-alpha.1)",
-						}),
-					async (argv) => {
-						const report = await runNpmBumpVersions({
-							version: argv.newVersion as string,
-							cwd: argv.cwd,
-							dryRun: argv.dryRun,
-						});
-						if (report.status === "fail") {
-							process.exitCode = 1;
-						}
-					}
-				)
-				.command(
-					"publish-initial",
-					"One-shot bootstrap publish for trusted-publishing-eligible packages",
-					(yy) =>
-						yy
-							.option("tag", {
-								type: "string",
-								default: "alpha",
-								describe: "npm distribution tag (defaults to alpha)",
-							})
-							.option("otp", {
-								type: "string",
-								describe:
-									"One-time password from your authenticator (required if npm needs 2FA for writes)",
-							}),
-					async (argv) => {
-						const report = await runNpmPublishInitial({
-							cwd: argv.cwd,
-							tag: argv.tag,
-							dryRun: argv.dryRun,
-							...(argv.otp ? { otp: argv.otp as string } : {}),
-						});
-						if (report.status === "fail") {
-							process.exitCode = 1;
-						}
-					}
-				)
-				.demandCommand(1, "Run `holocron npm --help` to see available npm subcommands."),
-		() => {}
-	)
-	.command(
-		"sync [steps..]",
-		"Sync state from config to the provider and local files (labels, properties, topics, keywords, description)",
-		(y) =>
-			y
-				.positional("steps", {
-					type: "string",
-					array: true,
-					describe: "Steps to run: labels, properties, topics, keywords, description (default: all)",
-				})
-				.option("repo", {
+		)
+		.command(
+			"doctor",
+			"Load the config and run a smoke check against every provider",
+			(y) =>
+				y.option("repo", {
 					type: "string",
 					describe: 'Repo coords ("owner/name"). Defaults to plugin-specific resolution.',
 				}),
-		async (argv) => {
-			const tokens = tokenContext(argv.token);
-			if (!tokens) return;
-			const loaded = await loadConfig(argv.cwd);
-			const report = await runSync({
-				loaded,
-				context: {
-					repoRoot: argv.cwd,
-					dryRun: argv.dryRun,
-					...(argv.repo ? { repo: argv.repo } : {}),
-					...tokens,
-				},
-				...(argv.steps && argv.steps.length > 0 ? { steps: argv.steps as string[] } : {}),
-			});
-			if (report.summary.fail > 0) {
-				process.exitCode = 1;
-			}
-		}
-	)
-	.command(
-		"sync-github",
-		"Sync workflow templates and composite actions to theholocron/.github via the GitHub API",
-		(y) =>
-			y
-				.option("repo", {
-					type: "string",
-					default: "theholocron/.github",
-					describe: "Target org/repo (default: theholocron/.github)",
-				})
-				.option("branch", {
-					type: "string",
-					describe:
-						"Push to this branch instead of the default branch (enables PR-based workflow for protected repos)",
-				})
-				.option("pr", {
-					type: "boolean",
-					default: false,
-					describe: "Open a PR after pushing to --branch (no-op without --branch)",
-				})
-				.option("message", {
-					type: "string",
-					describe: "Commit message (default: chore: sync from theholocron/holocron)",
-				})
-				.option("output-dir", {
-					type: "string",
-					describe: "Write generated files to this local directory instead of pushing (for validation)",
-				}),
-		async (argv) => {
-			const outputDir = argv["output-dir"] as string | undefined;
-			const parsed = tokenContext(argv.token);
-			if (!parsed) return;
-			let token: string;
-			if (outputDir) {
-				token = "no-token-needed";
-			} else {
-				try {
-					token = resolveSyncToken({ cliToken: parsed.cliTokens?.["github"] ?? parsed.cliToken });
-				} catch (err) {
-					console.error(`sync-github: ${err instanceof AuthError ? err.message : String(err)}`);
-					process.exitCode = 1;
-					return;
-				}
-			}
-			const report = await runSyncGithub({
-				token,
-				repo: argv.repo,
-				dryRun: argv.dryRun,
-				...(argv.branch ? { branch: argv.branch } : {}),
-				...(argv.pr ? { createPr: true } : {}),
-				...(argv.message ? { message: argv.message } : {}),
-				...(outputDir ? { outputDir } : {}),
-			});
-			if (report.status === "fail") {
-				process.exitCode = 1;
-			}
-		}
-	)
-	.command(
-		"config show",
-		"Print the resolved holocron config",
-		() => {},
-		async (argv) => {
-			const loaded = await loadConfig(argv.cwd);
-			console.log(JSON.stringify(loaded.resolved, null, 2));
-		}
-	)
-	.command(
-		"new [type] [name]",
-		"Scaffold a new repo from a GitHub template (e.g. cli, react, nextjs, node, monorepo, base)",
-		(y) =>
-			y
-				.positional("type", {
-					type: "string",
-					describe:
-						"Template type — maps to theholocron/<type>-template " +
-						"(e.g. cli, react, nextjs, node, monorepo, base)",
-				})
-				.positional("name", {
-					type: "string",
-					describe: "New repo name (kebab-case, e.g. my-tool)",
-				})
-				.option("description", {
-					type: "string",
-					describe: "Short description — replaces <description> placeholders in the template",
-				})
-				.option("org", {
-					type: "string",
-					default: "theholocron",
-					describe: "GitHub org that owns the template and will own the new repo",
-				})
-				.option("verify", {
-					type: "boolean",
-					default: true,
-					describe: "Run pnpm install after bootstrapping (default true; --no-verify skips)",
-				}),
-		async (argv) => {
-			try {
-				let type = argv.type as string | undefined;
-				let name = argv.name as string | undefined;
-				let description = argv.description as string | undefined;
-
-				const needsPrompt = !type || !name || description === undefined;
-				if (needsPrompt) {
-					const rl = createInterface({ input: stdin, output: stdout });
-					const ask = (question: string) =>
-						new Promise<string>((resolve) =>
-							rl.question(`  ${question} `, (answer) => resolve(answer.trim()))
-						);
-					try {
-						if (!type) {
-							console.log("  Known types: base, cli, monorepo, nextjs, node, react");
-							type = await ask("Template type:");
-						}
-						if (!name) name = await ask("Repo name (kebab-case):");
-						if (description === undefined) {
-							description = await ask("Short description (Enter to skip):");
-						}
-					} finally {
-						rl.close();
-					}
-				}
-
-				if (!type) {
-					console.error("new: template type is required");
-					process.exitCode = 1;
-					return;
-				}
-				if (!name) {
-					console.error("new: repo name is required");
-					process.exitCode = 1;
-					return;
-				}
-
-				const report = await runNew({
-					type,
-					name,
-					...(description ? { description } : {}),
-					org: argv.org,
-					dryRun: argv.dryRun,
-					noVerify: !argv.verify,
-					cwd: argv.cwd,
+			async (argv) => {
+				const tokens = tokenContext(argv.token);
+				if (!tokens) return;
+				const loaded = await loadConfig(argv.cwd);
+				const report = await runDoctor({
+					loaded,
+					context: {
+						repoRoot: argv.cwd,
+						dryRun: argv.dryRun,
+						...(argv.repo ? { repo: argv.repo } : {}),
+						...tokens,
+					},
 				});
-				if (report.status === "fail") process.exitCode = 1;
-			} catch (err) {
-				if (err instanceof NewError) {
-					console.error(`new: ${err.message}`);
+				if (report.summary.fail > 0) {
 					process.exitCode = 1;
-					return;
 				}
-				throw err;
 			}
-		}
-	)
-	.command(
-		"plugin create <slug> <vendor>",
-		"Scaffold a new @theholocron/holocron-plugin-<slug> package",
-		(y) =>
-			y
-				.positional("slug", { type: "string", demandOption: true, describe: "Package slug (kebab-case)" })
-				.positional("vendor", {
+		)
+		.command(
+			"setup",
+			"Apply infra setup actions across every configured capability",
+			(y) =>
+				y.option("repo", {
 					type: "string",
-					demandOption: true,
-					describe: "Vendor display name (PascalCase)",
-				})
-				.option("capability", {
-					type: "string",
-					describe:
-						"Capability key: source|ci|secrets|environments|issues|deployment|storage|auth|vault|dns|tooling|notifications|analytics|observability",
-				})
-				.option("token-env", {
-					type: "string",
-					describe: "Holocron env var name (defaults to HOLOCRON_<VENDOR>_TOKEN)",
-				})
-				.option("vendor-env", {
-					type: "string",
-					describe: "Vendor-native env var name",
-				})
-				.option("base-url", {
-					type: "string",
-					describe: "REST base URL",
-				})
-				.option("verify", {
-					type: "boolean",
-					default: true,
-					describe:
-						"Run post-scaffold pnpm install + typecheck + lint + test (default true; --no-verify skips)",
+					describe: 'Repo coords ("owner/name"). Defaults to plugin-specific resolution.',
 				}),
-		async (argv) => {
-			try {
-				const capabilityKeys = Object.keys(CARDINALITY).join(", ");
-				const needsPrompt = !argv.capability || !argv.vendorEnv || !argv.baseUrl;
-
-				let capability: CapabilityKey;
-				let vendorEnv: string;
-				let baseUrl: string;
-
-				if (needsPrompt) {
-					const rl = createInterface({ input: stdin, output: stdout });
-					const ask = (question: string) =>
-						new Promise<string>((resolve) =>
-							rl.question(`  ${question} `, (answer) => resolve(answer.trim()))
-						);
-					try {
-						if (!argv.capability) {
-							console.log(`  Available capabilities: ${capabilityKeys}`);
-							capability = (await ask("Capability:")) as CapabilityKey;
-						} else {
-							capability = argv.capability as CapabilityKey;
-						}
-						vendorEnv = argv.vendorEnv
-							? (argv.vendorEnv as string)
-							: await ask(
-									`Vendor-native env var for the ${argv.vendor as string} token (e.g. MYVENDOR_API_KEY):`
-								);
-						baseUrl = argv.baseUrl
-							? (argv.baseUrl as string)
-							: await ask(
-									`REST base URL for the ${argv.vendor as string} API (e.g. https://api.myvendor.com):`
-								);
-					} finally {
-						rl.close();
-					}
-				} else {
-					capability = argv.capability as CapabilityKey;
-					vendorEnv = argv.vendorEnv as string;
-					baseUrl = argv.baseUrl as string;
-				}
-
-				const report = runPluginCreate({
-					slug: argv.slug as string,
-					vendorName: argv.vendor as string,
-					capability,
-					vendorEnv,
-					baseUrl,
-					...(argv.tokenEnv ? { tokenEnv: argv.tokenEnv as string } : {}),
-					dryRun: argv.dryRun,
-					// Yargs: `--no-verify` flips `argv.verify` to false. We pass
-					// the inverse to preserve the internal `noVerify` naming.
-					noVerify: !argv.verify,
-					cwd: argv.cwd,
+			async (argv) => {
+				const tokens = tokenContext(argv.token);
+				if (!tokens) return;
+				const loaded = await loadConfig(argv.cwd);
+				const report = await runSetup({
+					loaded,
+					context: {
+						repoRoot: argv.cwd,
+						dryRun: argv.dryRun,
+						...(argv.repo ? { repo: argv.repo } : {}),
+						...tokens,
+					},
 				});
-				if (report.status === "fail") process.exitCode = 1;
-			} catch (err) {
-				if (err instanceof PluginCreateError) {
-					console.error(`plugin create: ${err.message}`);
+				if (report.summary.fail > 0) {
 					process.exitCode = 1;
-					return;
 				}
-				throw err;
 			}
-		}
-	)
-	.command(
-		"upgrade",
-		"Upgrade toolchain version pins across the repo",
-		(y) =>
-			y
-				.command(
-					"node <to>",
-					"Scan the repo and update every Node.js version pin to a new major",
-					(yy) =>
-						yy
-							.positional("to", {
-								type: "number",
-								demandOption: true,
-								describe: "Target Node.js major version (e.g., 22)",
-							})
-							.option("from", {
-								type: "number",
-								describe:
-									"Current major version to replace. Auto-detected from .nvmrc / engines.node when omitted.",
+		)
+		.command(
+			"skills",
+			"Manage agent skills from the @theholocron/skills registry",
+			(y) =>
+				y
+					.command(
+						"install",
+						"Copy skills from @theholocron/skills into .agents/ with agent symlinks",
+						() => {},
+						async (argv) => {
+							const loaded = await loadConfig(argv.cwd);
+							await runSkillsInstall({ loaded, context: { repoRoot: argv.cwd, dryRun: argv.dryRun } });
+						}
+					)
+					.command(
+						"remove [names..]",
+						"Remove installed skills via npx skills remove",
+						(yy) =>
+							yy.positional("names", {
+								type: "string",
+								array: true,
+								describe: "Skill name(s) to remove (omit to remove all installed skills)",
 							}),
-					async (argv) => {
-						// Read upgrade.node.extra from holocron.config.json if present.
-						// We read the raw file directly rather than through loadConfig because
-						// the upgrade config is not part of the plugin schema.
-						let extra: string[] = [];
-						try {
-							const raw = readFileSync(join(argv.cwd, "holocron.config.json"), "utf8");
-							const cfg = JSON.parse(raw) as Record<string, unknown>;
-							const upgradeNode = (cfg.upgrade as Record<string, unknown> | undefined)?.node as
-								| Record<string, unknown>
-								| undefined;
-							if (Array.isArray(upgradeNode?.extra)) {
-								extra = upgradeNode.extra as string[];
+						(argv) => {
+							const report = runSkillsRemove({
+								context: { repoRoot: argv.cwd, dryRun: argv.dryRun },
+								...(argv.names?.length ? { names: argv.names as string[] } : {}),
+							});
+							if (report.status === "fail") process.exitCode = 1;
+						}
+					)
+					.command(
+						"update [name]",
+						"Update installed skills to their latest upstream versions via npx skills update",
+						(yy) =>
+							yy.positional("name", {
+								type: "string",
+								describe: "Skill name to update (omit to update all installed skills)",
+							}),
+						(argv) => {
+							const report = runSkillsUpdate({
+								context: { repoRoot: argv.cwd, dryRun: argv.dryRun },
+								...(argv.name ? { name: argv.name as string } : {}),
+							});
+							if (report.status === "fail") process.exitCode = 1;
+						}
+					)
+					.demandCommand(1, "Run `holocron skills --help` to see available skills subcommands."),
+			() => {}
+		)
+		.command(
+			"secret set <name> [value]",
+			"Set a single secret via the configured `secrets` capability",
+			(y) =>
+				y
+					.positional("name", {
+						type: "string",
+						demandOption: true,
+						describe: "Secret name (e.g., NPM_TOKEN)",
+					})
+					.positional("value", {
+						type: "string",
+						describe:
+							"Secret value (positional). If omitted, sources from --from-stdin, --from-env, or env var matching <name>.",
+					})
+					.option("from-stdin", {
+						type: "boolean",
+						default: false,
+						describe: "Read the secret value from stdin",
+					})
+					.option("from-env", {
+						type: "string",
+						describe: "Read the secret value from the named env var (otherwise: env var matching <name>)",
+					})
+					.option("scope", {
+						type: "string",
+						default: "repo",
+						describe: 'Scope: "repo" (default), "env=<name>", or "org=<name>"',
+					}),
+			async (argv) => {
+				const tokens = tokenContext(argv.token);
+				if (!tokens) return;
+				const scopeArg = argv.scope as string;
+				const scope = parseScope(scopeArg);
+				const report = await runSecretSet({
+					loaded: await loadConfig(argv.cwd),
+					context: {
+						repoRoot: argv.cwd,
+						dryRun: argv.dryRun,
+						...tokens,
+					},
+					name: argv.name as string,
+					...(argv.value ? { value: argv.value as string } : {}),
+					...(argv.fromStdin ? { fromStdin: true } : {}),
+					...(argv.fromEnv ? { fromEnv: argv.fromEnv as string } : {}),
+					scope,
+				});
+				if (report.status === "fail") {
+					process.exitCode = 1;
+				}
+			}
+		)
+		.command(
+			"secrets sync <environmentId>",
+			"Read a vault environment + fan KEY=VALUEs out to secrets + deployment env vars",
+			(y) =>
+				y
+					.positional("environmentId", {
+						type: "string",
+						demandOption: true,
+						describe: "Vault environment id to read (1P Environment id, etc.)",
+					})
+					.option("project-id", {
+						type: "string",
+						describe: "Deployment project id (e.g., Vercel prj_*). Required when deployment is loaded.",
+					})
+					.option("target", {
+						type: "array",
+						default: ["production", "preview"] as Array<"development" | "preview" | "production">,
+						describe: "Deployment targets to sync to. Defaults to production + preview.",
+					}),
+			async (argv) => {
+				const tokens = tokenContext(argv.token);
+				if (!tokens) return;
+				const loaded = await loadConfig(argv.cwd);
+				const report = await runSecretsSync({
+					loaded,
+					context: {
+						repoRoot: argv.cwd,
+						dryRun: argv.dryRun,
+						...tokens,
+					},
+					environmentId: argv.environmentId as string,
+					...(argv.projectId ? { projectId: argv.projectId } : {}),
+					targets: argv.target as Array<"development" | "preview" | "production">,
+				});
+				if (report.summary.fail > 0) {
+					process.exitCode = 1;
+				}
+			}
+		)
+		.command(
+			"deploy <branch>",
+			"Trigger a deployment via the configured `deployment` capability",
+			(y) =>
+				y
+					.positional("branch", {
+						type: "string",
+						demandOption: true,
+						describe: "Git branch to deploy",
+					})
+					.option("project-id", {
+						type: "string",
+						demandOption: true,
+						describe: "Deployment project id (e.g., Vercel prj_*)",
+					})
+					.option("target", {
+						type: "string",
+						choices: ["production", "staging"] as const,
+						describe: "Named environment to deploy into. Omit for a branch preview.",
+					}),
+			async (argv) => {
+				const tokens = tokenContext(argv.token);
+				if (!tokens) return;
+				const loaded = await loadConfig(argv.cwd);
+				const report = await runDeploy({
+					loaded,
+					context: {
+						repoRoot: argv.cwd,
+						dryRun: argv.dryRun,
+						...tokens,
+					},
+					projectId: argv.projectId as string,
+					branch: argv.branch as string,
+					...(argv.target ? { target: argv.target as "production" | "staging" } : {}),
+				});
+				if (report.status === "fail") {
+					process.exitCode = 1;
+				}
+			}
+		)
+		.command(
+			"npm",
+			"npm-related monorepo utilities",
+			(y) =>
+				y
+					.command(
+						"bump-versions <new-version>",
+						"Bump all non-private package versions in lockstep (semantic-release prepareCmd)",
+						(yy) =>
+							yy.positional("new-version", {
+								type: "string",
+								demandOption: true,
+								describe: "Version to set (e.g., 4.2.0 or 2.0.0-alpha.1)",
+							}),
+						async (argv) => {
+							const report = await runNpmBumpVersions({
+								version: argv.newVersion as string,
+								cwd: argv.cwd,
+								dryRun: argv.dryRun,
+							});
+							if (report.status === "fail") {
+								process.exitCode = 1;
 							}
-						} catch {
-							/* no config or no upgrade section — fine */
 						}
+					)
+					.command(
+						"publish-initial",
+						"One-shot bootstrap publish for trusted-publishing-eligible packages",
+						(yy) =>
+							yy
+								.option("tag", {
+									type: "string",
+									default: "alpha",
+									describe: "npm distribution tag (defaults to alpha)",
+								})
+								.option("otp", {
+									type: "string",
+									describe:
+										"One-time password from your authenticator (required if npm needs 2FA for writes)",
+								}),
+						async (argv) => {
+							const report = await runNpmPublishInitial({
+								cwd: argv.cwd,
+								tag: argv.tag,
+								dryRun: argv.dryRun,
+								...(argv.otp ? { otp: argv.otp as string } : {}),
+							});
+							if (report.status === "fail") {
+								process.exitCode = 1;
+							}
+						}
+					)
+					.demandCommand(1, "Run `holocron npm --help` to see available npm subcommands."),
+			() => {}
+		)
+		.command(
+			"sync [steps..]",
+			"Sync state from config to the provider and local files (labels, properties, topics, keywords, description)",
+			(y) =>
+				y
+					.positional("steps", {
+						type: "string",
+						array: true,
+						describe: "Steps to run: labels, properties, topics, keywords, description (default: all)",
+					})
+					.option("repo", {
+						type: "string",
+						describe: 'Repo coords ("owner/name"). Defaults to plugin-specific resolution.',
+					}),
+			async (argv) => {
+				const tokens = tokenContext(argv.token);
+				if (!tokens) return;
+				const loaded = await loadConfig(argv.cwd);
+				const report = await runSync({
+					loaded,
+					context: {
+						repoRoot: argv.cwd,
+						dryRun: argv.dryRun,
+						...(argv.repo ? { repo: argv.repo } : {}),
+						...tokens,
+					},
+					...(argv.steps && argv.steps.length > 0 ? { steps: argv.steps as string[] } : {}),
+				});
+				if (report.summary.fail > 0) {
+					process.exitCode = 1;
+				}
+			}
+		)
+		.command(
+			"sync-github",
+			"Sync workflow templates and composite actions to theholocron/.github via the GitHub API",
+			(y) =>
+				y
+					.option("repo", {
+						type: "string",
+						default: "theholocron/.github",
+						describe: "Target org/repo (default: theholocron/.github)",
+					})
+					.option("branch", {
+						type: "string",
+						describe:
+							"Push to this branch instead of the default branch (enables PR-based workflow for protected repos)",
+					})
+					.option("pr", {
+						type: "boolean",
+						default: false,
+						describe: "Open a PR after pushing to --branch (no-op without --branch)",
+					})
+					.option("message", {
+						type: "string",
+						describe: "Commit message (default: chore: sync from theholocron/holocron)",
+					})
+					.option("output-dir", {
+						type: "string",
+						describe: "Write generated files to this local directory instead of pushing (for validation)",
+					}),
+			async (argv) => {
+				const outputDir = argv["output-dir"] as string | undefined;
+				const parsed = tokenContext(argv.token);
+				if (!parsed) return;
+				let token: string;
+				if (outputDir) {
+					token = "no-token-needed";
+				} else {
+					try {
+						token = resolveSyncToken({ cliToken: parsed.cliTokens?.["github"] ?? parsed.cliToken });
+					} catch (err) {
+						console.error(`sync-github: ${err instanceof AuthError ? err.message : String(err)}`);
+						process.exitCode = 1;
+						return;
+					}
+				}
+				const report = await runSyncGithub({
+					token,
+					repo: argv.repo,
+					dryRun: argv.dryRun,
+					...(argv.branch ? { branch: argv.branch } : {}),
+					...(argv.pr ? { createPr: true } : {}),
+					...(argv.message ? { message: argv.message } : {}),
+					...(outputDir ? { outputDir } : {}),
+				});
+				if (report.status === "fail") {
+					process.exitCode = 1;
+				}
+			}
+		)
+		.command(
+			"config show",
+			"Print the resolved holocron config",
+			() => {},
+			async (argv) => {
+				const loaded = await loadConfig(argv.cwd);
+				console.log(JSON.stringify(loaded.resolved, null, 2));
+			}
+		)
+		.command(
+			"new [type] [name]",
+			"Scaffold a new repo from a GitHub template (e.g. cli, react, nextjs, node, monorepo, base)",
+			(y) =>
+				y
+					.positional("type", {
+						type: "string",
+						describe:
+							"Template type — maps to theholocron/<type>-template " +
+							"(e.g. cli, react, nextjs, node, monorepo, base)",
+					})
+					.positional("name", {
+						type: "string",
+						describe: "New repo name (kebab-case, e.g. my-tool)",
+					})
+					.option("description", {
+						type: "string",
+						describe: "Short description — replaces <description> placeholders in the template",
+					})
+					.option("org", {
+						type: "string",
+						default: "theholocron",
+						describe: "GitHub org that owns the template and will own the new repo",
+					})
+					.option("verify", {
+						type: "boolean",
+						default: true,
+						describe: "Run pnpm install after bootstrapping (default true; --no-verify skips)",
+					}),
+			async (argv) => {
+				try {
+					let type = argv.type as string | undefined;
+					let name = argv.name as string | undefined;
+					let description = argv.description as string | undefined;
 
-						const report = await runUpgradeNode({
-							to: argv.to as number,
-							...(argv.from != null ? { from: argv.from as number } : {}),
-							cwd: argv.cwd,
-							dryRun: argv.dryRun,
-							extra,
-						});
-						if (report.status === "fail") {
-							if (report.message) console.error(`upgrade node: ${report.message}`);
-							process.exitCode = 1;
+					const needsPrompt = !type || !name || description === undefined;
+					if (needsPrompt) {
+						const rl = createInterface({ input: stdin, output: stdout });
+						const ask = (question: string) =>
+							new Promise<string>((resolve) =>
+								rl.question(`  ${question} `, (answer) => resolve(answer.trim()))
+							);
+						try {
+							if (!type) {
+								console.log("  Known types: base, cli, monorepo, nextjs, node, react");
+								type = await ask("Template type:");
+							}
+							if (!name) name = await ask("Repo name (kebab-case):");
+							if (description === undefined) {
+								description = await ask("Short description (Enter to skip):");
+							}
+						} finally {
+							rl.close();
 						}
 					}
-				)
-				.demandCommand(1, "Run `holocron upgrade --help` to see available upgrade subcommands."),
-		() => {}
-	)
-	.command(
-		"auth <subcommand>",
-		"Manage bootstrap credentials in the OS keyring",
-		(y) =>
-			y
-				.command(
-					"set <provider> [value]",
-					"Verify + store a bootstrap token for a provider",
-					(yy) =>
-						yy
-							.positional("provider", { type: "string", demandOption: true })
-							.positional("value", { type: "string" }),
-					async (argv) => {
-						const result = await runAuthSet({
-							provider: argv.provider as string,
-							...(argv.value ? { positional: argv.value as string } : {}),
-						});
-						if (result.status === "fail") process.exitCode = 1;
+
+					if (!type) {
+						console.error("new: template type is required");
+						process.exitCode = 1;
+						return;
 					}
-				)
-				.command(
-					"unset <provider>",
-					"Remove a stored bootstrap token",
-					(yy) => yy.positional("provider", { type: "string", demandOption: true }),
-					(argv) => {
-						runAuthUnset({ provider: argv.provider as string });
+					if (!name) {
+						console.error("new: repo name is required");
+						process.exitCode = 1;
+						return;
 					}
-				)
-				.command(
-					"check <provider>",
-					"Re-verify a stored bootstrap token",
-					(yy) => yy.positional("provider", { type: "string", demandOption: true }),
-					async (argv) => {
-						const result = await runAuthCheck({ provider: argv.provider as string });
-						if (result.status === "fail") process.exitCode = 1;
+
+					const report = await runNew({
+						type,
+						name,
+						...(description ? { description } : {}),
+						org: argv.org,
+						dryRun: argv.dryRun,
+						noVerify: !argv.verify,
+						cwd: argv.cwd,
+					});
+					if (report.status === "fail") process.exitCode = 1;
+				} catch (err) {
+					if (err instanceof NewError) {
+						console.error(`new: ${err.message}`);
+						process.exitCode = 1;
+						return;
 					}
-				)
-				.command(
-					"list",
-					"List every provider with a stored bootstrap token",
-					() => {},
-					async () => {
-						await runAuthList();
+					throw err;
+				}
+			}
+		)
+		.command(
+			"plugin create <slug> <vendor>",
+			"Scaffold a new @theholocron/holocron-plugin-<slug> package",
+			(y) =>
+				y
+					.positional("slug", { type: "string", demandOption: true, describe: "Package slug (kebab-case)" })
+					.positional("vendor", {
+						type: "string",
+						demandOption: true,
+						describe: "Vendor display name (PascalCase)",
+					})
+					.option("capability", {
+						type: "string",
+						describe:
+							"Capability key: source|ci|secrets|environments|issues|deployment|storage|auth|vault|dns|tooling|notifications|analytics|observability",
+					})
+					.option("token-env", {
+						type: "string",
+						describe: "Holocron env var name (defaults to HOLOCRON_<VENDOR>_TOKEN)",
+					})
+					.option("vendor-env", {
+						type: "string",
+						describe: "Vendor-native env var name",
+					})
+					.option("base-url", {
+						type: "string",
+						describe: "REST base URL",
+					})
+					.option("verify", {
+						type: "boolean",
+						default: true,
+						describe:
+							"Run post-scaffold pnpm install + typecheck + lint + test (default true; --no-verify skips)",
+					}),
+			async (argv) => {
+				try {
+					const capabilityKeys = Object.keys(CARDINALITY).join(", ");
+					const needsPrompt = !argv.capability || !argv.vendorEnv || !argv.baseUrl;
+
+					let capability: CapabilityKey;
+					let vendorEnv: string;
+					let baseUrl: string;
+
+					if (needsPrompt) {
+						const rl = createInterface({ input: stdin, output: stdout });
+						const ask = (question: string) =>
+							new Promise<string>((resolve) =>
+								rl.question(`  ${question} `, (answer) => resolve(answer.trim()))
+							);
+						try {
+							if (!argv.capability) {
+								console.log(`  Available capabilities: ${capabilityKeys}`);
+								capability = (await ask("Capability:")) as CapabilityKey;
+							} else {
+								capability = argv.capability as CapabilityKey;
+							}
+							vendorEnv = argv.vendorEnv
+								? (argv.vendorEnv as string)
+								: await ask(
+										`Vendor-native env var for the ${argv.vendor as string} token (e.g. MYVENDOR_API_KEY):`
+									);
+							baseUrl = argv.baseUrl
+								? (argv.baseUrl as string)
+								: await ask(
+										`REST base URL for the ${argv.vendor as string} API (e.g. https://api.myvendor.com):`
+									);
+						} finally {
+							rl.close();
+						}
+					} else {
+						capability = argv.capability as CapabilityKey;
+						vendorEnv = argv.vendorEnv as string;
+						baseUrl = argv.baseUrl as string;
 					}
-				)
-				.demandCommand(1, "Run `holocron auth --help` to see available auth subcommands."),
-		() => {}
-	)
-	.demandCommand(1, "Run `holocron --help` to see available commands.")
-	.strict()
-	.help()
-	.parse();
+
+					const report = runPluginCreate({
+						slug: argv.slug as string,
+						vendorName: argv.vendor as string,
+						capability,
+						vendorEnv,
+						baseUrl,
+						...(argv.tokenEnv ? { tokenEnv: argv.tokenEnv as string } : {}),
+						dryRun: argv.dryRun,
+						// Yargs: `--no-verify` flips `argv.verify` to false. We pass
+						// the inverse to preserve the internal `noVerify` naming.
+						noVerify: !argv.verify,
+						cwd: argv.cwd,
+					});
+					if (report.status === "fail") process.exitCode = 1;
+				} catch (err) {
+					if (err instanceof PluginCreateError) {
+						console.error(`plugin create: ${err.message}`);
+						process.exitCode = 1;
+						return;
+					}
+					throw err;
+				}
+			}
+		)
+		.command(
+			"upgrade",
+			"Upgrade toolchain version pins across the repo",
+			(y) =>
+				y
+					.command(
+						"node <to>",
+						"Scan the repo and update every Node.js version pin to a new major",
+						(yy) =>
+							yy
+								.positional("to", {
+									type: "number",
+									demandOption: true,
+									describe: "Target Node.js major version (e.g., 22)",
+								})
+								.option("from", {
+									type: "number",
+									describe:
+										"Current major version to replace. Auto-detected from .nvmrc / engines.node when omitted.",
+								}),
+						async (argv) => {
+							// Read upgrade.node.extra from holocron.config.json if present.
+							// We read the raw file directly rather than through loadConfig because
+							// the upgrade config is not part of the plugin schema.
+							let extra: string[] = [];
+							try {
+								const raw = readFileSync(join(argv.cwd, "holocron.config.json"), "utf8");
+								const cfg = JSON.parse(raw) as Record<string, unknown>;
+								const upgradeNode = (cfg.upgrade as Record<string, unknown> | undefined)?.node as
+									| Record<string, unknown>
+									| undefined;
+								if (Array.isArray(upgradeNode?.extra)) {
+									extra = upgradeNode.extra as string[];
+								}
+							} catch {
+								/* no config or no upgrade section — fine */
+							}
+
+							const report = await runUpgradeNode({
+								to: argv.to as number,
+								...(argv.from != null ? { from: argv.from as number } : {}),
+								cwd: argv.cwd,
+								dryRun: argv.dryRun,
+								extra,
+							});
+							if (report.status === "fail") {
+								if (report.message) console.error(`upgrade node: ${report.message}`);
+								process.exitCode = 1;
+							}
+						}
+					)
+					.demandCommand(1, "Run `holocron upgrade --help` to see available upgrade subcommands."),
+			() => {}
+		)
+		.command(
+			"auth <subcommand>",
+			"Manage bootstrap credentials in the OS keyring",
+			(y) =>
+				y
+					.command(
+						"set <provider> [value]",
+						"Verify + store a bootstrap token for a provider",
+						(yy) =>
+							yy
+								.positional("provider", { type: "string", demandOption: true })
+								.positional("value", { type: "string" }),
+						async (argv) => {
+							const result = await runAuthSet({
+								provider: argv.provider as string,
+								...(argv.value ? { positional: argv.value as string } : {}),
+							});
+							if (result.status === "fail") process.exitCode = 1;
+						}
+					)
+					.command(
+						"unset <provider>",
+						"Remove a stored bootstrap token",
+						(yy) => yy.positional("provider", { type: "string", demandOption: true }),
+						(argv) => {
+							runAuthUnset({ provider: argv.provider as string });
+						}
+					)
+					.command(
+						"check <provider>",
+						"Re-verify a stored bootstrap token",
+						(yy) => yy.positional("provider", { type: "string", demandOption: true }),
+						async (argv) => {
+							const result = await runAuthCheck({ provider: argv.provider as string });
+							if (result.status === "fail") process.exitCode = 1;
+						}
+					)
+					.command(
+						"list",
+						"List every provider with a stored bootstrap token",
+						() => {},
+						async () => {
+							await runAuthList();
+						}
+					)
+					.demandCommand(1, "Run `holocron auth --help` to see available auth subcommands."),
+			() => {}
+		)
+		.demandCommand(1, "Run `holocron --help` to see available commands.")
+		.strict()
+		.help()
+		.parse();
 } catch (err) {
 	captureException(err);
 	if (!process.exitCode) process.exitCode = 1;

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -1,0 +1,56 @@
+import type { ErrorEvent, EventHint } from "@sentry/node";
+import * as Sentry from "@sentry/node";
+
+// Paste your DSN from Sentry → Settings → Client Keys once the project is created.
+// Empty string = telemetry silently disabled — safe to ship before the project exists.
+const DSN = "";
+
+function isEnabled(): boolean {
+	return !process.env.NO_HOLOCRON_TELEMETRY && DSN !== "";
+}
+
+export function init(version: string): void {
+	if (!isEnabled()) return;
+	Sentry.init({
+		dsn: DSN,
+		release: `holocron@${version}`,
+		environment: process.env.CI ? "ci" : "local",
+		tracesSampleRate: 1.0,
+		beforeSend: scrubError,
+	});
+	Sentry.setTag("os", process.platform);
+	Sentry.setTag("node", process.version);
+	Sentry.setTag("ci", String(Boolean(process.env.CI)));
+}
+
+export function startCommand(name: string): (ok: boolean) => void {
+	if (!isEnabled()) return () => {};
+	Sentry.setTag("command", name);
+	const span = Sentry.startInactiveSpan({ name, op: "holocron.command", forceTransaction: true });
+	return (ok: boolean) => {
+		span.setStatus({ code: ok ? 1 : 2 });
+		span.end();
+	};
+}
+
+export function captureException(err: unknown): void {
+	if (!isEnabled()) return;
+	Sentry.captureException(err);
+}
+
+export async function flush(): Promise<void> {
+	if (!isEnabled()) return;
+	await Sentry.close(2_000);
+}
+
+// Scrub known token shapes from any string in the Sentry event payload.
+const TOKEN_RE = /\b(ghp_|ghs_|glpat-|xoxb-|xoxp-|npm_|sk-|[A-Z][A-Z0-9_]{2,}_TOKEN[=\s"'])\S*/g;
+
+function redact(raw: string): string {
+	return raw.replace(TOKEN_RE, "[REDACTED]");
+}
+
+function scrubError(event: ErrorEvent, _hint: EventHint): ErrorEvent {
+	return JSON.parse(redact(JSON.stringify(event))) as ErrorEvent;
+}
+

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/node";
 
 // Paste your DSN from Sentry → Settings → Client Keys once the project is created.
 // Empty string = telemetry silently disabled — safe to ship before the project exists.
-const DSN = "";
+const DSN = "https://95cbb72ad5636c94e119a5405ee8f55f@o4508238154104832.ingest.us.sentry.io/4511810950791168";
 
 function isEnabled(): boolean {
 	return !process.env.NO_HOLOCRON_TELEMETRY && DSN !== "";

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/node";
 
 // Paste your DSN from Sentry → Settings → Client Keys once the project is created.
 // Empty string = telemetry silently disabled — safe to ship before the project exists.
-const DSN = "https://95cbb72ad5636c94e119a5405ee8f55f@o4508238154104832.ingest.us.sentry.io/4511810950791168";
+const DSN: string = "https://95cbb72ad5636c94e119a5405ee8f55f@o4508238154104832.ingest.us.sentry.io/4511810950791168";
 
 function isEnabled(): boolean {
 	return !process.env.NO_HOLOCRON_TELEMETRY && DSN !== "";
@@ -44,7 +44,7 @@ export async function flush(): Promise<void> {
 }
 
 // Scrub known token shapes from any string in the Sentry event payload.
-const TOKEN_RE = /\b(ghp_|ghs_|glpat-|xoxb-|xoxp-|npm_|sk-|[A-Z][A-Z0-9_]{2,}_TOKEN[=\s"'])\S*/g;
+const TOKEN_RE = /\b(ghp_|ghs_|glpat-|xoxb-|xoxp-|npm_|sk-|[A-Z][A-Z0-9_]{2,}_TOKEN[=\s])[^\s"]*/g;
 
 function redact(raw: string): string {
 	return raw.replace(TOKEN_RE, "[REDACTED]");

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -53,4 +53,3 @@ function redact(raw: string): string {
 function scrubError(event: ErrorEvent, _hint: EventHint): ErrorEvent {
 	return JSON.parse(redact(JSON.stringify(event))) as ErrorEvent;
 }
-

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ catalogs:
       specifier: ^7.5.0
       version: 7.5.0
   default:
+    '@sentry/node':
+      specifier: ^10.0.0
+      version: 10.68.0
     '@types/node':
       specifier: ^26
       version: 26.0.1
@@ -230,6 +233,9 @@ importers:
       '@napi-rs/keyring':
         specifier: ^1.3.0
         version: 1.3.0
+      '@sentry/node':
+        specifier: 'catalog:'
+        version: 10.68.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
       '@theholocron/github-client':
         specifier: catalog:clients
         version: 1.3.3(vitest@4.1.10)
@@ -287,7 +293,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/holocron-plugin-1password:
     devDependencies:
@@ -335,7 +341,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/holocron-plugin-clerk:
     devDependencies:
@@ -386,7 +392,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/holocron-plugin-doppler:
     devDependencies:
@@ -437,7 +443,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/holocron-plugin-github:
     dependencies:
@@ -492,7 +498,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/holocron-plugin-infisical:
     devDependencies:
@@ -543,7 +549,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/holocron-plugin-neon:
     devDependencies:
@@ -594,7 +600,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/holocron-plugin-postman:
     devDependencies:
@@ -645,7 +651,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/holocron-plugin-vercel:
     devDependencies:
@@ -696,7 +702,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -711,6 +717,17 @@ packages:
 
   '@actions/io@3.0.2':
     resolution: {integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==}
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.1':
+    resolution: {integrity: sha512-Yidf5GOl60db80UxUtNdKK3pnY7obU/gs0xOfA0SCdnvVLMCvfYIer/egC3TqpPiT0Jg22eg3RlzcO+zKfPMcA==}
+    engines: {node: '>=18.0.0'}
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    resolution: {integrity: sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==}
+    hasBin: true
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1192,6 +1209,48 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@oxc-parser/binding-android-arm-eabi@0.140.0':
     resolution: {integrity: sha512-ZfjDZ422mo7eo3b3VltqNsV9kmv1qt/sPEAMSl64iOSwhVfd0eIZ9LB79Mbs1xYXJnk7WSROwzBCKDIiVxPTvQ==}
@@ -1729,6 +1788,51 @@ packages:
     engines: {node: '>=20.8.1'}
     peerDependencies:
       semantic-release: '>=20.1.0'
+
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.68.0':
+    resolution: {integrity: sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==}
+    engines: {node: '>=18'}
+
+  '@sentry/node-core@10.68.0':
+    resolution: {integrity: sha512-VreORXnruy8A2SyprZKENAq3ArGwn35KPewLQSQ5dgDXSFtUj2scLuzZoVsZ/Uyt83td0WPvD6Lv0X7MvSYAMQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+
+  '@sentry/node@10.68.0':
+    resolution: {integrity: sha512-bnvRzEehquG/894DD3BWNCBUbDWsLQfYPU+SNCMd6G4Ext75RthVkRs8R0sRaE6b8Tw9HSEgySHL834Tf8lVsA==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.68.0':
+    resolution: {integrity: sha512-JDNH9dacX0MSi7FRvabPCJUAXRMTe16bE/Gajc/7Gfcw7Rwvo4DZ0nd162PCSAW9QoEjUT12upDehEHJuFmsXg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+
+  '@sentry/server-utils@10.68.0':
+    resolution: {integrity: sha512-lp1ZSs1auw7HrCESSYt/n4dOUaKPVUIAKyVYRk6xVr4bMIN3RPub/H5Wm7QPj9CpXVC5bQFvB6+dHZXz809oMg==}
+    engines: {node: '>=18'}
 
   '@simple-libs/stream-utils@1.2.0':
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
@@ -2448,6 +2552,10 @@ packages:
   ast-v8-to-istanbul@1.0.5:
     resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -2519,6 +2627,9 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -3213,6 +3324,10 @@ packages:
     resolution: {integrity: sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==}
     engines: {node: '>=18.20'}
 
+  import-in-the-middle@3.3.2:
+    resolution: {integrity: sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==}
+    engines: {node: '>=18'}
+
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
@@ -3630,6 +3745,10 @@ packages:
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
+    engines: {node: '>=18.0.0'}
+
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -3660,6 +3779,9 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -4087,6 +4209,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -4177,6 +4303,9 @@ packages:
     resolution: {integrity: sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==}
     engines: {node: ^22.14.0 || >= 24.10.0}
     hasBin: true
+
+  semifies@1.0.0:
+    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
 
   semver-regex@4.0.5:
     resolution: {integrity: sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==}
@@ -4891,6 +5020,30 @@ snapshots:
 
   '@actions/io@3.0.2': {}
 
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.1':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      es-module-lexer: 2.3.0
+      magic-string: 0.30.21
+      module-details-from-path: 1.0.4
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      astring: 1.9.0
+      esquery: 1.7.0
+      meriyah: 6.1.4
+      semifies: 1.0.0
+      source-map: 0.6.1
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -5308,6 +5461,49 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      import-in-the-middle: 3.3.2
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
+
   '@oxc-parser/binding-android-arm-eabi@0.140.0':
     optional: true
 
@@ -5688,6 +5884,58 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@sentry/conventions@0.16.0': {}
+
+  '@sentry/core@10.68.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+
+  '@sentry/node-core@10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.68.0
+      '@sentry/opentelemetry': 10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.3.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@sentry/node@10.68.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.68.0
+      '@sentry/node-core': 10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.68.0
+      import-in-the-middle: 3.3.2
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.68.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.68.0
+
+  '@sentry/server-utils@10.68.0':
+    dependencies:
+      '@apm-js-collab/code-transformer-bundler-plugins': 0.7.1
+      '@apm-js-collab/tracing-hooks': 0.13.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.68.0
+      meriyah: 6.1.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@simple-libs/stream-utils@1.2.0': {}
 
   '@simple-libs/stream-utils@2.0.0': {}
@@ -5739,7 +5987,7 @@ snapshots:
 
   '@theholocron/http-client@1.3.3(vitest@4.1.10)':
     optionalDependencies:
-      vitest: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@theholocron/infisical-client@1.3.3(vitest@4.1.10)':
     dependencies:
@@ -5798,7 +6046,7 @@ snapshots:
 
   '@theholocron/vitest-config@7.5.0(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
     dependencies:
-      vitest: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
 
@@ -5961,7 +6209,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.24(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)':
     dependencies:
@@ -5971,7 +6219,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -5991,6 +6239,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -6293,6 +6549,8 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  astring@1.9.0: {}
+
   async-function@1.0.0:
     optional: true
 
@@ -6364,6 +6622,8 @@ snapshots:
   chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
+
+  cjs-module-lexer@2.2.0: {}
 
   clean-stack@2.2.0: {}
 
@@ -7237,6 +7497,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  import-in-the-middle@3.3.2:
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.0
+      module-details-from-path: 1.0.4
+
   import-meta-resolve@4.2.0: {}
 
   import-without-cache@0.4.0: {}
@@ -7670,6 +7936,8 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
+  meriyah@6.1.4: {}
+
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
@@ -7693,6 +7961,8 @@ snapshots:
     optional: true
 
   minimist@1.2.8: {}
+
+  module-details-from-path@1.0.4: {}
 
   ms@2.1.3: {}
 
@@ -8118,6 +8388,13 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -8279,6 +8556,8 @@ snapshots:
       - kerberos
       - supports-color
       - typescript
+
+  semifies@1.0.0: {}
 
   semver-regex@4.0.5: {}
 
@@ -8803,7 +9082,22 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.23
+      rollup: 4.62.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.22.4
+      yaml: 2.9.0
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -8826,7 +9120,37 @@ snapshots:
       vite: 7.3.6(@types/node@26.0.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 26.0.1
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.2
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ catalog:
   vitest: ^4.1.10
   typescript: ^5.9.3
   yargs: ^18.0.0
+  '@sentry/node': ^10.0.0
   '@types/node': ^26
   '@types/yargs': ^17.0.35
 


### PR DESCRIPTION
## Summary

Wires Sentry into the holocron CLI for crash reporting and command-level performance tracing.

- **`src/telemetry.ts`** — new module: `init`, `startCommand`, `captureException`, `flush`
- **`src/cli.ts`** — calls `init` at startup, uses yargs `.middleware()` to name each command transaction, wraps `.parse()` in try/catch for unhandled errors, flushes before process exit
- **`@sentry/node ^10.0.0`** added to workspace catalog and CLI dependencies

### How it works

Each command invocation becomes a Sentry transaction (`holocron.command` op). Tags captured on every event: `os`, `node`, `ci`, `command`, plus `release` and `environment` from init.

A `beforeSend` hook scrubs known token patterns (`ghp_`, `npm_`, `*_TOKEN=`, etc.) from all error events before they leave the process.

### Opt-out

```bash
NO_HOLOCRON_TELEMETRY=1 holocron setup
```

Any truthy value disables Sentry entirely — `init`, `startCommand`, and `flush` all become no-ops. Safe for CI environments that should not phone home.

### Activate

Telemetry is **inert until a DSN is set** — `DSN = ""` in `telemetry.ts` means nothing is sent. Once a Sentry project is created, paste the DSN there and telemetry goes live.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] `pnpm test` passes (existing tests unaffected — `isEnabled()` returns false with empty DSN)
- [ ] `NO_HOLOCRON_TELEMETRY=1 node dist/cli.mjs version` exits cleanly with no Sentry calls