### PR TITLE
ci: improve caching and parallelism in reusable workflows

### DIFF
--- a/packages/cli/src/templates/workflows/audit.yml
+++ b/packages/cli/src/templates/workflows/audit.yml
@@ -35,8 +35,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository
-        with:
-          fetch-depth: 0
 
       - uses: theholocron/.github/.github/actions/setup@main
         name: Setup
@@ -54,6 +52,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: knip-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository

--- a/packages/cli/src/templates/workflows/release.yml
+++ b/packages/cli/src/templates/workflows/release.yml
@@ -85,8 +85,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || secrets.GH_TOKEN || github.token }}
 
-      - run: npm install -g npm@11 sigstore
-        name: Upgrade npm for OIDC support
+      - name: Configure npm global prefix
+        run: |
+          npm config set prefix ~/.npm-global
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+
+      - name: Cache npm global packages
+        id: cache-npm-globals
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.npm-global
+          key: npm-globals-npm11-sigstore-${{ runner.os }}
+
+      - name: Upgrade npm for OIDC support
+        if: steps.cache-npm-globals.outputs.cache-hit != 'true'
+        run: npm install -g npm@11 sigstore
         # sigstore is required by libnpmpublish/provenance.js at module parse
         # time — before any config takes effect. Some npm 11.x builds stopped
         # bundling it; installing it globally into the same prefix ensures it

--- a/packages/cli/src/templates/workflows/sync-github.yml
+++ b/packages/cli/src/templates/workflows/sync-github.yml
@@ -64,13 +64,24 @@ jobs:
       - run: pnpm build
         name: Build CLI
 
+      - name: Cache actionlint
+        id: cache-actionlint
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: /tmp/actionlint
+          key: actionlint-v1.7.7-linux-amd64
+
+      - name: Download actionlint
+        if: steps.cache-actionlint.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz \
+            | tar -xz -C /tmp actionlint
+
       - name: Validate generated workflows
         run: |
           node packages/cli/dist/cli.mjs sync-github \
             --repo "$PRIMARY_REPO" \
             --output-dir /tmp/sync-validate
-          curl -fsSL https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz \
-            | tar -xz -C /tmp actionlint
           /tmp/actionlint /tmp/sync-validate/.github/workflows/*.yml
         env:
           PRIMARY_REPO: ${{ inputs.primary-repo }}

--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository
-        with:
-          fetch-depth: 0
 
       - uses: theholocron/.github/.github/actions/setup@main
         name: Setup


### PR DESCRIPTION
## Summary

**Commit 1 — General caching and parallelism fixes:**
- Drop `fetch-depth: 0` from `test` and `audit` (bundle-size) checkouts — tests and builds don't need full git history
- Add concurrency group to the `knip` job in `audit`, matching the guard already on `bundle-size`
- Cache the `actionlint` binary in `sync-github` with a version-pinned key; download only on cache miss
- Cache npm global packages (`npm@11` + `sigstore`) in `release` via a custom `~/.npm-global` prefix; install skipped on cache hit

**Commit 2 — Turbo caching (local + remote):**
- `setup` action: cache `.turbo/` via `actions/cache` when `turbo.json` is present, keyed on `${{ github.sha }}` with a runner-scoped restore-key — same-commit re-runs hit immediately; incremental pushes get a warm partial hit
- `test`, `typecheck`, `audit`, `release`, `sync-github`: declare `TURBO_TOKEN` + `TURBO_TEAM` as optional secrets and expose them at the job `env` level — any `turbo run` invocation will transparently read/write the Vercel Remote Cache when those secrets are present, sharing task outputs across branches and PRs

## Secrets setup (one-time, for remote cache)

Add to org secrets:
- `TURBO_TOKEN` — generate at vercel.com → Settings → Tokens
- `TURBO_TEAM` — your Vercel team slug (e.g. `theholocron`)

Callers opt in by passing them via `secrets: inherit`.

## Test plan

- [ ] After merge, trigger a sync to verify generated workflows in `.github` look correct
- [ ] Run tests/build in a downstream repo and confirm `.turbo/` cache is populated on first run and hit on re-run
- [ ] Add `TURBO_TOKEN` + `TURBO_TEAM` org secrets and verify a subsequent run shows Turbo remote cache hits in the CLI output
- [ ] Confirm `knip` runs cancel correctly on a new push during execution