### PR TITLE
refactor(docs): use createDocsCollections and defineConfig factories

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -1,39 +1,8 @@
-import { relative } from "node:path";
-import { fileURLToPath } from "node:url";
-
-import starlight from "@astrojs/starlight";
+import { defineConfig } from "@theholocron/astro-config";
 import holocronConfig from "@theholocron/holocron-docs";
-import { docsTheme } from "@theholocron/docs-theme";
-import { defineConfig } from "astro/config";
-
-// Starlight autogenerate matches filePaths relative to the Astro project root.
-// Our content lives outside docs/ so we compute the relative path so the
-// directory: value matches how the loader stores filePaths.
-const docsDir = fileURLToPath(new URL(".", import.meta.url));
-const contentDir = fileURLToPath(new URL("../packages/holocron-docs/content", import.meta.url));
-const contentRelDir = relative(docsDir, contentDir);
 
 export default defineConfig({
-	site: "https://theholocron.github.io",
-	base: "/holocron",
-	integrations: [
-		starlight({
-			title: holocronConfig.name,
-			plugins: [docsTheme()],
-			social: [
-				{
-					icon: "github",
-					label: "GitHub",
-					href: "https://github.com/theholocron/holocron",
-				},
-			],
-			sidebar: [
-				{ label: "Overview", slug: "" },
-				{
-					label: "Reference",
-					items: [{ autogenerate: { directory: contentRelDir } }],
-				},
-			],
-		}),
-	],
+	docs: holocronConfig,
+	importMetaUrl: import.meta.url,
+	sidebarLabel: "Reference",
 });

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -1,8 +1,12 @@
+import starlight from "@astrojs/starlight";
+import { docsTheme } from "@theholocron/docs-theme";
 import { defineConfig } from "@theholocron/astro-config";
 import holocronConfig from "@theholocron/holocron-docs";
 
 export default defineConfig({
 	docs: holocronConfig,
 	importMetaUrl: import.meta.url,
+	starlight,
+	docsTheme,
 	sidebarLabel: "Reference",
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.5",
-    "@theholocron/docs-theme": "^1.1.0",
+    "@theholocron/astro-config": "^7.8.0",
+    "@theholocron/docs-theme": "^1.3.0",
     "@theholocron/holocron-docs": "workspace:*",
     "astro": "^7.1.5"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@astrojs/starlight": "^0.41.5",
     "@theholocron/astro-config": "^7.8.0",
-    "@theholocron/docs-theme": "^1.2.2",
+    "@theholocron/docs-theme": "^1.3.0",
     "@theholocron/holocron-docs": "workspace:*",
     "astro": "^7.1.5"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.41.5",
-    "@theholocron/astro-config": "^7.8.0",
+    "@theholocron/astro-config": "^7.8.1",
     "@theholocron/docs-theme": "^1.3.0",
     "@theholocron/holocron-docs": "workspace:*",
     "astro": "^7.1.5"

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@astrojs/starlight": "^0.41.5",
     "@theholocron/astro-config": "^7.8.0",
-    "@theholocron/docs-theme": "^1.3.0",
+    "@theholocron/docs-theme": "^1.2.2",
     "@theholocron/holocron-docs": "workspace:*",
     "astro": "^7.1.5"
   },

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,4 +1,26 @@
-import { createDocsCollections } from "@theholocron/docs-theme/content";
-import holocronConfig from "@theholocron/holocron-docs";
+import { fileURLToPath } from "node:url";
 
-export const collections = createDocsCollections(holocronConfig, import.meta.url);
+import { docsSchema } from "@astrojs/starlight/schema";
+import holocronConfig from "@theholocron/holocron-docs";
+import { createDocsLoader } from "@theholocron/docs-theme/loader";
+import { defineCollection } from "astro:content";
+
+const REPO_SLUG = holocronConfig.slug;
+
+function localSlug(configSlug: string): string {
+	if (configSlug === REPO_SLUG) return "";
+	if (configSlug.startsWith(`${REPO_SLUG}/`)) return configSlug.slice(REPO_SLUG.length + 1);
+	return configSlug;
+}
+
+export const collections = {
+	docs: defineCollection({
+		loader: createDocsLoader([
+			{
+				dir: fileURLToPath(new URL("../../packages/holocron-docs/content", import.meta.url)),
+				slug: localSlug(holocronConfig.slug),
+			},
+		]),
+		schema: docsSchema(),
+	}),
+};

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,26 +1,4 @@
-import { fileURLToPath } from "node:url";
-
-import { docsSchema } from "@astrojs/starlight/schema";
+import { createDocsCollections } from "@theholocron/docs-theme/content";
 import holocronConfig from "@theholocron/holocron-docs";
-import { createDocsLoader } from "@theholocron/docs-theme/loader";
-import { defineCollection } from "astro:content";
 
-const REPO_SLUG = holocronConfig.slug;
-
-function localSlug(configSlug: string): string {
-	if (configSlug === REPO_SLUG) return "";
-	if (configSlug.startsWith(`${REPO_SLUG}/`)) return configSlug.slice(REPO_SLUG.length + 1);
-	return configSlug;
-}
-
-export const collections = {
-	docs: defineCollection({
-		loader: createDocsLoader([
-			{
-				dir: fileURLToPath(new URL("../../packages/holocron-docs/content", import.meta.url)),
-				slug: localSlug(holocronConfig.slug),
-			},
-		]),
-		schema: docsSchema(),
-	}),
-};
+export const collections = createDocsCollections(holocronConfig, import.meta.url);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,8 +234,8 @@ importers:
         specifier: ^0.41.5
         version: 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)
       '@theholocron/astro-config':
