### PR TITLE
fix: drop stale npm global cache and add persist-credentials: false

### DIFF
--- a/packages/cli/src/templates/workflows/release.yml
+++ b/packages/cli/src/templates/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
         name: Checkout repository
         with:
           fetch-depth: 0
+          persist-credentials: false
           # Use HOLOCRON_RELEASE_TOKEN when available — git push (tags, release commits)
           # uses the checkout credential, not GITHUB_TOKEN env var. The
           # built-in github.token cannot push through branch protection rulesets.
@@ -98,15 +99,7 @@ jobs:
           npm config set prefix ~/.npm-global
           echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
 
-      - name: Cache npm global packages
-        id: cache-npm-globals
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.npm-global
-          key: npm-globals-npm11-sigstore-${{ runner.os }}
-
       - name: Upgrade npm for OIDC support
-        if: steps.cache-npm-globals.outputs.cache-hit != 'true'
         run: npm install -g npm@11 sigstore
         # sigstore is required by libnpmpublish/provenance.js at module parse
         # time — before any config takes effect. Some npm 11.x builds stopped


### PR DESCRIPTION
## Summary

- Removes the `Cache npm global packages` step from the release template — the stale `npm-globals-npm11-sigstore-Linux` cache (populated under setup-node v4) was being restored unchanged after the v7 upgrade, carrying old auth config into `~/.npm-global` and shadowing OIDC Trusted Publishing.
- Drops the `if: steps.cache-npm-globals.outputs.cache-hit != 'true'` guard so `npm install -g npm@11 sigstore` always runs — it's fast enough (~10 s) that caching is not worth the failure mode.
- Adds `persist-credentials: false` to the checkout step so the runner token is not written to the workspace git config, closing the auth-leakage vector.

Mirrors the fix in theholocron/.github — this is the authoritative template change.

## Test plan

- [ ] Sync propagates correctly to theholocron/.github via `sync-workflow-templates`.
- [ ] Release workflow completes without provenance/auth failures.