### PR TITLE
fix(lint): pass app-slug via env to prevent code injection (CWE-78)

### DIFF
--- a/packages/cli/src/templates/workflows/lint.yml
+++ b/packages/cli/src/templates/workflows/lint.yml
@@ -56,14 +56,17 @@ jobs:
         # GitHub marks commits as Verified when the author email matches the
         # App bot's noreply address (<numeric-id>+<slug>[bot]@users.noreply.github.com).
         # The numeric ID must be fetched via the API — it differs from the App ID.
+        # app-slug is passed via env rather than interpolated into the script to
+        # prevent code injection (CWE-78).
         if: steps.app-token.conclusion == 'success'
         run: |
-          BOT_SLUG="${{ steps.app-token.outputs.app-slug }}[bot]"
+          BOT_SLUG="${APP_SLUG}[bot]"
           BOT_ID=$(gh api "/users/${BOT_SLUG}" --jq .id)
           echo "name=${BOT_SLUG}" >> "$GITHUB_OUTPUT"
           echo "email=${BOT_ID}+${BOT_SLUG}@users.noreply.github.com" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository


### PR DESCRIPTION
## Problem

CodeQL flagged `${{ steps.app-token.outputs.app-slug }}` being interpolated directly into the shell script body in the "Resolve App bot identity" step as a potential code injection (CWE-78). If the value ever contained shell metacharacters it could alter the script's behavior.

## Fix

Move `app-slug` into the step's `env` block as `APP_SLUG` and reference it as `${APP_SLUG}` in the script. The shell then receives it as a literal environment variable rather than having it spliced into the script text at expression-evaluation time.

## Test plan

- [ ] Merge and sync to `.github` — CodeQL alert on PR #73 should be resolved
- [ ] Confirm the lint auto-commit flow still works end-to-end