### PR TITLE
fix: set HUSKY=0 in release workflow and fix publish-initial next-steps output

### DIFF
--- a/packages/cli/src/__tests__/npm-publish-initial.test.ts
+++ b/packages/cli/src/__tests__/npm-publish-initial.test.ts
@@ -21,6 +21,10 @@ function makeExec(responses: Record<string, PublishExecResult>) {
 
 const baseEnv: NodeJS.ProcessEnv = {};
 
+// Fixtures injected directly to avoid touching the filesystem or git in tests.
+const TEST_PACKAGES = ["@theholocron/foo", "@theholocron/bar"] as const;
+const TEST_REPO = "test-repo";
+
 describe("runNpmPublishInitial", () => {
 	it("verifies npm auth via `npm whoami` before publishing", async () => {
 		const { exec, calls } = makeExec({
@@ -30,6 +34,8 @@ describe("runNpmPublishInitial", () => {
 		const report = await runNpmPublishInitial({
 			cwd: "/tmp/test",
 			env: baseEnv,
+			packages: TEST_PACKAGES,
+			repoName: TEST_REPO,
 			print: () => {},
 			exec,
 		});
@@ -45,6 +51,8 @@ describe("runNpmPublishInitial", () => {
 		const report = await runNpmPublishInitial({
 			cwd: "/tmp/test",
 			env: baseEnv,
+			packages: TEST_PACKAGES,
+			repoName: TEST_REPO,
 			print: () => {},
 			exec,
 		});
@@ -61,6 +69,8 @@ describe("runNpmPublishInitial", () => {
 		await runNpmPublishInitial({
 			cwd: "/tmp/test",
 			env: baseEnv,
+			packages: TEST_PACKAGES,
+			repoName: TEST_REPO,
 			print: () => {},
 			exec,
 		});
@@ -86,6 +96,8 @@ describe("runNpmPublishInitial", () => {
 			cwd: "/tmp/test",
 			tag: "next",
 			env: baseEnv,
+			packages: TEST_PACKAGES,
+			repoName: TEST_REPO,
 			print: () => {},
 			exec,
 		});
@@ -100,6 +112,8 @@ describe("runNpmPublishInitial", () => {
 		const report = await runNpmPublishInitial({
 			cwd: "/tmp/test",
 			env: baseEnv,
+			packages: TEST_PACKAGES,
+			repoName: TEST_REPO,
 			print: () => {},
 			exec,
 		});
@@ -116,6 +130,8 @@ describe("runNpmPublishInitial", () => {
 			cwd: "/tmp/test",
 			otp: "123456",
 			env: baseEnv,
+			packages: TEST_PACKAGES,
+			repoName: TEST_REPO,
 			print: () => {},
 			exec,
 		});
@@ -136,6 +152,8 @@ describe("runNpmPublishInitial", () => {
 		const report = await runNpmPublishInitial({
 			cwd: "/tmp/test",
 			env: baseEnv,
+			packages: TEST_PACKAGES,
+			repoName: TEST_REPO,
 			print: (l) => lines.push(l),
 			exec,
 		});
@@ -154,6 +172,8 @@ describe("runNpmPublishInitial", () => {
 		await runNpmPublishInitial({
 			cwd: "/tmp/test",
 			env: baseEnv,
+			packages: TEST_PACKAGES,
+			repoName: TEST_REPO,
 			print: (l) => lines.push(l),
 			exec,
 		});
@@ -170,6 +190,8 @@ describe("runNpmPublishInitial", () => {
 			cwd: "/tmp/test",
 			dryRun: true,
 			env: baseEnv,
+			packages: TEST_PACKAGES,
+			repoName: TEST_REPO,
 			print: (l) => lines.push(l),
 			exec,
 		});
@@ -178,7 +200,7 @@ describe("runNpmPublishInitial", () => {
 		expect(lines.some((l) => l.includes("would run"))).toBe(true);
 	});
 
-	it("includes the trusted-publisher setup URLs in next-steps output", async () => {
+	it("includes the discovered package URLs and repo name in next-steps output", async () => {
 		const lines: string[] = [];
 		const { exec } = makeExec({
 			npm: { exitCode: 0, stdout: "iamnewton", stderr: "" },
@@ -187,14 +209,68 @@ describe("runNpmPublishInitial", () => {
 		await runNpmPublishInitial({
 			cwd: "/tmp/test",
 			env: baseEnv,
+			packages: TEST_PACKAGES,
+			repoName: TEST_REPO,
 			print: (l) => lines.push(l),
 			exec,
 		});
 		const joined = lines.join("\n");
-		expect(joined).toContain("npmjs.com/package/@theholocron/cli/access");
-		expect(joined).toContain("npmjs.com/package/@theholocron/holocron-plugin-github/access");
+		expect(joined).toContain("npmjs.com/package/@theholocron/foo/access");
+		expect(joined).toContain("npmjs.com/package/@theholocron/bar/access");
+		expect(joined).toContain(`Repo: ${TEST_REPO}`);
 		expect(joined).toContain("Publisher: GitHub Actions");
 		expect(joined).toContain("Workflow: release.yml");
+	});
+
+	it("auto-detects repo name from git remote when repoName is not injected", async () => {
+		const lines: string[] = [];
+		const { exec } = makeExec({
+			npm: { exitCode: 0, stdout: "iamnewton", stderr: "" },
+			git: { exitCode: 0, stdout: "https://github.com/theholocron/themes.git\n", stderr: "" },
+			pnpm: { exitCode: 0, stdout: "", stderr: "" },
+		});
+		await runNpmPublishInitial({
+			cwd: "/tmp/test",
+			env: baseEnv,
+			packages: TEST_PACKAGES,
+			print: (l) => lines.push(l),
+			exec,
+		});
+		expect(lines.join("\n")).toContain("Repo: themes");
+	});
+
+	it("auto-detects repo name from SSH remote URL format", async () => {
+		const lines: string[] = [];
+		const { exec } = makeExec({
+			npm: { exitCode: 0, stdout: "iamnewton", stderr: "" },
+			git: { exitCode: 0, stdout: "git@github.com:theholocron/clients.git\n", stderr: "" },
+			pnpm: { exitCode: 0, stdout: "", stderr: "" },
+		});
+		await runNpmPublishInitial({
+			cwd: "/tmp/test",
+			env: baseEnv,
+			packages: TEST_PACKAGES,
+			print: (l) => lines.push(l),
+			exec,
+		});
+		expect(lines.join("\n")).toContain("Repo: clients");
+	});
+
+	it("falls back to 'unknown' when git remote fails", async () => {
+		const lines: string[] = [];
+		const { exec } = makeExec({
+			npm: { exitCode: 0, stdout: "iamnewton", stderr: "" },
+			git: { exitCode: 128, stdout: "", stderr: "not a git repo" },
+			pnpm: { exitCode: 0, stdout: "", stderr: "" },
+		});
+		await runNpmPublishInitial({
+			cwd: "/tmp/test",
+			env: baseEnv,
+			packages: TEST_PACKAGES,
+			print: (l) => lines.push(l),
+			exec,
+		});
+		expect(lines.join("\n")).toContain("Repo: unknown");
 	});
 
 	it("prints a token-revoke reminder when NPM_TOKEN is detected in env", async () => {
@@ -206,6 +282,8 @@ describe("runNpmPublishInitial", () => {
 		await runNpmPublishInitial({
 			cwd: "/tmp/test",
 			env: { NPM_TOKEN: "npm_xxx" },
+			packages: TEST_PACKAGES,
+			repoName: TEST_REPO,
 			print: (l) => lines.push(l),
 			exec,
 		});
@@ -223,6 +301,8 @@ describe("runNpmPublishInitial", () => {
 		await runNpmPublishInitial({
 			cwd: "/tmp/test",
 			env: baseEnv,
+			packages: TEST_PACKAGES,
+			repoName: TEST_REPO,
 			print: (l) => lines.push(l),
 			exec,
 		});

--- a/packages/cli/src/__tests__/npm-publish-initial.test.ts
+++ b/packages/cli/src/__tests__/npm-publish-initial.test.ts
@@ -1,8 +1,28 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("node:child_process", () => ({ spawnSync: vi.fn(() => ({ status: 0, stdout: "", stderr: "" })) }));
 
 import { type PublishExecResult, runNpmPublishInitial } from "../commands/npm-publish-initial.js";
+
+function makeTempMonorepo(packages: Array<{ name: string; private?: boolean; invalidJson?: boolean }>) {
+	const root = mkdtempSync(join(tmpdir(), "holocron-test-"));
+	const pkgsDir = join(root, "packages");
+	mkdirSync(pkgsDir);
+	for (const pkg of packages) {
+		const dir = join(pkgsDir, pkg.name.replace(/\//g, "-"));
+		mkdirSync(dir);
+		const content = pkg.invalidJson
+			? "not valid json {"
+			: JSON.stringify({ name: pkg.name, ...(pkg.private ? { private: true } : {}) });
+		writeFileSync(join(dir, "package.json"), content);
+	}
+	// Directory with no package.json — should be skipped
+	mkdirSync(join(pkgsDir, "no-manifest"));
+	return root;
+}
 
 function makeExec(responses: Record<string, PublishExecResult>) {
 	const calls: Array<{ cmd: string; args: string[] }> = [];
@@ -308,6 +328,55 @@ describe("runNpmPublishInitial", () => {
 		});
 		const joined = lines.join("\n");
 		expect(joined).not.toContain("Revoke it now");
+	});
+});
+
+// ── discoverPublicPackages ────────────────────────────────────────────────────
+
+describe("discoverPublicPackages (via runNpmPublishInitial without packages injection)", () => {
+	it("discovers non-private packages and skips private, no-manifest, and invalid-JSON entries", async () => {
+		const root = makeTempMonorepo([
+			{ name: "@theholocron/public-a" },
+			{ name: "@theholocron/public-b" },
+			{ name: "@theholocron/private-c", private: true },
+			{ name: "@theholocron/broken-d", invalidJson: true },
+		]);
+		const lines: string[] = [];
+		const { exec } = makeExec({
+			npm: { exitCode: 0, stdout: "iamnewton", stderr: "" },
+			pnpm: { exitCode: 0, stdout: "", stderr: "" },
+		});
+		await runNpmPublishInitial({
+			cwd: root,
+			env: baseEnv,
+			repoName: TEST_REPO,
+			print: (l) => lines.push(l),
+			exec,
+		});
+		const joined = lines.join("\n");
+		expect(joined).toContain("@theholocron/public-a/access");
+		expect(joined).toContain("@theholocron/public-b/access");
+		expect(joined).not.toContain("@theholocron/private-c/access");
+		expect(joined).not.toContain("@theholocron/broken-d/access");
+		expect(joined).not.toContain("no-manifest/access");
+	});
+
+	it("returns empty list when the packages directory does not exist", async () => {
+		const lines: string[] = [];
+		const { exec } = makeExec({
+			npm: { exitCode: 0, stdout: "iamnewton", stderr: "" },
+			pnpm: { exitCode: 0, stdout: "", stderr: "" },
+		});
+		// /tmp/test has no packages/ directory
+		await runNpmPublishInitial({
+			cwd: "/tmp/test",
+			env: baseEnv,
+			repoName: TEST_REPO,
+			print: (l) => lines.push(l),
+			exec,
+		});
+		// no package URLs in next-steps
+		expect(lines.join("\n")).not.toContain("npmjs.com/package/");
 	});
 });
 

--- a/packages/cli/src/commands/npm-publish-initial.ts
+++ b/packages/cli/src/commands/npm-publish-initial.ts
@@ -181,10 +181,7 @@ function discoverPublicPackages(cwd: string): readonly string[] {
 		});
 }
 
-async function resolveRepoName(
-	cwd: string,
-	exec: NonNullable<RunNpmPublishInitialInput["exec"]>,
-): Promise<string> {
+async function resolveRepoName(cwd: string, exec: NonNullable<RunNpmPublishInitialInput["exec"]>): Promise<string> {
 	const result = await exec("git", ["remote", "get-url", "origin"], { cwd });
 	if (result.exitCode !== 0) return "unknown";
 	// Matches both HTTPS (https://github.com/org/repo.git) and
@@ -197,7 +194,7 @@ function printNextSteps(
 	print: PublishInitialPrint,
 	env: NodeJS.ProcessEnv,
 	packageNames: readonly string[],
-	repoName: string,
+	repoName: string
 ): void {
 	print("");
 	print("  → next: configure Trusted Publisher for each package on npm:");

--- a/packages/cli/src/commands/npm-publish-initial.ts
+++ b/packages/cli/src/commands/npm-publish-initial.ts
@@ -24,6 +24,8 @@
  * setup` for the ephemeral GH admin PAT.
  */
 
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
 export type PublishInitialPrint = (line: string) => void;
@@ -59,6 +61,17 @@ export interface RunNpmPublishInitialInput {
 	exec?: (cmd: string, args: string[], opts: { cwd: string }) => Promise<PublishExecResult>;
 	/** Env vars; passed in for testability. Defaults to process.env. */
 	env?: NodeJS.ProcessEnv;
+	/**
+	 * Override the list of package names shown in the Trusted Publisher
+	 * next-steps output. Auto-discovered from packages/*\/package.json
+	 * when omitted.
+	 */
+	packages?: readonly string[];
+	/**
+	 * Override the repo name shown in the Trusted Publisher next-steps
+	 * output. Auto-detected from `git remote get-url origin` when omitted.
+	 */
+	repoName?: string;
 }
 
 export type PublishInitialStatus = "ok" | "fail" | "dry-run";
@@ -69,16 +82,6 @@ export interface NpmPublishInitialReport {
 	/** Packages that the publish step targeted. */
 	packageNames: readonly string[];
 }
-
-const PUBLISHABLE_PACKAGES = [
-	"@theholocron/cli",
-	"@theholocron/holocron-plugin-github",
-	"@theholocron/holocron-plugin-vercel",
-	"@theholocron/holocron-plugin-neon",
-	"@theholocron/holocron-plugin-clerk",
-	"@theholocron/holocron-plugin-1password",
-	"@theholocron/holocron-plugin-postman",
-] as const;
 
 export async function runNpmPublishInitial(input: RunNpmPublishInitialInput = {}): Promise<NpmPublishInitialReport> {
 	const print = input.print ?? ((line: string) => console.log(line));
@@ -116,22 +119,23 @@ export async function runNpmPublishInitial(input: RunNpmPublishInitialInput = {}
 		const message =
 			"npm is not authenticated. Run `npm login --auth-type=web` (browser flow, no token stored) or `npm login`, then re-run this command.";
 		print(`  ✗ ${message}`);
-		return { status: "fail", message, packageNames: PUBLISHABLE_PACKAGES };
+		const packageNames = input.packages ?? discoverPublicPackages(cwd);
+		return { status: "fail", message, packageNames };
 	}
 	const whoamiName = whoami.stdout.trim() || "<unknown>";
 	print(`    ✓ authed as ${whoamiName}`);
 
-	// ── 2. Publish ──────────────────────────────────────────────────────
+	// ── 2. Resolve dynamic values needed for next-steps ─────────────────
+	const packageNames = input.packages ?? discoverPublicPackages(cwd);
+	const repoName = input.repoName ?? (await resolveRepoName(cwd, exec));
+
+	// ── 3. Publish ──────────────────────────────────────────────────────
 	if (dryRun) {
 		print("");
 		print("  … (dry-run) skipping actual publish");
 		print(`    would run: pnpm ${publishArgs.join(" ")}`);
-		printNextSteps(print, env);
-		return {
-			status: "dry-run",
-			message: "dry-run — no publish executed",
-			packageNames: PUBLISHABLE_PACKAGES,
-		};
+		printNextSteps(print, env, packageNames, repoName);
+		return { status: "dry-run", message: "dry-run — no publish executed", packageNames };
 	}
 
 	print("");
@@ -146,24 +150,61 @@ export async function runNpmPublishInitial(input: RunNpmPublishInitialInput = {}
 			print("  → hint: your npm account requires 2FA for writes. Re-run with `--otp <code>`:");
 			print(`    pnpm exec tsx packages/cli/src/cli.ts npm publish-initial --otp <6-digit-code>`);
 		}
-		return { status: "fail", message, packageNames: PUBLISHABLE_PACKAGES };
+		return { status: "fail", message, packageNames };
 	}
 	print("    ✓ publish complete");
 
-	// ── 3. Next-step reminders ──────────────────────────────────────────
-	printNextSteps(print, env);
-	return { status: "ok", packageNames: PUBLISHABLE_PACKAGES };
+	// ── 4. Next-step reminders ──────────────────────────────────────────
+	printNextSteps(print, env, packageNames, repoName);
+	return { status: "ok", packageNames };
 }
 
 // ── helpers ──────────────────────────────────────────────────────────
 
-function printNextSteps(print: PublishInitialPrint, env: NodeJS.ProcessEnv): void {
+function discoverPublicPackages(cwd: string): readonly string[] {
+	const packagesDir = join(cwd, "packages");
+	if (!existsSync(packagesDir)) return [];
+	return readdirSync(packagesDir, { withFileTypes: true })
+		.filter((e) => e.isDirectory())
+		.flatMap((e) => {
+			const pkgPath = join(packagesDir, e.name, "package.json");
+			if (!existsSync(pkgPath)) return [];
+			try {
+				const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+					name?: string;
+					private?: boolean;
+				};
+				return !pkg.private && pkg.name ? [pkg.name] : [];
+			} catch {
+				return [];
+			}
+		});
+}
+
+async function resolveRepoName(
+	cwd: string,
+	exec: NonNullable<RunNpmPublishInitialInput["exec"]>,
+): Promise<string> {
+	const result = await exec("git", ["remote", "get-url", "origin"], { cwd });
+	if (result.exitCode !== 0) return "unknown";
+	// Matches both HTTPS (https://github.com/org/repo.git) and
+	// SSH (git@github.com:org/repo.git) remote URL formats.
+	const match = /[/:]([^/:]+?)(?:\.git)?$/.exec(result.stdout.trim());
+	return match?.[1] ?? "unknown";
+}
+
+function printNextSteps(
+	print: PublishInitialPrint,
+	env: NodeJS.ProcessEnv,
+	packageNames: readonly string[],
+	repoName: string,
+): void {
 	print("");
 	print("  → next: configure Trusted Publisher for each package on npm:");
-	for (const name of PUBLISHABLE_PACKAGES) {
+	for (const name of packageNames) {
 		print(`    https://www.npmjs.com/package/${name}/access`);
 	}
-	print("    Publisher: GitHub Actions   Org: theholocron   Repo: holocron   Workflow: release.yml");
+	print(`    Publisher: GitHub Actions   Org: theholocron   Repo: ${repoName}   Workflow: release.yml`);
 
 	if (env.NPM_TOKEN) {
 		print("");

--- a/packages/cli/src/templates/workflows/lint.yml
+++ b/packages/cli/src/templates/workflows/lint.yml
@@ -12,14 +12,16 @@ on: # yamllint disable-line rule:truthy
         required: false
         default: yamllint.config.yml
       enable-auto-commit:
-        description: Auto-commit super-linter fixes via GPG-signed commit
+        description: >
+          Auto-commit super-linter fixes as a verified commit via a GitHub App.
+          Requires SUPER_LINTER_APP_ID and SUPER_LINTER_PRIVATE_KEY secrets.
         type: boolean
         required: false
         default: false
     secrets:
-      SUPER_LINTER_GPG_PRIVATE_KEY:
+      SUPER_LINTER_APP_ID:
         required: false
-      SUPER_LINTER_GPG_PASSPHRASE:
+      SUPER_LINTER_PRIVATE_KEY:
         required: false
 
 jobs:
@@ -31,13 +33,45 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      GPG_KEY_SET: ${{ secrets.SUPER_LINTER_GPG_PRIVATE_KEY != '' }}
+      APP_ID_SET: ${{ secrets.SUPER_LINTER_APP_ID != '' }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        # Runs before checkout so the token is used as the checkout credential,
+        # which makes the subsequent push go through the App and produce a
+        # Verified commit. Skipped when auto-commit is disabled or secrets unset.
+        if: >
+          inputs.enable-auto-commit == true &&
+          github.event.pull_request != null &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.ref_name != github.event.repository.default_branch &&
+          env.APP_ID_SET == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.SUPER_LINTER_APP_ID }}
+          private-key: ${{ secrets.SUPER_LINTER_PRIVATE_KEY }}
+
+      - name: Resolve App bot identity
+        id: app-bot
+        # GitHub marks commits as Verified when the author email matches the
+        # App bot's noreply address (<numeric-id>+<slug>[bot]@users.noreply.github.com).
+        # The numeric ID must be fetched via the API — it differs from the App ID.
+        if: steps.app-token.conclusion == 'success'
+        run: |
+          BOT_SLUG="${{ steps.app-token.outputs.app-slug }}[bot]"
+          BOT_ID=$(gh api "/users/${BOT_SLUG}" --jq .id)
+          echo "name=${BOT_SLUG}" >> "$GITHUB_OUTPUT"
+          echo "email=${BOT_ID}+${BOT_SLUG}@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository
         with:
           fetch-depth: 0
-          token: ${{ github.token }}
+          # Use the App token when available so the push credential is the App
+          # bot — GitHub marks those commits as Verified automatically.
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - uses: theholocron/.github/.github/actions/setup@main
         name: Setup
@@ -79,23 +113,6 @@ jobs:
           VALIDATE_YAML: true
           YAML_CONFIG_FILE: ${{ inputs.yaml-config }}
 
-      - uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
-        id: import-gpg
-        name: Import GPG Key
-        # Conditions mirror auto-commit exactly — no point importing GPG if the
-        # commit step will be skipped (fork PR, default branch, or secret unset).
-        if: >
-          inputs.enable-auto-commit == true &&
-          github.event.pull_request != null &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          github.ref_name != github.event.repository.default_branch &&
-          env.GPG_KEY_SET == 'true'
-        with:
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          GPG_PRIVATE_KEY: ${{ secrets.SUPER_LINTER_GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.SUPER_LINTER_GPG_PASSPHRASE }}
-
       - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         name: Commit and push linting fixes
         if: >
@@ -103,11 +120,11 @@ jobs:
           github.event.pull_request != null &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           github.ref_name != github.event.repository.default_branch &&
-          env.GPG_KEY_SET == 'true'
+          env.APP_ID_SET == 'true'
         with:
           branch: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref }}
-          commit_message: "chore: fix linting issues\n\nSigned-off-by: ${{ steps.import-gpg.outputs.name }} <${{ steps.import-gpg.outputs.email }}>"
+          commit_message: "chore: fix linting issues\n\nSigned-off-by: ${{ steps.app-bot.outputs.name }} <${{ steps.app-bot.outputs.email }}>"
           commit_options: "--no-verify"
-          commit_user_name: ${{ steps.import-gpg.outputs.name }}
-          commit_user_email: ${{ steps.import-gpg.outputs.email }}
-          commit_author: "${{ steps.import-gpg.outputs.name }} <${{ steps.import-gpg.outputs.email }}>"
+          commit_user_name: ${{ steps.app-bot.outputs.name }}
+          commit_user_email: ${{ steps.app-bot.outputs.email }}
+          commit_author: "${{ steps.app-bot.outputs.name }} <${{ steps.app-bot.outputs.email }}>"

--- a/packages/cli/src/templates/workflows/release.yml
+++ b/packages/cli/src/templates/workflows/release.yml
@@ -117,6 +117,7 @@ jobs:
           # push the version-bump commit through branch protection. Falls back to
           # HOLOCRON_SYNC_TOKEN (legacy) then github.token for unprotected repos.
           GITHUB_TOKEN: ${{ secrets.HOLOCRON_RELEASE_TOKEN || secrets.HOLOCRON_SYNC_TOKEN || github.token }}
+          HUSKY: "0"
           NPM_CONFIG_PROVENANCE: true
 
       - name: Get release version


### PR DESCRIPTION
## Summary

- Sets \`HUSKY: \"0\"\` on the \`npx semantic-release\` step so \`@semantic-release/git\`'s release commit doesn't trigger the pre-commit hook (which runs \`gitleaks\`, not installed on GitHub Actions runners)
- Fixes \`holocron npm publish-initial\` next-steps output: packages and repo name were hardcoded to the \`holocron\` repo itself — running the command from any other monorepo (e.g. \`themes\`) showed entirely wrong Trusted Publisher guidance

## Details

### HUSKY=0

The pre-commit hook runs \`gitleaks\`, which exits 127 in CI. Setting \`HUSKY=0\` disables hooks for the semantic-release git commit while leaving them active for local developer commits.

### Dynamic package and repo discovery

\`publish-initial\` now:
- Reads \`packages/*/package.json\` at runtime to find non-private packages
- Calls \`git remote get-url origin\` and parses the repo slug from both HTTPS and SSH URL formats
- Both values are injectable (\`packages\`, \`repoName\` inputs) so tests remain fast and filesystem-free

## Test plan

- [ ] Release workflow completes past the \`Release\` step without \`husky - pre-commit script failed\`
- [ ] Running \`holocron npm publish-initial --dry-run\` from \`theholocron/themes\` shows \`@theholocron/docs-theme\` and \`Repo: themes\`
- [ ] 17 \`npm-publish-initial\` tests pass