### PR TITLE
feat(cli): sync Sentry release name with package version and auto-associate commits

### DIFF
--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -37,6 +37,7 @@ export default defineConfig([
 				release: {
 					name: `holocron@${version}`,
 					setCommits: { auto: true },
+					deploy: { env: "production" },
 				},
 			}),
 		],

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -1,7 +1,10 @@
+import { readFileSync } from "node:fs";
 import { sentryRollupPlugin } from "@sentry/rollup-plugin";
 import { defineConfig } from "tsdown";
 
 import { rawYml } from "./raw-yml.js";
+
+const { version } = JSON.parse(readFileSync("./package.json", "utf-8")) as { version: string };
 
 const sharedDeps = { neverBundle: [/^@theholocron\//] };
 const sharedPlugins = [rawYml()];
@@ -31,6 +34,10 @@ export default defineConfig([
 				authToken: process.env.SENTRY_AUTH_TOKEN,
 				org: "theholocron",
 				project: "holocron-cli",
+				release: {
+					name: `holocron@${version}`,
+					setCommits: { auto: true },
+				},
 			}),
 		],
 	},


### PR DESCRIPTION
## Summary

Two fixes to complete the Sentry release tracking setup:

1. **Release name now matches `telemetry.ts`** — reads `version` from `package.json` at build time and sets the Sentry release to `holocron@<version>`. Previously the rollup plugin defaulted to the git commit SHA while `telemetry.ts` tagged errors with `holocron@3.1.1` — mismatched names meant sourcemaps and error events couldn't be correlated.

2. **Commit association via `setCommits: { auto: true }`** — the plugin automatically walks git history to associate commits with the release. This powers Sentry's Suspect Commits feature (identifying which commit introduced a regression) without a separate `@sentry/cli` workflow step.

## Test plan

- [ ] CI build passes
- [ ] After merge + release, verify in Sentry → Releases that the release is named `holocron@<version>` with commits attached