-        specifier: ^7.8.0
-        version: 7.8.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0)))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^7.8.1
+        version: 7.8.1(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))
       '@theholocron/docs-theme':
         specifier: ^1.3.0
         version: 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))
@@ -2330,12 +2330,10 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@theholocron/astro-config@7.8.0':
-    resolution: {integrity: sha512-5fKu7x31YhPCODxbw2fOT6/wdCjiUmbOr1HXxzQlneW4dmhycgz3vOZbgPqQrDN4q/0gunmVkbHKO8hhthhyzg==}
+  '@theholocron/astro-config@7.8.1':
+    resolution: {integrity: sha512-ML8EESizp2X7uTnw2y2Xg+rtgm7GLnrFIPfVPXc3ZK2AtNmwSwNtycKJleKefy4Vwn+iUdZgjK1bbZuPV8j0eA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@astrojs/starlight': '>=0.30.0'
-      '@theholocron/docs-theme': '>=1.2.2'
       astro: '>=5.0.0'
 
   '@theholocron/clerk-client@1.3.5':
@@ -7795,10 +7793,8 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@theholocron/astro-config@7.8.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0)))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))':
+  '@theholocron/astro-config@7.8.1(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@astrojs/starlight': 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)
-      '@theholocron/docs-theme': 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))
       astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0)
 
   '@theholocron/clerk-client@1.3.5(vitest@4.1.10)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,9 +233,12 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.41.5
         version: 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)
+      '@theholocron/astro-config':
+        specifier: ^7.8.0
+        version: 7.8.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0)))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))
       '@theholocron/docs-theme':
-        specifier: ^1.1.0
-        version: 1.1.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^1.3.0
+        version: 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))
       '@theholocron/holocron-docs':
         specifier: workspace:*
         version: link:../packages/holocron-docs
@@ -2327,6 +2330,14 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@theholocron/astro-config@7.8.0':
+    resolution: {integrity: sha512-5fKu7x31YhPCODxbw2fOT6/wdCjiUmbOr1HXxzQlneW4dmhycgz3vOZbgPqQrDN4q/0gunmVkbHKO8hhthhyzg==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@astrojs/starlight': '>=0.30.0'
+      '@theholocron/docs-theme': '>=1.2.2'
+      astro: '>=5.0.0'
+
   '@theholocron/clerk-client@1.3.5':
     resolution: {integrity: sha512-Z0LeLYPKM0Ac7SJ4A8hm+4At3hcS1U419l/CUDUyQcxlQzNU+0VFMAMMUG4MiqYdGQW6U9mJCd4S/AqrHOHPNg==}
     engines: {node: '>=22.0.0'}
@@ -2338,8 +2349,8 @@ packages:
       '@commitlint/cli': ^21
       '@commitlint/config-conventional': ^21
 
-  '@theholocron/docs-theme@1.1.0':
-    resolution: {integrity: sha512-UI9NvBg5L5v3HRQ6kVmT4Pjy8SQ2Du+8b1AslERF/fTtngxapl68NEPCcBc+YwVsg8xB87I6t3UMTdDaqAiAzQ==}
+  '@theholocron/docs-theme@1.3.0':
+    resolution: {integrity: sha512-F6+j8kPySJ01cxmRlRxY/zaPaP106LsmehMQnDUHWTYfVaIWm9GfVp6xa2Jaix2tESujIXUSMhTyLRo1Z9bqGA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@astrojs/starlight': '>=0.30.0'
@@ -7784,6 +7795,12 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@theholocron/astro-config@7.8.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0)))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@astrojs/starlight': 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)
+      '@theholocron/docs-theme': 1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))
+      astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0)
+
   '@theholocron/clerk-client@1.3.5(vitest@4.1.10)':
     dependencies:
       '@theholocron/http-client': 1.3.5(vitest@4.1.10)
@@ -7795,7 +7812,7 @@ snapshots:
       '@commitlint/cli': 19.8.1(@types/node@26.1.2)(typescript@5.9.3)
       '@commitlint/config-conventional': 19.8.1
 
-  '@theholocron/docs-theme@1.1.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))':
+  '@theholocron/docs-theme@1.3.0(@astrojs/starlight@0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3))(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@astrojs/starlight': 0.41.5(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0))(typescript@5.9.3)
       astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(jiti@2.7.0)(rollup@4.62.3)(tsx@4.22.4)(yaml@2.9.0)


### PR DESCRIPTION
## Summary

- Replaces \`astro.config.ts\` boilerplate with \`defineConfig\` from \`@theholocron/astro-config\`
- Replaces \`content.config.ts\` boilerplate with \`createDocsCollections\` from \`@theholocron/docs-theme/content\`
- Removes direct \`gray-matter\` dependency (now internal to docs-theme)
- Bumps \`@theholocron/docs-theme\` to \`^1.3.0\` (required for the \`/content\` export)

## Note

CI will go green once [theholocron/themes#26](https://github.com/theholocron/themes/pull/26) merges and \`@theholocron/docs-theme@1.3.0\` publishes.

## Test plan

- [ ] \`astro build\` succeeds
- [ ] Docs site renders correctly