### PR TITLE
ci: add deploy-docs reusable workflow template and use it

### DIFF
--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -11,7 +11,11 @@ export default defineConfig({
 		topics: ["automation", "cli", "developer-tools", "holocron", "nodejs", "typescript"],
 		...repo,
 	},
-	workflows: [...workflows, { name: "release", with: { "sentry-project": "holocron-cli" } }],
+	workflows: [
+		...workflows,
+		{ name: "release", with: { "sentry-project": "holocron-cli" } },
+		{ name: "deploy-docs", with: { name: "holocron" }, paths: ["packages/holocron-docs/**"] },
+	],
 	providers: {
 		...providers,
 		vault: ["doppler", { project: "holocron", config: "dev" }],

--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -656,4 +656,35 @@ describe("generateThinCallerContent", () => {
 		expect(content).not.toContain("issues:");
 		expect(content).toContain("secrets: inherit");
 	});
+
+	it("appends additionalPaths to the existing paths: block", () => {
+		const content = generateThinCallerContent("deploy-docs", undefined, ["packages/configs-docs/**"]);
+		expect(content).toContain("- docs/**");
+		expect(content).toContain("- packages/configs-docs/**");
+		const docsIdx = content.indexOf("- docs/**");
+		const pkgIdx = content.indexOf("- packages/configs-docs/**");
+		expect(docsIdx).toBeLessThan(pkgIdx);
+	});
+
+	it("appends multiple additionalPaths entries in order", () => {
+		const content = generateThinCallerContent("deploy-docs", undefined, [
+			"packages/configs-docs/**",
+			"packages/configs-theme/**",
+		]);
+		expect(content).toContain("- packages/configs-docs/**");
+		expect(content).toContain("- packages/configs-theme/**");
+	});
+
+	it("returns template unchanged when additionalPaths is empty", () => {
+		const base = generateThinCallerContent("deploy-docs");
+		const withEmpty = generateThinCallerContent("deploy-docs", undefined, []);
+		expect(withEmpty).toBe(base);
+	});
+
+	it("applies both additionalPaths and withOverrides together", () => {
+		const content = generateThinCallerContent("deploy-docs", { name: "configs" }, ["packages/configs-docs/**"]);
+		expect(content).toContain("- packages/configs-docs/**");
+		expect(content).toContain("name: configs");
+		expect(content).toContain("secrets: inherit");
+	});
 });

