### PR TITLE
fix: pass SENTRY_AUTH_TOKEN through Turbo to build task for sourcemap upload

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,8 @@
     "build": {
       "inputs": ["src/**", "tsdown.config.ts", "tsconfig.json", "package.json"],
       "outputs": ["dist/**"],
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "passThroughEnv": ["SENTRY_AUTH_TOKEN"]
     },
     "lint": {
       "inputs": ["src/**", "eslint.config.ts", "eslint.config.js"],


### PR DESCRIPTION
## Summary

Turbo does not forward env vars to tasks unless explicitly declared. Without `passThroughEnv`, `SENTRY_AUTH_TOKEN` is invisible to the `tsdown` build step even though it is set as a CI secret — meaning the Sentry rollup plugin would warn and skip the sourcemap upload on every CI build.

Adds `passThroughEnv: ["SENTRY_AUTH_TOKEN"]` to the `build` task. Using `passThroughEnv` (not `env`) keeps the token out of the cache key — the build output is identical with or without the token; the upload is a side effect.

## Test plan

- [ ] CI build passes
- [ ] After merge, verify sourcemaps appear in Sentry → holocron-cli → Source Maps on the next release build