### PR TITLE
fix: sort imports and add --provenance to pnpm publish

### DIFF
--- a/packages/cli/src/__tests__/npm-publish-initial.test.ts
+++ b/packages/cli/src/__tests__/npm-publish-initial.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("node:child_process", () => ({ spawnSync: vi.fn(() => ({ status: 0, stdout: "", stderr: "" })) }));

--- a/packages/cli/src/commands/npm-publish-initial.ts
+++ b/packages/cli/src/commands/npm-publish-initial.ts
@@ -24,9 +24,9 @@
  * setup` for the ephemeral GH admin PAT.
  */
 
+import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { spawnSync } from "node:child_process";
 
 export type PublishInitialPrint = (line: string) => void;
 

--- a/release.config.ts
+++ b/release.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
 	exec: {
 		prepareCmd: "node packages/cli/dist/cli.mjs npm bump-versions ${nextRelease.version}",
 		publishCmd:
-			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --tag ${nextRelease.channel || 'latest'}",
+			"pnpm -r --filter='./packages/*' publish --access public --no-git-checks --provenance --tag ${nextRelease.channel || 'latest'}",
 	},
 });


### PR DESCRIPTION
Two related fixes:

1. **Import sort** — `node:child_process` must come before `node:fs` in `npm-publish-initial.ts`; `node:` imports need a blank line separator from external imports in the test file.

2. **`--provenance` flag** — adds explicit `--provenance` to the `publishCmd` in `release.config.ts`. `NPM_CONFIG_PROVENANCE=true` in the workflow env is not reliably picked up by pnpm across all versions; the flag makes OIDC Trusted Publishing unambiguous regardless of pnpm version or `.npmrc` state.