### PR TITLE
fix: revert registry-url and NODE_AUTH_TOKEN — pnpm 10.15+ handles OIDC natively

### DIFF
--- a/packages/cli/src/templates/actions/setup-node.yml
+++ b/packages/cli/src/templates/actions/setup-node.yml
@@ -6,11 +6,6 @@ inputs:
     description: Node.js version
     required: false
     default: "22.x"
-  registry-url:
-    description: npm registry URL
-    required: false
-    default: "https://registry.npmjs.org/"
-
 runs:
   using: composite
 
@@ -25,7 +20,11 @@ runs:
         node-version: ${{ hashFiles('.node-version') != '' && '' || inputs.node-version }}
         node-version-file: ${{ hashFiles('.node-version') != '' && '.node-version' || '' }}
         cache: ${{ hashFiles('pnpm-lock.yaml') != '' && 'pnpm' || '' }}
-        registry-url: ${{ inputs.registry-url }}
+        # Do NOT add registry-url here. setup-node writes .npmrc with
+        # _authToken=${NODE_AUTH_TOKEN} and sets NPM_CONFIG_USERCONFIG to it.
+        # pnpm reads that file, fails env-var substitution when the token is
+        # empty, and loses auth entirely. Without registry-url, pnpm 10.15+
+        # handles Trusted Publishing via its own native OIDC exchange.
 
     - name: Add node_modules/.bin to PATH
       shell: bash

--- a/packages/cli/src/templates/workflows/release.yml
+++ b/packages/cli/src/templates/workflows/release.yml
@@ -120,9 +120,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.HOLOCRON_RELEASE_TOKEN || secrets.HOLOCRON_SYNC_TOKEN || github.token }}
           HUSKY: "0"
           NPM_CONFIG_PROVENANCE: true
-          # actions/setup-node writes a default NODE_AUTH_TOKEN=${{ github.token }}
-          # which shadows the OIDC Trusted Publishing exchange. Explicitly clear it.
-          NODE_AUTH_TOKEN: ""
 
       - name: Get release version
         id: release_version


### PR DESCRIPTION
## Summary

Reverts the `registry-url` input added to `setup-node` and the `NODE_AUTH_TOKEN: ""` env added to the release workflow. Both were wrong.

**What `registry-url` does when set**: `setup-node` writes a temp `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and sets `NPM_CONFIG_USERCONFIG` to point at it. Every subsequent pnpm command reads that file and tries to substitute `${NODE_AUTH_TOKEN}`. When the token is empty, pnpm warns `Failed to replace env in config: ${NODE_AUTH_TOKEN}` and has no auth configured → `ENEEDAUTH`.

**Why holocron's own release workflow never had this problem**: it intentionally omits `registry-url` from `setup-node` (see the comment in `.github/workflows/release.yml`). Without it, no `.npmrc` is written and pnpm 10.15+ handles Trusted Publishing via its own native OIDC token request using the `id-token: write` permission.

**Net change vs main**: only the cache drop and `persist-credentials: false` remain — both are still correct and stay.