### PR TITLE
docs: 📝 replace npm i -g with pnpm add -g in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A pluggable, capability-based CLI for spinning up and operating software project
 <!-- prettier-ignore -->
 ```bash
 # 1. Install the CLI + the source plugin and a vault plugin
-npm  i -g @theholocron/cli@alpha
+pnpm add -g @theholocron/cli@alpha
 pnpm add -D @theholocron/holocron-plugin-github@alpha
 
 # Vault — pick one: 1password, doppler, or infisical

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,7 +9,7 @@ spinning up and operating software projects.
 
 <!-- prettier-ignore -->
 ```bash
-npm i -g @theholocron/cli@alpha
+pnpm add -g @theholocron/cli@alpha
 holocron --help
 
 ```


### PR DESCRIPTION
Replaces `npm  i -g` with `pnpm add -g` in the root README and `packages/cli/README.md`.