### PR TITLE
chore: add theholocron/themes to secondary sync repos

### DIFF
--- a/.github/workflows/sync-workflow-templates.yml
+++ b/.github/workflows/sync-workflow-templates.yml
@@ -21,6 +21,7 @@ jobs:
         theholocron/clients
         theholocron/configs
         theholocron/skills
+        theholocron/themes
         theholocron/utils
     secrets:
       HOLOCRON_SYNC_TOKEN: ${{ secrets.HOLOCRON_SYNC_TOKEN }}


### PR DESCRIPTION
Adds `theholocron/themes` to the `secondary-repos` list in `sync-workflow-templates.yml` so it receives reusable workflow updates on every sync.