--- a/packages/cli/src/commands/setup-workflows.ts
+++ b/packages/cli/src/commands/setup-workflows.ts
@@ -78,17 +78,31 @@ export const WORKFLOW_CHECK_CONTEXTS: Partial<Record<string, string>> = {
  * If neither pattern matches the template, a warning is emitted and the
  * base template is returned unchanged.
  */
-export function generateThinCallerContent(name: string, withOverrides?: Record<string, unknown>): string {
+export function generateThinCallerContent(
+	name: string,
+	withOverrides?: Record<string, unknown>,
+	additionalPaths?: string[]
+): string {
 	const base = WORKFLOW_TEMPLATES[name];
 	if (!base) return "";
-	if (!withOverrides || Object.keys(withOverrides).length === 0) return base;
 
 	const fmt = (k: string, v: unknown) => `      ${k}: ${v === true ? "true" : v === false ? "false" : String(v)}`;
+
+	let result = base;
+
+	// Append extra push.paths entries after the existing paths: block.
+	if (additionalPaths && additionalPaths.length > 0) {
+		const pathsBlockRe = /( {4}paths:\n)((?:[ ]{6}- [^\n]+\n)+)/;
+		const newEntries = additionalPaths.map((p) => `      - ${p}\n`).join("");
+		result = result.replace(pathsBlockRe, (_, header, existing) => header + existing + newEntries);
+	}
+
+	if (!withOverrides || Object.keys(withOverrides).length === 0) return result;
 
 	// If the template already has a with: block, merge overrides into it.
 	// Existing keys are replaced; new keys are appended.
 	const withBlockRe = /( {4}with:\n)((?:[ ]{6}[^\n]+\n)*)/;
-	const existingMatch = base.match(withBlockRe);
+	const existingMatch = result.match(withBlockRe);
 	if (existingMatch) {
 		const existingEntries = new Map(
 			existingMatch[2]
@@ -104,16 +118,16 @@ export function generateThinCallerContent(name: string, withOverrides?: Record<s
 			existingEntries.set(k, v === true ? "true" : v === false ? "false" : String(v));
 		}
 		const merged = [...existingEntries.entries()].map(([k, v]) => `      ${k}: ${v}`).join("\n");
-		return base.replace(withBlockRe, `    with:\n${merged}\n`);
+		return result.replace(withBlockRe, `    with:\n${merged}\n`);
 	}
 
 	// No existing with: block — inject before `    secrets: inherit` at end.
 	const withBlock = Object.entries(withOverrides)
 		.map(([k, v]) => fmt(k, v))
 		.join("\n");
-	const result = base.replace(/ {4}secrets: inherit\n$/, `    with:\n${withBlock}\n    secrets: inherit\n`);
-	if (result === base) {
+	const injected = result.replace(/ {4}secrets: inherit\n$/, `    with:\n${withBlock}\n    secrets: inherit\n`);
+	if (injected === result) {
 		console.warn(`[generateThinCallerContent] could not inject with: overrides into "${name}" template`);
 	}
-	return result;
+	return injected;
 }

--- a/packages/cli/src/commands/setup-workflows.ts
+++ b/packages/cli/src/commands/setup-workflows.ts
@@ -12,6 +12,7 @@ import auditYml from "./workflows/audit.yml";
 import bookkeepingYml from "./workflows/bookkeeping.yml";
 import codeqlYml from "./workflows/codeql.yml";
 import dependenciesYml from "./workflows/dependencies.yml";
+import deployDocsYml from "./workflows/deploy-docs.yml";
 import greetingsYml from "./workflows/greetings.yml";
 import lintYml from "./workflows/lint.yml";
 import releaseYml from "./workflows/release.yml";
@@ -45,6 +46,7 @@ export const WORKFLOW_TEMPLATES: Record<string, string> = {
 	bookkeeping: bookkeepingYml,
 	audit: auditYml,
 	"sync-github": syncGithubYml,
+	"deploy-docs": deployDocsYml,
 };
 
 export const KNOWN_WORKFLOWS = new Set(Object.keys(WORKFLOW_TEMPLATES));

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -521,6 +521,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		for (const entry of workflows) {
 			const name = typeof entry === "string" ? entry : entry.name;
 			const withOverrides = typeof entry === "object" ? entry.with : undefined;
+			const additionalPaths = typeof entry === "object" ? entry.paths : undefined;
 			if (!KNOWN_WORKFLOWS.has(name)) {
 				steps.push({
 					capability: "source",
@@ -535,7 +536,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 				await runStep("source", `write workflow ${name}`, dryRun, async () => {
 					await source.writeWorkflowFile(
 						`${name}.yml`,
-						workflowHeader() + generateThinCallerContent(name, withOverrides)
+						workflowHeader() + generateThinCallerContent(name, withOverrides, additionalPaths)
 					);
 				})
 			);

--- a/packages/cli/src/commands/workflows/deploy-docs.yml
+++ b/packages/cli/src/commands/workflows/deploy-docs.yml
@@ -5,7 +5,6 @@ on: # yamllint disable-line rule:truthy
     branches: [main]
     paths:
       - docs/**
-      - packages/holocron-docs/**
   workflow_dispatch:
 
 concurrency:
@@ -21,6 +20,4 @@ jobs:
   deploy-docs:
     name: Deploy Docs
     uses: theholocron/.github/.github/workflows/deploy-docs.yml@main
-    with:
-      name: holocron
     secrets: inherit

--- a/packages/cli/src/commands/workflows/deploy-docs.yml.d.ts
+++ b/packages/cli/src/commands/workflows/deploy-docs.yml.d.ts
@@ -1,0 +1,2 @@
+declare const content: string;
+export default content;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -126,16 +126,21 @@ export interface HolocronConfig {
 	 * Use the object form to pass `with:` inputs to the reusable workflow.
 	 *
 	 * Supported values: "lint" | "test" | "typecheck" | "codeql" | "review" |
-	 *   "release" | "stale" | "greetings" | "dependencies" | "bookkeeping" | "audit"
+	 *   "release" | "stale" | "greetings" | "dependencies" | "bookkeeping" | "audit" |
+	 *   "deploy-docs"
 	 *
 	 * `holocron setup` writes `.github/workflows/<name>.yml` for each entry,
 	 * calling the corresponding `ci-<name>.yml@main` reusable workflow.
 	 * Files are overwritten on each run — they are generated artifacts.
 	 *
+	 * Use `paths` to append additional `on.push.paths` entries beyond the
+	 * template default (e.g. the repo-specific docs content package path).
+	 *
 	 * @example
 	 * ["lint", { "name": "release", "with": { "run-build": false } }]
+	 * { "name": "deploy-docs", "with": { "name": "configs" }, "paths": ["packages/configs-docs/**"] }
 	 */
-	workflows?: Array<string | { name: string; with?: Record<string, unknown> }>;
+	workflows?: Array<string | { name: string; with?: Record<string, unknown>; paths?: string[] }>;
 	providers: RawProvidersConfig;
 	apps?: AppConfig[];
 	doctor?: DoctorConfig;
@@ -179,7 +184,7 @@ export interface ResolvedHolocronConfig {
 	description?: string;
 	homepage?: string;
 	repo?: RepoConfig;
-	workflows?: Array<string | { name: string; with?: Record<string, unknown> }>;
+	workflows?: Array<string | { name: string; with?: Record<string, unknown>; paths?: string[] }>;
 	providers: ResolvedProvidersConfig;
 	apps: AppConfig[];
 	doctor: DoctorConfig;

--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -14,6 +14,7 @@ import auditWorkflow from "./workflows/audit.yml";
 import bookkeepingWorkflow from "./workflows/bookkeeping.yml";
 import codeqlWorkflow from "./workflows/codeql.yml";
 import dependenciesWorkflow from "./workflows/dependencies.yml";
+import deployDocsWorkflow from "./workflows/deploy-docs.yml";
 import greetingsWorkflow from "./workflows/greetings.yml";
 import lintWorkflow from "./workflows/lint.yml";
 import releaseWorkflow from "./workflows/release.yml";
@@ -34,6 +35,7 @@ export const REUSABLE_WORKFLOWS: Record<string, string> = {
 	bookkeeping: bookkeepingWorkflow,
 	codeql: codeqlWorkflow,
 	dependencies: dependenciesWorkflow,
+	"deploy-docs": deployDocsWorkflow,
 	greetings: greetingsWorkflow,
 	lint: lintWorkflow,
 	release: releaseWorkflow,

--- a/packages/cli/src/templates/workflows/deploy-docs.yml
+++ b/packages/cli/src/templates/workflows/deploy-docs.yml
@@ -1,0 +1,58 @@
+name: Deploy Docs
+
+on: # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      name:
+        description: Repo name prefix used to derive package names (<name>-docs, <name>-site)
+        required: true
+        type: string
+      use-turbo:
+        description: Build content packages with pnpm turbo build (default true)
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        name: Checkout repository
+
+      - uses: theholocron/.github/.github/actions/setup@main
+        name: Setup
+
+      - name: Build content packages
+        if: ${{ inputs.use-turbo }}
+        run: pnpm turbo build --filter=@theholocron/${{ inputs.name }}-docs
+
+      - name: Build content packages
+        if: ${{ !inputs.use-turbo }}
+        run: pnpm --filter @theholocron/${{ inputs.name }}-docs build
+
+      - name: Build docs site
+        run: pnpm --filter @theholocron/${{ inputs.name }}-site build
+
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        name: Upload pages artifact
+        with:
+          path: docs/dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        id: deployment
+        name: Deploy to GitHub Pages

--- a/packages/cli/src/templates/workflows/deploy-docs.yml
+++ b/packages/cli/src/templates/workflows/deploy-docs.yml
@@ -28,14 +28,20 @@ jobs:
 
       - name: Build content packages
         if: ${{ inputs.use-turbo }}
-        run: pnpm turbo build --filter=@theholocron/${{ inputs.name }}-docs
+        env:
+          DOCS_NAME: ${{ inputs.name }}
+        run: pnpm turbo build --filter=@theholocron/$DOCS_NAME-docs
 
       - name: Build content packages
         if: ${{ !inputs.use-turbo }}
-        run: pnpm --filter @theholocron/${{ inputs.name }}-docs build
+        env:
+          DOCS_NAME: ${{ inputs.name }}
+        run: pnpm --filter @theholocron/$DOCS_NAME-docs build
 
       - name: Build docs site
-        run: pnpm --filter @theholocron/${{ inputs.name }}-site build
+        env:
+          DOCS_NAME: ${{ inputs.name }}
+        run: pnpm --filter @theholocron/$DOCS_NAME-site build
 
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         name: Upload pages artifact

--- a/packages/cli/src/templates/workflows/deploy-docs.yml.d.ts
+++ b/packages/cli/src/templates/workflows/deploy-docs.yml.d.ts
@@ -1,0 +1,2 @@
+declare const content: string;
+export default content;


### PR DESCRIPTION
## Summary

- Adds `deploy-docs.yml` to the template registry (`REUSABLE_WORKFLOWS` in `templates/index.ts`) so `holocron sync-github` pushes it to `theholocron/.github`
- Adds a thin-caller template to `WORKFLOW_TEMPLATES` in `setup-workflows.ts` so `holocron setup` can generate it for new repos
- Converts `holocron`'s own `deploy-docs.yml` to the thin-caller pattern (`with: { name: holocron }`)

## Test plan

- [ ] `pnpm build` passes in `packages/cli`
- [ ] Existing tests pass
- [ ] After `theholocron/.github#87` merges, verify the thin caller triggers a successful Pages deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)