### PR TITLE
fix: remove npm global prefix step — poisons ~/.npmrc and breaks pnpm OIDC

### DIFF
--- a/packages/cli/src/templates/workflows/release.yml
+++ b/packages/cli/src/templates/workflows/release.yml
@@ -94,11 +94,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.HOLOCRON_READ_TOKEN || secrets.GH_TOKEN || github.token }}
 
-      - name: Configure npm global prefix
-        run: |
-          npm config set prefix ~/.npm-global
-          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
-
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@11 sigstore
         # sigstore is required by libnpmpublish/provenance.js at module parse


### PR DESCRIPTION
## Summary

Removes the `Configure npm global prefix` step from the release workflow template.

## Root cause

Sync #71 introduced `npm config set prefix ~/.npm-global` to give npm a user-writable global install location. But this writes `prefix=/home/runner/.npm-global` to `~/.npmrc`. pnpm reads `~/.npmrc` for npm configuration — with a non-default prefix set there, pnpm's OIDC Trusted Publishing lookup breaks and it falls through to `ENEEDAUTH`.

The `theholocron/holocron` release workflow has never had this step and publishes successfully. Node.js from hostedtoolcache already provides a user-writable npm prefix on PATH — no prefix configuration needed.

Mirrors theholocron/.github PR #84.