### PR TITLE
fix: double-quote DOCS_NAME env var to satisfy shellcheck SC2086

### DIFF
--- a/packages/cli/src/templates/workflows/deploy-docs.yml
+++ b/packages/cli/src/templates/workflows/deploy-docs.yml
@@ -30,18 +30,18 @@ jobs:
         if: ${{ inputs.use-turbo }}
         env:
           DOCS_NAME: ${{ inputs.name }}
-        run: pnpm turbo build --filter=@theholocron/$DOCS_NAME-docs
+        run: pnpm turbo build --filter=@theholocron/"$DOCS_NAME"-docs
 
       - name: Build content packages
         if: ${{ !inputs.use-turbo }}
         env:
           DOCS_NAME: ${{ inputs.name }}
-        run: pnpm --filter @theholocron/$DOCS_NAME-docs build
+        run: pnpm --filter @theholocron/"$DOCS_NAME"-docs build
 
       - name: Build docs site
         env:
           DOCS_NAME: ${{ inputs.name }}
-        run: pnpm --filter @theholocron/$DOCS_NAME-site build
+        run: pnpm --filter @theholocron/"$DOCS_NAME"-site build
 
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         name: Upload pages artifact


### PR DESCRIPTION
## Summary

- Wraps `$DOCS_NAME` in double quotes in all three `run:` steps of the `deploy-docs` reusable workflow template
- Fixes ShellCheck SC2086 (unquoted variable subject to word splitting / globbing) caught by `sync-github` validation

Follows up on #281.

## Test plan

- [ ] `holocron sync-github` dry-run produces no ShellCheck warnings for `deploy-docs.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)