### PR TITLE
fix(setup): auto-install @theholocron/skills when missing

### DIFF
--- a/packages/cli/src/__tests__/skills.test.ts
+++ b/packages/cli/src/__tests__/skills.test.ts
@@ -73,7 +73,11 @@ describe("installSkills", () => {
 		await expect(installSkills({ agent: "claude", skills: ["git-safety"], repoRoot: tmpDir })).rejects.toThrow(
 			"failed to auto-install @theholocron/skills"
 		);
-		expect(spy).toHaveBeenCalledWith("pnpm", ["add", "-D", "@theholocron/skills"], expect.objectContaining({ cwd: tmpDir }));
+		expect(spy).toHaveBeenCalledWith(
+			"pnpm",
+			["add", "-D", "@theholocron/skills"],
+			expect.objectContaining({ cwd: tmpDir })
+		);
 	});
 
 	it("throws if pnpm add succeeds but package is still unresolvable", async () => {

--- a/packages/cli/src/__tests__/skills.test.ts
+++ b/packages/cli/src/__tests__/skills.test.ts
@@ -65,10 +65,21 @@ describe("installSkills", () => {
 		await expect(stat(join(tmpDir, ".agents"))).rejects.toThrow();
 	});
 
-	it("throws when @theholocron/skills is not installed (step becomes fail)", async () => {
-		// No node_modules in tmpDir
+	it("calls pnpm add when @theholocron/skills is missing and throws if install fails", async () => {
+		const { spawnSync } = await import("node:child_process");
+		const spy = spawnSync as ReturnType<typeof vi.fn>;
+		spy.mockReturnValueOnce({ status: 1 });
+
 		await expect(installSkills({ agent: "claude", skills: ["git-safety"], repoRoot: tmpDir })).rejects.toThrow(
-			"@theholocron/skills not found"
+			"failed to auto-install @theholocron/skills"
+		);
+		expect(spy).toHaveBeenCalledWith("pnpm", ["add", "-D", "@theholocron/skills"], expect.objectContaining({ cwd: tmpDir }));
+	});
+
+	it("throws if pnpm add succeeds but package is still unresolvable", async () => {
+		// spawnSync global mock returns { status: 0 } — install "succeeds" but nothing was written
+		await expect(installSkills({ agent: "claude", skills: ["git-safety"], repoRoot: tmpDir })).rejects.toThrow(
+			"failed to auto-install @theholocron/skills"
 		);
 	});
 
@@ -430,14 +441,14 @@ describe("runSkillsInstall", () => {
 		expect(lines.join("\n")).toContain("installed 1");
 	});
 
-	it("prints a graceful error message when @theholocron/skills is not installed", async () => {
-		// No node_modules/@theholocron/skills — installSkills will throw
+	it("prints a graceful error message when @theholocron/skills cannot be installed", async () => {
+		// spawnSync global mock returns { status: 0 } but package is still unresolvable
 		const lines: string[] = [];
 		const loaded = loadedFrom({ name: "test", providers: {}, agent: "claude", skills: ["git-safety"] });
 		await runSkillsInstall({ loaded, context: { repoRoot: tmpDir }, print: (l) => lines.push(l) });
 		const output = lines.join("\n");
 		expect(output).toContain("Installing");
-		expect(output).toContain("@theholocron/skills not found");
+		expect(output).toContain("failed to auto-install @theholocron/skills");
 		// Must not throw — error is caught and printed
 	});
 });

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -18,6 +18,7 @@
  * one central place.
  */
 
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { access, copyFile, mkdir, readdir, readFile, rm, stat, symlink, unlink, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -929,12 +930,24 @@ export async function installSkills({
 
 	// Locate @theholocron/skills relative to the consumer repo.
 	// Uses ./package.json subpath — must be declared in the package exports map.
+	// Auto-installs if not present rather than failing with a manual instruction.
 	const require = createRequire(pathToFileURL(join(repoRoot, "package.json")));
 	let skillsRoot: string;
 	try {
 		skillsRoot = dirname(require.resolve("@theholocron/skills/package.json"));
 	} catch {
-		throw new Error("@theholocron/skills not found — run: pnpm add -D @theholocron/skills");
+		const result = spawnSync("pnpm", ["add", "-D", "@theholocron/skills"], {
+			cwd: repoRoot,
+			stdio: "inherit",
+		});
+		if (result.status !== 0) {
+			throw new Error("failed to auto-install @theholocron/skills");
+		}
+		try {
+			skillsRoot = dirname(require.resolve("@theholocron/skills/package.json"));
+		} catch {
+			throw new Error("failed to auto-install @theholocron/skills");
+		}
 	}
 
 	// Find which skills from the previous run are no longer wanted (prune stale).


### PR DESCRIPTION
## Summary

- `holocron setup` now runs `pnpm add -D @theholocron/skills` automatically when the package isn't installed, instead of printing a manual instruction and failing
- If the install command fails (non-zero exit), throws `"failed to auto-install @theholocron/skills"`
- If install succeeds but the package is still unresolvable (e.g. registry outage, bad network), also throws `"failed to auto-install @theholocron/skills"`

## Test plan

- [ ] Updated existing "throws when not installed" test to cover the install-fails path (spawnSync returns status 1)
- [ ] Added test for install-succeeds-but-unresolvable path (spawnSync returns status 0, package still absent)
- [ ] Updated `runSkillsInstall` graceful-error test to match new error message
- [ ] All existing skills tests pass