### PR TITLE
chore: remove Synced timestamp from thin caller headers

### DIFF
--- a/packages/cli/src/commands/setup-workflows.ts
+++ b/packages/cli/src/commands/setup-workflows.ts
@@ -26,7 +26,6 @@ export function workflowHeader(source = "packages/cli/src/commands/setup-workflo
 	return [
 		`# AUTO-GENERATED — do not edit directly.`,
 		`# Source:  theholocron/holocron · ${source}`,
-		`# Synced:  ${new Date().toISOString()}`,
 		`# Tool:    holocron setup`,
 		`# Changes: run \`holocron setup\` to regenerate.`,
 		``,

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -121,7 +121,6 @@ function thinCallerHeader(forPrimary = false): string {
 	return [
 		doNotEdit,
 		`# Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts`,
-		`# Synced:  ${new Date().toISOString()}`,
 		`# Tool:    holocron sync-github`,
 		`# Changes: edit source in theholocron/holocron and push to alpha or main.`,
 		``,


### PR DESCRIPTION
## Summary

Removes the `# Synced: <timestamp>` line from thin caller workflow headers in consuming repos (themes, clients, utils, configs, etc.).

The timestamp in `.github`'s reusable workflow files is meaningful — those files contain the actual implementation and the timestamp reflects a substantive sync. But thin callers just delegate to `.github@main` and never change their logic. Every sync produced a PR that touched only the timestamp, forcing a merge with zero functional change.

`reusableHeader()` in `sync-github.ts` keeps its timestamp. `thinCallerHeader()` and `workflowHeader()` (used by `holocron setup`) no longer include it.