### PR TITLE
fix: 🐛 add mdx to editorconfig template and exclude from checker

### DIFF
--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -64,7 +64,7 @@ function editorconfigContent(): string {
 		`indent_style = space`,
 		`indent_size = 2`,
 		``,
-		`[*.md]`,
+		`[*.{md,mdx}]`,
 		`trim_trailing_whitespace = false`,
 		`indent_style = space`,
 		`indent_size = 2`,
@@ -182,7 +182,7 @@ const EDITORCONFIG_CHECKER_CONFIG =
 			IgnoreDefaults: false,
 			SpacesAfterTabs: false,
 			NoColor: false,
-			Exclude: ["(^|.+/)LICENSE$", "^public/.*"],
+			Exclude: ["(^|.+/)LICENSE$", "^public/.*", "\\.mdx$"],
 			AllowedContentTypes: [],
 			PassedFiles: [],
 			Disable: {


### PR DESCRIPTION
## Summary

Two changes to the generated `.editorconfig` and `.editorconfig-checker.json` templates:

- `[*.md]` → `[*.{md,mdx}]` so MDX files pick up the space-indent rule alongside Markdown (they're the same language)
- Add `\\.mdx$` to the editorconfig-checker exclusion list

**Why the exclusion is needed:** MDX files mix tab-indented JSX component children (formatted by prettier's `useTabs: true` config) with space-indented Markdown list content (formatted by prettier's markdown semantic rules) in the same file. The editorconfig-checker can't validate these files without false positives regardless of which indent style is declared. prettier is the authority on MDX formatting consistency.

Discovered while fixing lint failures on `theholocron/theholocron.github.io` PR #107.