### PR TITLE
ci: wire Turbo local and remote caching into reusable workflows

### DIFF
--- a/packages/cli/src/templates/actions/setup.yml
+++ b/packages/cli/src/templates/actions/setup.yml
@@ -16,3 +16,12 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - uses: theholocron/.github/.github/actions/install@main
+
+    - name: Cache Turbo artifacts
+      if: ${{ hashFiles('turbo.json') != '' }}
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: .turbo
+        key: turbo-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          turbo-${{ runner.os }}-

--- a/packages/cli/src/templates/workflows/audit.yml
+++ b/packages/cli/src/templates/workflows/audit.yml
@@ -21,6 +21,10 @@ on: # yamllint disable-line rule:truthy
     secrets:
       CODECOV_TOKEN:
         required: false
+      TURBO_TOKEN:
+        required: false
+      TURBO_TEAM:
+        required: false
 
 jobs:
   bundle-size:
@@ -32,6 +36,9 @@ jobs:
     concurrency:
       group: audit-${{ github.ref }}
       cancel-in-progress: true
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository
@@ -55,6 +62,9 @@ jobs:
     concurrency:
       group: knip-${{ github.ref }}
       cancel-in-progress: true
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository

--- a/packages/cli/src/templates/workflows/audit.yml
+++ b/packages/cli/src/templates/workflows/audit.yml
@@ -23,8 +23,6 @@ on: # yamllint disable-line rule:truthy
         required: false
       TURBO_TOKEN:
         required: false
-      TURBO_TEAM:
-        required: false
 
 jobs:
   bundle-size:
@@ -38,7 +36,7 @@ jobs:
       cancel-in-progress: true
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository
@@ -64,7 +62,7 @@ jobs:
       cancel-in-progress: true
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository

--- a/packages/cli/src/templates/workflows/release.yml
+++ b/packages/cli/src/templates/workflows/release.yml
@@ -47,6 +47,10 @@ on: # yamllint disable-line rule:truthy
           Sentry auth token for sourcemap upload and release creation.
           Required when sentry-project is set. Use the org-level secret.
         required: false
+      TURBO_TOKEN:
+        required: false
+      TURBO_TEAM:
+        required: false
 
 jobs:
   release:
@@ -58,6 +62,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     # Do not cancel in-progress releases — a partial release is worse than a slow one.
     concurrency:
       group: release-${{ github.ref }}

--- a/packages/cli/src/templates/workflows/release.yml
+++ b/packages/cli/src/templates/workflows/release.yml
@@ -49,8 +49,6 @@ on: # yamllint disable-line rule:truthy
         required: false
       TURBO_TOKEN:
         required: false
-      TURBO_TEAM:
-        required: false
 
 jobs:
   release:
@@ -64,7 +62,7 @@ jobs:
     timeout-minutes: 30
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     # Do not cancel in-progress releases — a partial release is worse than a slow one.
     concurrency:
       group: release-${{ github.ref }}

--- a/packages/cli/src/templates/workflows/sync-github.yml
+++ b/packages/cli/src/templates/workflows/sync-github.yml
@@ -46,6 +46,10 @@ on: # yamllint disable-line rule:truthy
           Generic GitHub token fallback for `gh` CLI calls. Used when neither
           HOLOCRON_READ_TOKEN nor HOLOCRON_SYNC_TOKEN is set.
         required: false
+      TURBO_TOKEN:
+        required: false
+      TURBO_TEAM:
+        required: false
 
 jobs:
   sync:
@@ -54,6 +58,9 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository

--- a/packages/cli/src/templates/workflows/sync-github.yml
+++ b/packages/cli/src/templates/workflows/sync-github.yml
@@ -48,8 +48,6 @@ on: # yamllint disable-line rule:truthy
         required: false
       TURBO_TOKEN:
         required: false
-      TURBO_TEAM:
-        required: false
 
 jobs:
   sync:
@@ -60,7 +58,7 @@ jobs:
       contents: read
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository

--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -2,6 +2,11 @@ name: Test
 
 on: # yamllint disable-line rule:truthy
   workflow_call:
+    secrets:
+      TURBO_TOKEN:
+        required: false
+      TURBO_TEAM:
+        required: false
 
 jobs:
   unit:
@@ -11,6 +16,9 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository

--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -5,8 +5,6 @@ on: # yamllint disable-line rule:truthy
     secrets:
       TURBO_TOKEN:
         required: false
-      TURBO_TEAM:
-        required: false
 
 jobs:
   unit:
@@ -18,7 +16,7 @@ jobs:
     timeout-minutes: 15
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository

--- a/packages/cli/src/templates/workflows/typecheck.yml
+++ b/packages/cli/src/templates/workflows/typecheck.yml
@@ -5,8 +5,6 @@ on: # yamllint disable-line rule:truthy
     secrets:
       TURBO_TOKEN:
         required: false
-      TURBO_TEAM:
-        required: false
 
 jobs:
   typecheck:
@@ -17,7 +15,7 @@ jobs:
     timeout-minutes: 10
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository

--- a/packages/cli/src/templates/workflows/typecheck.yml
+++ b/packages/cli/src/templates/workflows/typecheck.yml
@@ -2,6 +2,11 @@ name: Typecheck
 
 on: # yamllint disable-line rule:truthy
   workflow_call:
+    secrets:
+      TURBO_TOKEN:
+        required: false
+      TURBO_TEAM:
+        required: false
 
 jobs:
   typecheck:
@@ -10,6 +15,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository


### PR DESCRIPTION
## Summary

- **`setup` action**: cache `.turbo/` via `actions/cache` when `turbo.json` is present, keyed on `${{ github.sha }}` with a runner-scoped restore-key. Same-commit re-runs hit immediately; incremental pushes get a warm partial hit.
- **`test`, `typecheck`, `audit`, `release`, `sync-github`**: declare `TURBO_TOKEN` as an optional secret and set both `TURBO_TOKEN` (from `secrets`) and `TURBO_TEAM` (from `vars` — it's a non-sensitive team slug, not a secret) at the job `env` level. Any `pnpm` script that invokes `turbo run` will transparently read/write the Vercel Remote Cache when those values are present, sharing task outputs across branches and PRs.

## Secrets/vars setup (one-time)

Already configured at the org level:
- `TURBO_TOKEN` — org secret
- `TURBO_TEAM` — org variable

Callers that use `secrets: inherit` get `TURBO_TOKEN` automatically. `TURBO_TEAM` flows through as a variable without any declaration needed.

## Test plan

- [ ] After merge, trigger a sync to verify generated workflows in `.github` look correct
- [ ] Run tests/build in a downstream repo and confirm `.turbo/` cache is populated on first run and hit on re-run
- [ ] Confirm a subsequent run shows Turbo remote cache hits in the CLI output (`FULL TURBO` or per-task cache hit logs)