### PR TITLE
feat(sync): sync homepage to package.json and GitHub repo website field

### DIFF
--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -885,7 +885,11 @@ describe("runSync", () => {
 		});
 
 		it("step reports ok even when package.json is absent and no syncHomepage provider", async () => {
-			const loaded = loadedFrom({ name: "demo", homepage: "https://example.com", providers: { source: "github" } });
+			const loaded = loadedFrom({
+				name: "demo",
+				homepage: "https://example.com",
+				providers: { source: "github" },
+			});
 			const loader = makeLoaderWith(loaded, {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 			});

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -842,7 +842,13 @@ describe("runSync", () => {
 			"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 		});
 
-		const report = await runSync({ loaded, context: { repoRoot: "/tmp/test" }, loader, steps: ["homepage"], print: () => {} });
+		const report = await runSync({
+			loaded,
+			context: { repoRoot: "/tmp/test" },
+			loader,
+			steps: ["homepage"],
+			print: () => {},
+		});
 
 		const step = report.steps.find((s) => s.step === "sync homepage");
 		expect(step?.status).toBe("skip");
@@ -859,8 +865,15 @@ describe("runSync", () => {
 		});
 
 		it("writes homepage to package.json#homepage", async () => {
-			await writeFile(join(tmpDir, "package.json"), JSON.stringify({ name: "demo", homepage: "" }, null, 2) + "\n");
-			const loaded = loadedFrom({ name: "demo", homepage: "https://example.com", providers: { source: "github" } });
+			await writeFile(
+				join(tmpDir, "package.json"),
+				JSON.stringify({ name: "demo", homepage: "" }, null, 2) + "\n"
+			);
+			const loaded = loadedFrom({
+				name: "demo",
+				homepage: "https://example.com",
+				providers: { source: "github" },
+			});
 			const loader = makeLoaderWith(loaded, {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
 			});
@@ -873,7 +886,11 @@ describe("runSync", () => {
 
 		it("calls source.syncHomepage when provider implements it", async () => {
 			let capturedUrl: string | null = null;
-			const loaded = loadedFrom({ name: "demo", homepage: "https://example.com", providers: { source: "github" } });
+			const loaded = loadedFrom({
+				name: "demo",
+				homepage: "https://example.com",
+				providers: { source: "github" },
+			});
 			const loader = makeLoaderWith(loaded, {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", {
 					source: {

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -884,6 +884,24 @@ describe("runSync", () => {
 			expect(pkg.homepage).toBe("https://example.com");
 		});
 
+		it("step reports ok even when package.json is absent and no syncHomepage provider", async () => {
+			const loaded = loadedFrom({ name: "demo", homepage: "https://example.com", providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+			});
+
+			const report = await runSync({
+				loaded,
+				context: { repoRoot: tmpDir },
+				loader,
+				steps: ["homepage"],
+				print: () => {},
+			});
+
+			const step = report.steps.find((s) => s.step === "sync homepage");
+			expect(step?.status).toBe("ok");
+		});
+
 		it("calls source.syncHomepage when provider implements it", async () => {
 			let capturedUrl: string | null = null;
 			const loaded = loadedFrom({

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -991,7 +991,11 @@ describe("runSync", () => {
 		try {
 			await writeFile(join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
 			let captured: Record<string, string> | null = null;
-			const loaded = loadedFrom({ name: "demo", repo: { name: "theholocron/demo" }, providers: { source: "github" } });
+			const loaded = loadedFrom({
+				name: "demo",
+				repo: { name: "theholocron/demo" },
+				providers: { source: "github" },
+			});
 			const loader = makeLoaderWith(loaded, {
 				"@theholocron/holocron-plugin-github": makePlugin("gh", {
 					source: {

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -986,6 +986,31 @@ describe("runSync", () => {
 		expect(step?.status).toBe("ok");
 	});
 
+	it("sets monorepo=true when pnpm-workspace.yaml exists in repoRoot", async () => {
+		const tmpDir = await mkdtemp(join(tmpdir(), "holocron-test-"));
+		try {
+			await writeFile(join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+			let captured: Record<string, string> | null = null;
+			const loaded = loadedFrom({ name: "demo", repo: { name: "theholocron/demo" }, providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", {
+					source: {
+						syncProperties: async (values: Record<string, string>) => {
+							captured = values;
+							return `${Object.keys(values).length} properties set`;
+						},
+					},
+				}),
+			});
+
+			await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["properties"], print: () => {} });
+
+			expect(captured!["monorepo"]).toBe("true");
+		} finally {
+			await rm(tmpDir, { recursive: true });
+		}
+	});
+
 	it("includes branch_protection_level when repo.protection is set", async () => {
 		let captured: Record<string, string> | null = null;
 		const loaded = loadedFrom({

--- a/packages/cli/src/__tests__/sync.test.ts
+++ b/packages/cli/src/__tests__/sync.test.ts
@@ -69,10 +69,10 @@ describe("runSync", () => {
 		const report = await runSync({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
 
 		expect(called).toEqual(["labels", "properties", "topics"]);
-		expect(report.steps).toHaveLength(6);
+		expect(report.steps).toHaveLength(7);
 		expect(report.steps.filter((s) => s.status === "ok")).toHaveLength(5);
 		expect(report.steps.find((s) => s.step === "sync teams")?.status).toBe("skip");
-		expect(report.summary).toMatchObject({ ok: 5, fail: 0, skip: 1 });
+		expect(report.summary).toMatchObject({ ok: 5, fail: 0, skip: 2 });
 	});
 
 	it("runs only the requested step when a single step filter is given", async () => {
@@ -833,6 +833,70 @@ describe("runSync", () => {
 
 			const step = report.steps.find((s) => s.step === "sync description");
 			expect(step?.status).toBe("ok");
+		});
+	});
+
+	it("skips sync homepage when no homepage is configured", async () => {
+		const loaded = loadedFrom({ name: "demo", providers: { source: "github" } });
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+		});
+
+		const report = await runSync({ loaded, context: { repoRoot: "/tmp/test" }, loader, steps: ["homepage"], print: () => {} });
+
+		const step = report.steps.find((s) => s.step === "sync homepage");
+		expect(step?.status).toBe("skip");
+		expect(step?.message).toBe("no homepage configured");
+	});
+
+	describe("sync homepage — file writes and GitHub sync", () => {
+		let tmpDir: string;
+		beforeEach(async () => {
+			tmpDir = await mkdtemp(join(tmpdir(), "holocron-test-"));
+		});
+		afterEach(async () => {
+			await rm(tmpDir, { recursive: true });
+		});
+
+		it("writes homepage to package.json#homepage", async () => {
+			await writeFile(join(tmpDir, "package.json"), JSON.stringify({ name: "demo", homepage: "" }, null, 2) + "\n");
+			const loaded = loadedFrom({ name: "demo", homepage: "https://example.com", providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+			});
+
+			await runSync({ loaded, context: { repoRoot: tmpDir }, loader, steps: ["homepage"], print: () => {} });
+
+			const pkg = JSON.parse(await readFile(join(tmpDir, "package.json"), "utf8")) as { homepage: string };
+			expect(pkg.homepage).toBe("https://example.com");
+		});
+
+		it("calls source.syncHomepage when provider implements it", async () => {
+			let capturedUrl: string | null = null;
+			const loaded = loadedFrom({ name: "demo", homepage: "https://example.com", providers: { source: "github" } });
+			const loader = makeLoaderWith(loaded, {
+				"@theholocron/holocron-plugin-github": makePlugin("gh", {
+					source: {
+						syncHomepage: async (url: string) => {
+							capturedUrl = url;
+							return "homepage updated";
+						},
+					},
+				}),
+			});
+
+			const report = await runSync({
+				loaded,
+				context: { repoRoot: tmpDir },
+				loader,
+				steps: ["homepage"],
+				print: () => {},
+			});
+
+			expect(capturedUrl).toBe("https://example.com");
+			const step = report.steps.find((s) => s.step === "sync homepage");
+			expect(step?.status).toBe("ok");
+			expect(step?.message).toContain("GitHub");
 		});
 	});
 

--- a/packages/cli/src/capabilities/index.ts
+++ b/packages/cli/src/capabilities/index.ts
@@ -203,6 +203,12 @@ export interface Source extends ProviderIdentity {
 	 * Optional — providers that don't support setting descriptions omit this.
 	 */
 	syncDescription?(description: string): Promise<string>;
+
+	/**
+	 * Set the repository homepage URL (the "Website" field on the repo landing page).
+	 * Optional — providers that don't support setting a homepage omit this.
+	 */
+	syncHomepage?(homepage: string): Promise<string>;
 }
 
 // ───────────────────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -8,11 +8,11 @@ import { PluginLoader, type RuntimeContext } from "../loader.js";
 import type { SetupPrintLine, SetupReport, SetupStepResult } from "./setup.js";
 import { CANONICAL_LABELS, STALE_LABELS } from "./setup.js";
 
-export const SYNC_STEPS = ["labels", "properties", "teams", "topics", "keywords", "description"] as const;
+export const SYNC_STEPS = ["labels", "properties", "teams", "topics", "keywords", "description", "homepage"] as const;
 export type SyncStep = (typeof SYNC_STEPS)[number];
 
 // Steps that write to the local filesystem only — no provider token needed.
-const LOCAL_STEPS = new Set<SyncStep>(["keywords", "description"]);
+const LOCAL_STEPS = new Set<SyncStep>(["keywords", "description", "homepage"]);
 
 export interface RunSyncInput {
 	loaded: LoadedConfig;
@@ -202,7 +202,7 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 	// optionally push to GitHub when source is loaded. They run outside
 	// the `if (loader.has("source"))` block so they work without a token.
 
-	for (const stepName of ["keywords", "description"] as const) {
+	for (const stepName of ["keywords", "description", "homepage"] as const) {
 		if (requestedSteps !== undefined && !requestedSteps.includes(stepName)) {
 			continue;
 		}
@@ -258,6 +258,38 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 						if (readmeWrote) parts.push("README.md");
 						if (source?.syncDescription) parts.push("GitHub");
 						return parts.length > 0 ? parts.join(", ") + " updated" : "description synced";
+					})
+				);
+				print(formatSyncStep(steps[steps.length - 1]!));
+			}
+		}
+
+		if (stepName === "homepage") {
+			const homepage = config.homepage;
+			if (!homepage) {
+				steps.push({
+					capability: "local",
+					step: "sync homepage",
+					status: "skip",
+					message: "no homepage configured",
+				});
+				print(formatSyncStep(steps[steps.length - 1]!));
+			} else {
+				const source = loader.has("source") ? (loader.get("source") as Source) : null;
+				steps.push(
+					await runSyncStep("local", "sync homepage", dryRun, async () => {
+						const pkgWrote = await writePackageJsonField(
+							input.context.repoRoot,
+							"homepage",
+							homepage
+						);
+						if (source?.syncHomepage) {
+							await source.syncHomepage(homepage);
+						}
+						const parts: string[] = [];
+						if (pkgWrote) parts.push("package.json");
+						if (source?.syncHomepage) parts.push("GitHub");
+						return parts.length > 0 ? parts.join(", ") + " updated" : "homepage synced";
 					})
 				);
 				print(formatSyncStep(steps[steps.length - 1]!));

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -278,11 +278,7 @@ export async function runSync(input: RunSyncInput): Promise<SetupReport> {
 				const source = loader.has("source") ? (loader.get("source") as Source) : null;
 				steps.push(
 					await runSyncStep("local", "sync homepage", dryRun, async () => {
-						const pkgWrote = await writePackageJsonField(
-							input.context.repoRoot,
-							"homepage",
-							homepage
-						);
+						const pkgWrote = await writePackageJsonField(input.context.repoRoot, "homepage", homepage);
 						if (source?.syncHomepage) {
 							await source.syncHomepage(homepage);
 						}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -111,6 +111,8 @@ export interface HolocronConfig {
 	/** Project name. Derived from package.json when absent. */
 	name?: string;
 	description?: string;
+	/** Project homepage URL. Synced to package.json#homepage and the GitHub repo's website field by `holocron sync`. */
+	homepage?: string;
 	/**
 	 * Repository identity and metadata. When set, `PluginLoader` injects
 	 * `repo.name` into every plugin's `RuntimeContext.repo` so plugins that
@@ -175,6 +177,7 @@ export type ResolvedProvidersConfig = Partial<Record<CapabilityKey, ResolvedProv
 export interface ResolvedHolocronConfig {
 	name: string;
 	description?: string;
+	homepage?: string;
 	repo?: RepoConfig;
 	workflows?: Array<string | { name: string; with?: Record<string, unknown> }>;
 	providers: ResolvedProvidersConfig;
@@ -296,6 +299,7 @@ export function resolveConfig(raw: HolocronConfig): ResolvedHolocronConfig {
 	return {
 		name: raw.name,
 		description: raw.description,
+		homepage: raw.homepage,
 		repo: raw.repo,
 		workflows: raw.workflows,
 		providers,

--- a/packages/holocron-plugin-github/src/__tests__/source.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/source.test.ts
@@ -86,6 +86,15 @@ describe("GitHubSource — REST methods", () => {
 		expect(result).toBe("description updated");
 	});
 
+	it("syncHomepage → PATCH /repos/{repo} with homepage", async () => {
+		const { source, calls } = makeSource([{ status: 200, body: {} }]);
+		const result = await source.syncHomepage("https://example.com");
+		expect(calls[0]?.method).toBe("PATCH");
+		expect(calls[0]?.url).toBe(`https://api.github.com/repos/${REPO}`);
+		expect(calls[0]?.body).toEqual({ homepage: "https://example.com" });
+		expect(result).toBe("homepage updated");
+	});
+
 	it("enableVulnerabilityAlerts → PUT /vulnerability-alerts", async () => {
 		const { source, calls } = makeSource([{ status: 204 }]);
 		await source.enableVulnerabilityAlerts();

--- a/packages/holocron-plugin-github/src/capabilities/source.ts
+++ b/packages/holocron-plugin-github/src/capabilities/source.ts
@@ -158,6 +158,11 @@ export class GitHubSource implements Source {
 		await this.client.repos.updateRepo(this.repo, { description });
 		return "description updated";
 	}
+
+	async syncHomepage(homepage: string): Promise<string> {
+		await this.client.repos.updateRepo(this.repo, { homepage });
+		return "homepage updated";
+	}
 }
 
 function isENOENT(err: unknown): boolean {


### PR DESCRIPTION
## Summary

- Adds `homepage` to `HolocronConfig` and `ResolvedHolocronConfig` — set it in `holocron.config.ts` alongside `description`
- `holocron sync homepage` (or `holocron sync` with no filter) writes the value to `package.json#homepage` and, when the GitHub source plugin is loaded, pushes it to the repo's **Website** field via `PATCH /repos/{owner}/{repo}`
- Follows the exact same pattern as the existing `description` step: local-only write when no source token is present, GitHub sync when it is
- `syncHomepage?` added to the `Source` capability interface; implemented in `holocron-plugin-github`

## Configuration

```ts
// holocron.config.ts
export default defineConfig({
  homepage: "https://theholocron.github.io/clients/",
  // ...
});
```

## Test plan

- [x] `pnpm --filter @theholocron/cli test` — 517 tests pass
- [x] `pnpm typecheck` — clean across all packages
- [x] Skip case: no homepage configured → status `skip`, message `"no homepage configured"`
- [x] Write case: homepage configured → `package.json#homepage` updated
- [x] GitHub case: `syncHomepage` called with the configured URL, message includes `"GitHub"`