### PR TITLE
feat: ✨ add docs.pages config and GitHub Pages setup step

### DIFF
--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -119,4 +119,51 @@ describe("resolveConfig", () => {
 		expect(resolved.apps).toEqual([]);
 		expect(resolved.doctor).toEqual({});
 	});
+
+	it("docs is undefined when not set", () => {
+		expect(resolveConfig(minimal).docs).toBeUndefined();
+	});
+
+	it("throws when docs is set but build is absent", () => {
+		expect(() => resolveConfig({ ...minimal, docs: {} })).toThrow(ConfigError);
+		expect(() => resolveConfig({ ...minimal, docs: {} })).toThrow("`docs.build` is required");
+	});
+
+	it("resolves docs: { build: 'workflow' }", () => {
+		const resolved = resolveConfig({ ...minimal, docs: { build: "workflow" } });
+		expect(resolved.docs).toEqual({ build: "workflow" });
+	});
+
+	it("resolves docs with all fields", () => {
+		const resolved = resolveConfig({
+			...minimal,
+			docs: { build: "workflow", domain: "docs.theholocron.dev", https: true },
+		});
+		expect(resolved.docs).toEqual({
+			build: "workflow",
+			domain: "docs.theholocron.dev",
+			https: true,
+		});
+	});
+
+	it("derives homepage from docs.domain when homepage is not explicitly set", () => {
+		const resolved = resolveConfig({
+			...minimal,
+			docs: { build: "workflow", domain: "docs.theholocron.dev" },
+		});
+		expect(resolved.homepage).toBe("https://docs.theholocron.dev/");
+	});
+
+	it("explicit homepage takes precedence over docs.domain derivation", () => {
+		const resolved = resolveConfig({
+			...minimal,
+			homepage: "https://theholocron.dev/",
+			docs: { build: "workflow", domain: "docs.theholocron.dev" },
+		});
+		expect(resolved.homepage).toBe("https://theholocron.dev/");
+	});
+
+	it("homepage is undefined when neither homepage nor docs.domain is set", () => {
+		expect(resolveConfig(minimal).homepage).toBeUndefined();
+	});
 });

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -2182,7 +2182,9 @@ describe("setup: Pages step", () => {
 		const called: unknown[] = [];
 		const { loaded, loader } = makePagedLoader(
 			{ build: "workflow", domain: "docs.theholocron.dev", https: true },
-			async (...args) => { called.push(args); }
+			async (...args) => {
+				called.push(args);
+			}
 		);
 
 		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
@@ -2200,10 +2202,7 @@ describe("setup: Pages step", () => {
 
 	it("includes 'https: enforced' in the result message when https is true", async () => {
 		process.env.HOLOCRON_DEPLOY_TOKEN = "deploy-pat";
-		const { loaded, loader } = makePagedLoader(
-			{ build: "workflow", https: true },
-			async () => {}
-		);
+		const { loaded, loader } = makePagedLoader({ build: "workflow", https: true }, async () => {});
 
 		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
 
@@ -2213,10 +2212,9 @@ describe("setup: Pages step", () => {
 
 	it("records a skip step when HOLOCRON_DEPLOY_TOKEN is absent", async () => {
 		const called: unknown[] = [];
-		const { loaded, loader } = makePagedLoader(
-			{ build: "workflow" },
-			async (...args) => { called.push(args); }
-		);
+		const { loaded, loader } = makePagedLoader({ build: "workflow" }, async (...args) => {
+			called.push(args);
+		});
 
 		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
 

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -2154,3 +2154,90 @@ describe("setup: skills step", () => {
 		expect(step?.message).toBe("vault unreachable");
 	});
 });
+
+// ── setup: Pages step ─────────────────────────────────────────────────────────
+
+describe("setup: Pages step", () => {
+	const PAGES_STEP = "configure GitHub Pages";
+
+	afterEach(() => {
+		delete process.env.HOLOCRON_DEPLOY_TOKEN;
+	});
+
+	function makePagedLoader(docs: Parameters<typeof resolveConfig>[0]["docs"], configurePages?: () => Promise<void>) {
+		const loaded: LoadedConfig = {
+			resolved: resolveConfig({ name: "demo", providers: { source: "github" }, docs }),
+			filepath: "/tmp/test/holocron.config.json",
+		};
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: { ...(configurePages ? { configurePages } : {}) },
+			}),
+		});
+		return { loaded, loader };
+	}
+
+	it("calls configurePages and records ok when HOLOCRON_DEPLOY_TOKEN is set", async () => {
+		process.env.HOLOCRON_DEPLOY_TOKEN = "deploy-pat-xyz";
+		const called: unknown[] = [];
+		const { loaded, loader } = makePagedLoader(
+			{ build: "workflow", domain: "docs.theholocron.dev", https: true },
+			async (...args) => { called.push(args); }
+		);
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(called).toHaveLength(1);
+		expect(called[0]).toEqual([
+			{ build: "workflow", domain: "docs.theholocron.dev", https: true },
+			"deploy-pat-xyz",
+		]);
+		const step = report.steps.find((s) => s.step === PAGES_STEP);
+		expect(step?.status).toBe("ok");
+		expect(step?.message).toContain("workflow");
+		expect(step?.message).toContain("docs.theholocron.dev");
+	});
+
+	it("includes 'https: enforced' in the result message when https is true", async () => {
+		process.env.HOLOCRON_DEPLOY_TOKEN = "deploy-pat";
+		const { loaded, loader } = makePagedLoader(
+			{ build: "workflow", https: true },
+			async () => {}
+		);
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		const step = report.steps.find((s) => s.step === PAGES_STEP);
+		expect(step?.message).toContain("https: enforced");
+	});
+
+	it("records a skip step when HOLOCRON_DEPLOY_TOKEN is absent", async () => {
+		const called: unknown[] = [];
+		const { loaded, loader } = makePagedLoader(
+			{ build: "workflow" },
+			async (...args) => { called.push(args); }
+		);
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(called).toHaveLength(0);
+		const step = report.steps.find((s) => s.step === PAGES_STEP);
+		expect(step?.status).toBe("skip");
+		expect(step?.message).toContain("HOLOCRON_DEPLOY_TOKEN");
+	});
+
+	it("does not add a Pages step when docs is absent from config", async () => {
+		process.env.HOLOCRON_DEPLOY_TOKEN = "deploy-pat";
+		const loaded: LoadedConfig = {
+			resolved: resolveConfig({ name: "demo", providers: { source: "github" } }),
+			filepath: "/tmp/test/holocron.config.json",
+		};
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", { source: {} }),
+		});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(report.steps.find((s) => s.step === PAGES_STEP)).toBeUndefined();
+	});
+});

--- a/packages/cli/src/capabilities/index.ts
+++ b/packages/cli/src/capabilities/index.ts
@@ -209,6 +209,32 @@ export interface Source extends ProviderIdentity {
 	 * Optional — providers that don't support setting a homepage omit this.
 	 */
 	syncHomepage?(homepage: string): Promise<string>;
+
+	/**
+	 * Enable or update GitHub Pages for the repository.
+	 * Idempotent: POST to create, PUT to update existing settings.
+	 * Requires HOLOCRON_DEPLOY_TOKEN (pages:write + repo scope) — passed
+	 * explicitly because it is a different PAT from the main admin token.
+	 * Optional — providers without a Pages concept omit this.
+	 */
+	configurePages?(config: PagesConfig, token: string): Promise<void>;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Pages
+// ───────────────────────────────────────────────────────────────────────
+
+export interface PagesConfig {
+	/** GitHub Pages build source. */
+	build: "workflow" | "branch";
+	/**
+	 * Custom domain / CNAME (e.g. "docs.theholocron.dev").
+	 * When set and `homepage` is absent in holocron.config, setup derives
+	 * homepage as `https://{domain}/`.
+	 */
+	domain?: string;
+	/** Enforce HTTPS. Only effective once the custom domain is DNS-verified. */
+	https?: boolean;
 }
 
 // ───────────────────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -703,6 +703,33 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		}
 	}
 
+	// ── docs: configure GitHub Pages ────────────────────────────────────
+	if (loader.has("source") && config.docs) {
+		const source = loader.get("source") as Source;
+		const deployToken = process.env.HOLOCRON_DEPLOY_TOKEN;
+		print(style.step("docs"));
+		if (!deployToken) {
+			steps.push({
+				capability: "source",
+				step: "configure GitHub Pages",
+				status: "skip",
+				message: "HOLOCRON_DEPLOY_TOKEN not set — skipping Pages setup",
+			});
+			print(formatStep(steps[steps.length - 1]!));
+		} else if (source.configurePages) {
+			steps.push(
+				await runStep("source", "configure GitHub Pages", dryRun, async () => {
+					await source.configurePages!(config.docs!, deployToken);
+					const parts: string[] = [config.docs!.build];
+					if (config.docs!.domain) parts.push(`domain: ${config.docs!.domain}`);
+					if (config.docs!.https) parts.push("https: enforced");
+					return parts.join(", ");
+				})
+			);
+			print(formatStep(steps[steps.length - 1]!));
+		}
+	}
+
 	// ── deployment: ensure project ──────────────────────────────────────
 	if (loader.has("deployment")) {
 		const deploy = loader.get("deployment") as Deployment;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -27,6 +27,7 @@
 import {
 	type CapabilityKey,
 	CARDINALITY,
+	type PagesConfig,
 	REQUIRED_CAPABILITIES,
 	type TeamEntry,
 	type TeamPermission,
@@ -66,7 +67,30 @@ export type RawProvidersConfig = Partial<Record<CapabilityKey, RawProviderEntry>
 
 export type RepoProtection = "balanced" | "strict" | "none";
 
-export type { TeamEntry, TeamPermission };
+export type { PagesConfig, TeamEntry, TeamPermission };
+
+/**
+ * Raw `docs` config as written by the user. `build` is optional so the
+ * field can be declared without committing to a build type yet; setup
+ * will error if `docs` is present but `build` is absent.
+ */
+export interface DocsConfig {
+	/**
+	 * GitHub Pages build source.
+	 * "workflow" → GitHub Actions  (PUT { build_type: "workflow" })
+	 * "branch"   → classic gh-pages branch (PUT { build_type: "legacy", source: { branch: "gh-pages", path: "/" } })
+	 * When absent, Pages is not managed by `holocron setup`.
+	 */
+	build?: "workflow" | "branch";
+	/**
+	 * Custom domain / CNAME (e.g. "docs.theholocron.dev").
+	 * When set and `homepage` is not explicitly provided, setup derives
+	 * `homepage` as `https://{domain}/` for package.json and the repo website field.
+	 */
+	domain?: string;
+	/** Enforce HTTPS. Only effective once the custom domain is DNS-verified. */
+	https?: boolean;
+}
 
 export interface RepoProperties {
 	lifecycle?: "active" | "experimental" | "deprecated";
@@ -160,6 +184,15 @@ export interface HolocronConfig {
 	 * ["git-safety", "pr-workflow", "commit-standards"]
 	 */
 	skills?: string[];
+	/**
+	 * GitHub Pages configuration. When present, `holocron setup` calls the
+	 * Pages API using `HOLOCRON_DEPLOY_TOKEN` (requires `pages:write` + `repo` scope).
+	 * When absent, Pages is left as-is.
+	 *
+	 * @example
+	 * { build: "workflow", domain: "docs.theholocron.dev", https: true }
+	 */
+	docs?: DocsConfig;
 }
 
 // ───────────────────────────────────────────────────────────────────────
@@ -190,6 +223,8 @@ export interface ResolvedHolocronConfig {
 	doctor: DoctorConfig;
 	agent?: "claude" | "codex" | "gemini";
 	skills?: string[];
+	/** Resolved Pages config. `build` is guaranteed present when this field exists. */
+	docs?: PagesConfig;
 }
 
 // ───────────────────────────────────────────────────────────────────────
@@ -301,10 +336,22 @@ export function resolveConfig(raw: HolocronConfig): ResolvedHolocronConfig {
 		}
 	}
 
+	// Validate docs and narrow build to required
+	let docs: PagesConfig | undefined;
+	if (raw.docs !== undefined) {
+		if (!raw.docs.build) {
+			throw new ConfigError("`docs.build` is required when `docs` is set");
+		}
+		docs = raw.docs as PagesConfig;
+	}
+
+	// Derive homepage from docs.domain when not explicitly set
+	const homepage = raw.homepage ?? (docs?.domain ? `https://${docs.domain}/` : undefined);
+
 	return {
 		name: raw.name,
 		description: raw.description,
-		homepage: raw.homepage,
+		homepage,
 		repo: raw.repo,
 		workflows: raw.workflows,
 		providers,
@@ -312,5 +359,6 @@ export function resolveConfig(raw: HolocronConfig): ResolvedHolocronConfig {
 		doctor: raw.doctor ?? {},
 		agent: raw.agent,
 		skills: raw.skills,
+		docs,
 	};
 }

--- a/packages/holocron-plugin-github/src/__tests__/source.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/source.test.ts
@@ -182,6 +182,99 @@ describe("GitHubSource — REST methods", () => {
 	});
 });
 
+describe("GitHubSource — configurePages", () => {
+	const PAGES_URL = `https://api.github.com/repos/${REPO}/pages`;
+
+	// configurePages creates its own pagesClient using this.fetchImpl.
+	// Pass the same stub fetch to SourceOptions so all calls are intercepted.
+	function makeSourceForPages(responses: Parameters<typeof stubFetch>[0]) {
+		const { fetch, calls } = stubFetch(responses);
+		const rest = createGitHubClient({ token: "admin-pat", fetch });
+		const source = new GitHubSource(rest, { repo: REPO, repoRoot: process.cwd(), fetch });
+		return { source, calls };
+	}
+
+	it("POST then PUT when Pages is not yet enabled", async () => {
+		const { source, calls } = makeSourceForPages([
+			{ status: 404, body: { message: "Not Found" } },
+			{ status: 201, body: { build_type: "workflow", status: "building", https_enforced: false, custom_domain: null } },
+			{ status: 204 },
+		]);
+		await source.configurePages!({ build: "workflow" }, "deploy-pat");
+		expect(calls[0]?.url).toBe(PAGES_URL);
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[1]?.url).toBe(PAGES_URL);
+		expect(calls[1]?.method).toBe("POST");
+		expect(calls[1]?.body).toMatchObject({ build_type: "workflow" });
+		expect(calls[2]?.url).toBe(PAGES_URL);
+		expect(calls[2]?.method).toBe("PUT");
+		expect(calls[2]?.body).toMatchObject({ build_type: "workflow" });
+	});
+
+	it("skips POST when Pages already exists", async () => {
+		const { source, calls } = makeSourceForPages([
+			{ status: 200, body: { build_type: "workflow", status: "built", https_enforced: false, custom_domain: null } },
+			{ status: 204 },
+		]);
+		await source.configurePages!({ build: "workflow" }, "deploy-pat");
+		expect(calls).toHaveLength(2);
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[1]?.method).toBe("PUT");
+	});
+
+	it("includes cname and https_enforced in PUT when provided", async () => {
+		const { source, calls } = makeSourceForPages([
+			{ status: 200, body: { build_type: "workflow", status: "built", https_enforced: false, custom_domain: null } },
+			{ status: 204 },
+		]);
+		await source.configurePages!(
+			{ build: "workflow", domain: "docs.theholocron.dev", https: true },
+			"deploy-pat"
+		);
+		expect(calls[1]?.body).toMatchObject({
+			build_type: "workflow",
+			cname: "docs.theholocron.dev",
+			https_enforced: true,
+		});
+	});
+
+	it("omits cname and https_enforced when not provided", async () => {
+		const { source, calls } = makeSourceForPages([
+			{ status: 200, body: { build_type: "workflow", status: "built", https_enforced: false, custom_domain: null } },
+			{ status: 204 },
+		]);
+		await source.configurePages!({ build: "workflow" }, "deploy-pat");
+		expect(calls[1]?.body).not.toHaveProperty("cname");
+		expect(calls[1]?.body).not.toHaveProperty("https_enforced");
+	});
+
+	it("uses legacy build type with gh-pages source for branch", async () => {
+		const { source, calls } = makeSourceForPages([
+			{ status: 404, body: { message: "Not Found" } },
+			{ status: 201, body: { build_type: "legacy", status: "building", https_enforced: false, custom_domain: null } },
+			{ status: 204 },
+		]);
+		await source.configurePages!({ build: "branch" }, "deploy-pat");
+		expect(calls[1]?.body).toMatchObject({
+			build_type: "legacy",
+			source: { branch: "gh-pages", path: "/" },
+		});
+		expect(calls[2]?.body).toMatchObject({
+			build_type: "legacy",
+			source: { branch: "gh-pages", path: "/" },
+		});
+	});
+
+	it("uses the deploy token (not the admin token) for Pages API calls", async () => {
+		const { source, calls } = makeSourceForPages([
+			{ status: 200, body: { build_type: "workflow", status: "built", https_enforced: false, custom_domain: null } },
+			{ status: 204 },
+		]);
+		await source.configurePages!({ build: "workflow" }, "deploy-pat-xyz");
+		expect(calls[0]?.headers["authorization"]).toBe("Bearer deploy-pat-xyz");
+	});
+});
+
 describe("GitHubSource — workflow files (local fs)", () => {
 	let repoRoot: string;
 
@@ -259,5 +352,27 @@ describe("GitHubSource — workflow files (local fs)", () => {
 		await expect(source.writeWorkflowFile("lint.yml", "name: lint")).rejects.toThrow(
 			/exists but is not a directory/
 		);
+	});
+
+	it("listWorkflowFiles rethrows non-ENOENT errors", async () => {
+		// Putting a file at the workflows path makes readdir throw ENOTDIR, not ENOENT.
+		await mkdir(join(repoRoot, ".github"), { recursive: true });
+		await writeFile(join(repoRoot, ".github", "workflows"), "not a directory");
+		const { source } = makeSource([], repoRoot);
+		await expect(source.listWorkflowFiles()).rejects.toThrow();
+	});
+
+	it("readWorkflowFile rethrows non-ENOENT errors", async () => {
+		await mkdir(join(repoRoot, ".github"), { recursive: true });
+		await writeFile(join(repoRoot, ".github", "workflows"), "not a directory");
+		const { source } = makeSource([], repoRoot);
+		await expect(source.readWorkflowFile("lint.yml")).rejects.toThrow();
+	});
+
+	it("removeWorkflowFile rethrows non-ENOENT errors", async () => {
+		await mkdir(join(repoRoot, ".github"), { recursive: true });
+		await writeFile(join(repoRoot, ".github", "workflows"), "not a directory");
+		const { source } = makeSource([], repoRoot);
+		await expect(source.removeWorkflowFile("lint.yml")).rejects.toThrow();
 	});
 });

--- a/packages/holocron-plugin-github/src/__tests__/source.test.ts
+++ b/packages/holocron-plugin-github/src/__tests__/source.test.ts
@@ -197,7 +197,10 @@ describe("GitHubSource — configurePages", () => {
 	it("POST then PUT when Pages is not yet enabled", async () => {
 		const { source, calls } = makeSourceForPages([
 			{ status: 404, body: { message: "Not Found" } },
-			{ status: 201, body: { build_type: "workflow", status: "building", https_enforced: false, custom_domain: null } },
+			{
+				status: 201,
+				body: { build_type: "workflow", status: "building", https_enforced: false, custom_domain: null },
+			},
 			{ status: 204 },
 		]);
 		await source.configurePages!({ build: "workflow" }, "deploy-pat");
@@ -213,7 +216,10 @@ describe("GitHubSource — configurePages", () => {
 
 	it("skips POST when Pages already exists", async () => {
 		const { source, calls } = makeSourceForPages([
-			{ status: 200, body: { build_type: "workflow", status: "built", https_enforced: false, custom_domain: null } },
+			{
+				status: 200,
+				body: { build_type: "workflow", status: "built", https_enforced: false, custom_domain: null },
+			},
 			{ status: 204 },
 		]);
 		await source.configurePages!({ build: "workflow" }, "deploy-pat");
@@ -224,13 +230,13 @@ describe("GitHubSource — configurePages", () => {
 
 	it("includes cname and https_enforced in PUT when provided", async () => {
 		const { source, calls } = makeSourceForPages([
-			{ status: 200, body: { build_type: "workflow", status: "built", https_enforced: false, custom_domain: null } },
+			{
+				status: 200,
+				body: { build_type: "workflow", status: "built", https_enforced: false, custom_domain: null },
+			},
 			{ status: 204 },
 		]);
-		await source.configurePages!(
-			{ build: "workflow", domain: "docs.theholocron.dev", https: true },
-			"deploy-pat"
-		);
+		await source.configurePages!({ build: "workflow", domain: "docs.theholocron.dev", https: true }, "deploy-pat");
 		expect(calls[1]?.body).toMatchObject({
 			build_type: "workflow",
 			cname: "docs.theholocron.dev",
@@ -240,7 +246,10 @@ describe("GitHubSource — configurePages", () => {
 
 	it("omits cname and https_enforced when not provided", async () => {
 		const { source, calls } = makeSourceForPages([
-			{ status: 200, body: { build_type: "workflow", status: "built", https_enforced: false, custom_domain: null } },
+			{
+				status: 200,
+				body: { build_type: "workflow", status: "built", https_enforced: false, custom_domain: null },
+			},
 			{ status: 204 },
 		]);
 		await source.configurePages!({ build: "workflow" }, "deploy-pat");
@@ -251,7 +260,10 @@ describe("GitHubSource — configurePages", () => {
 	it("uses legacy build type with gh-pages source for branch", async () => {
 		const { source, calls } = makeSourceForPages([
 			{ status: 404, body: { message: "Not Found" } },
-			{ status: 201, body: { build_type: "legacy", status: "building", https_enforced: false, custom_domain: null } },
+			{
+				status: 201,
+				body: { build_type: "legacy", status: "building", https_enforced: false, custom_domain: null },
+			},
 			{ status: 204 },
 		]);
 		await source.configurePages!({ build: "branch" }, "deploy-pat");
@@ -267,7 +279,10 @@ describe("GitHubSource — configurePages", () => {
 
 	it("uses the deploy token (not the admin token) for Pages API calls", async () => {
 		const { source, calls } = makeSourceForPages([
-			{ status: 200, body: { build_type: "workflow", status: "built", https_enforced: false, custom_domain: null } },
+			{
+				status: 200,
+				body: { build_type: "workflow", status: "built", https_enforced: false, custom_domain: null },
+			},
 			{ status: 204 },
 		]);
 		await source.configurePages!({ build: "workflow" }, "deploy-pat-xyz");

--- a/packages/holocron-plugin-github/src/auth.ts
+++ b/packages/holocron-plugin-github/src/auth.ts
@@ -27,3 +27,8 @@ export const resolveAdminToken = createFeatureResolver({
 	envName: "HOLOCRON_ADMIN_TOKEN",
 	keyringKey: "github.admin",
 });
+
+export const resolveDeployToken = createFeatureResolver({
+	envName: "HOLOCRON_DEPLOY_TOKEN",
+	keyringKey: "github.deploy",
+});

--- a/packages/holocron-plugin-github/src/capabilities/source.ts
+++ b/packages/holocron-plugin-github/src/capabilities/source.ts
@@ -2,15 +2,12 @@ import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path";
 
 import type { LabelDef, PagesConfig, RepoRef, RepoSettings, Ruleset, Source, TeamEntry } from "@theholocron/cli";
-import { createGitHubClient, type GitHubClient } from "@theholocron/github-client";
-
-// Temporary — remove once @theholocron/github-client (feat/github-pages-api) is released
-// and the catalog version in pnpm-workspace.yaml is bumped to pick up the pages module.
-interface PagesApi {
-	getPages(repo: string): Promise<{ build_type: string | null } | null>;
-	createPages(repo: string, payload: Record<string, unknown>): Promise<unknown>;
-	updatePages(repo: string, payload: Record<string, unknown>): Promise<void>;
-}
+import {
+	createGitHubClient,
+	type CreatePagesPayload,
+	type GitHubClient,
+	type UpdatePagesPayload,
+} from "@theholocron/github-client";
 
 import { syncLabels } from "./labels.js";
 import { syncProperties } from "./properties.js";
@@ -180,33 +177,29 @@ export class GitHubSource implements Source {
 	}
 
 	async configurePages(config: PagesConfig, token: string): Promise<void> {
-		const rawClient = createGitHubClient({
+		const pagesClient = createGitHubClient({
 			token,
 			baseUrl: this.baseUrl,
 			fetch: this.fetchImpl,
 		});
-		// Cast until @theholocron/github-client (feat/github-pages-api) is released.
-		const pagesApi = (rawClient as unknown as { pages: PagesApi }).pages;
 
 		const buildType = config.build === "workflow" ? "workflow" : "legacy";
 		const branchSource = config.build === "branch" ? { branch: "gh-pages", path: "/" } : undefined;
 
 		// Enable Pages if not already on.
-		const existing = await pagesApi.getPages(this.repo);
+		const existing = await pagesClient.pages.getPages(this.repo);
 		if (!existing) {
-			await pagesApi.createPages(this.repo, {
-				build_type: buildType,
-				...(branchSource ? { source: branchSource } : {}),
-			});
+			const createPayload: CreatePagesPayload = { build_type: buildType };
+			if (branchSource) createPayload.source = branchSource;
+			await pagesClient.pages.createPages(this.repo, createPayload);
 		}
 
 		// PUT the full desired state so re-runs are idempotent.
-		await pagesApi.updatePages(this.repo, {
-			build_type: buildType,
-			...(branchSource ? { source: branchSource } : {}),
-			...(config.domain !== undefined ? { cname: config.domain } : {}),
-			...(config.https !== undefined ? { https_enforced: config.https } : {}),
-		});
+		const updatePayload: UpdatePagesPayload = { build_type: buildType };
+		if (branchSource) updatePayload.source = branchSource;
+		if (config.domain !== undefined) updatePayload.cname = config.domain;
+		if (config.https !== undefined) updatePayload.https_enforced = config.https;
+		await pagesClient.pages.updatePages(this.repo, updatePayload);
 	}
 }
 

--- a/packages/holocron-plugin-github/src/capabilities/source.ts
+++ b/packages/holocron-plugin-github/src/capabilities/source.ts
@@ -1,8 +1,16 @@
 import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
-import type { LabelDef, RepoRef, RepoSettings, Ruleset, Source, TeamEntry } from "@theholocron/cli";
-import type { GitHubClient } from "@theholocron/github-client";
+import type { LabelDef, PagesConfig, RepoRef, RepoSettings, Ruleset, Source, TeamEntry } from "@theholocron/cli";
+import { createGitHubClient, type GitHubClient } from "@theholocron/github-client";
+
+// Temporary — remove once @theholocron/github-client (feat/github-pages-api) is released
+// and the catalog version in pnpm-workspace.yaml is bumped to pick up the pages module.
+interface PagesApi {
+	getPages(repo: string): Promise<{ build_type: string | null } | null>;
+	createPages(repo: string, payload: Record<string, unknown>): Promise<unknown>;
+	updatePages(repo: string, payload: Record<string, unknown>): Promise<void>;
+}
 
 import { syncLabels } from "./labels.js";
 import { syncProperties } from "./properties.js";
@@ -12,6 +20,9 @@ import { syncTopics } from "./topics.js";
 export interface SourceOptions {
 	repo: string;
 	repoRoot: string;
+	/** Forwarded to a secondary client created for Pages calls (HOLOCRON_DEPLOY_TOKEN). */
+	baseUrl?: string;
+	fetch?: typeof fetch;
 }
 
 export class GitHubSource implements Source {
@@ -23,6 +34,8 @@ export class GitHubSource implements Source {
 	private readonly repo: string;
 	private readonly repoRoot: string;
 	private readonly workflowDir: string;
+	private readonly baseUrl?: string;
+	private readonly fetchImpl?: typeof fetch;
 
 	constructor(
 		private readonly client: GitHubClient,
@@ -34,6 +47,8 @@ export class GitHubSource implements Source {
 		this.repo = opts.repo;
 		this.repoRoot = opts.repoRoot;
 		this.workflowDir = join(opts.repoRoot, ".github", "workflows");
+		this.baseUrl = opts.baseUrl;
+		this.fetchImpl = opts.fetch;
 	}
 
 	async whoami(): Promise<{ login: string }> {
@@ -162,6 +177,36 @@ export class GitHubSource implements Source {
 	async syncHomepage(homepage: string): Promise<string> {
 		await this.client.repos.updateRepo(this.repo, { homepage });
 		return "homepage updated";
+	}
+
+	async configurePages(config: PagesConfig, token: string): Promise<void> {
+		const rawClient = createGitHubClient({
+			token,
+			baseUrl: this.baseUrl,
+			fetch: this.fetchImpl,
+		});
+		// Cast until @theholocron/github-client (feat/github-pages-api) is released.
+		const pagesApi = (rawClient as unknown as { pages: PagesApi }).pages;
+
+		const buildType = config.build === "workflow" ? "workflow" : "legacy";
+		const branchSource = config.build === "branch" ? { branch: "gh-pages", path: "/" } : undefined;
+
+		// Enable Pages if not already on.
+		const existing = await pagesApi.getPages(this.repo);
+		if (!existing) {
+			await pagesApi.createPages(this.repo, {
+				build_type: buildType,
+				...(branchSource ? { source: branchSource } : {}),
+			});
+		}
+
+		// PUT the full desired state so re-runs are idempotent.
+		await pagesApi.updatePages(this.repo, {
+			build_type: buildType,
+			...(branchSource ? { source: branchSource } : {}),
+			...(config.domain !== undefined ? { cname: config.domain } : {}),
+			...(config.https !== undefined ? { https_enforced: config.https } : {}),
+		});
 	}
 }
 

--- a/packages/holocron-plugin-github/src/index.ts
+++ b/packages/holocron-plugin-github/src/index.ts
@@ -42,7 +42,12 @@ export interface PluginContext {
 // ── Capability factories ──────────────────────────────────────────────
 
 export function source(ctx: PluginContext): Source {
-	return new GitHubSource(ctx.client, { repo: ctx.repo, repoRoot: ctx.repoRoot });
+	return new GitHubSource(ctx.client, {
+		repo: ctx.repo,
+		repoRoot: ctx.repoRoot,
+		baseUrl: ctx.options.baseUrl,
+		fetch: ctx.options.fetch,
+	});
 }
 
 export function secrets(ctx: PluginContext): Secrets {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: ^1.3.5
       version: 1.3.5
     '@theholocron/github-client':
-      specifier: ^1.3.5
-      version: 1.3.5
+      specifier: ^1.6.0
+      version: 1.6.0
     '@theholocron/infisical-client':
       specifier: ^1.3.5
       version: 1.3.5
@@ -263,7 +263,7 @@ importers:
         version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
       '@theholocron/github-client':
         specifier: catalog:clients
-        version: 1.3.5(vitest@4.1.10)
+        version: 1.6.0(vitest@4.1.10)
       '@theholocron/http-client':
         specifier: ^1.3.5
         version: 1.3.5(vitest@4.1.10)
@@ -502,7 +502,7 @@ importers:
         version: 7.6.1(@eslint/js@10.0.1(eslint@10.8.0(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.24(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.2.2(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.0(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.0(jiti@2.7.0)))(eslint@10.8.0(jiti@2.7.0))(globals@17.8.0)(typescript-eslint@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/github-client':
         specifier: catalog:clients
-        version: 1.3.5(vitest@4.1.10)
+        version: 1.6.0(vitest@4.1.10)
       '@theholocron/tsconfig':
         specifier: catalog:configs
         version: 7.6.1(typescript@5.9.3)
@@ -2387,8 +2387,8 @@ packages:
       eslint-plugin-storybook:
         optional: true
 
-  '@theholocron/github-client@1.3.5':
-    resolution: {integrity: sha512-trvWxa7qvBxOzJ4shah0ZnIa7qC4v/e/PZrg2XThuMLZXVQskk9N2FuH8N404QLAcftAY6qPoJDcHf1qhlqEhQ==}
+  '@theholocron/github-client@1.6.0':
+    resolution: {integrity: sha512-h+nbOUTR+8YlObab7OMOs2MqpCrENrtHWcTySVBesoluJZoAQ4/uaqq2U7Z9WP5UT9+WN9J7R8/QrkGlxaPXtw==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/holocron-config@7.6.1':
@@ -7832,7 +7832,7 @@ snapshots:
       eslint-plugin-n: 18.2.2(eslint@10.8.0(jiti@2.7.0))(typescript@5.9.3)
       eslint-plugin-react: 7.37.5(eslint@10.8.0(jiti@2.7.0))
 
-  '@theholocron/github-client@1.3.5(vitest@4.1.10)':
+  '@theholocron/github-client@1.6.0(vitest@4.1.10)':
     dependencies:
       '@theholocron/http-client': 1.3.5(vitest@4.1.10)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,7 @@ catalogs:
   clients:
     '@theholocron/clerk-client': ^1.3.5
     '@theholocron/doppler-client': ^1.3.5
-    '@theholocron/github-client': ^1.3.5
+    '@theholocron/github-client': ^1.6.0
     '@theholocron/http-client': ^1.3.5
     '@theholocron/infisical-client': ^1.3.5
     '@theholocron/neon-client': ^1.3.5


### PR DESCRIPTION
## Summary

Adds `docs?: DocsConfig` to `HolocronConfig` so repos can declare their GitHub Pages setup in `holocron.config.ts`, and wires a new setup step that calls the Pages API using `HOLOCRON_DEPLOY_TOKEN`.

### Config shape

```ts
docs: {
  build: "workflow" | "branch";  // required — absent means Pages not managed
  domain?: string;               // CNAME; also derives homepage when not set explicitly
  https?: boolean;               // enforce HTTPS (requires DNS-verified domain)
}
```

### How it works

1. `resolveConfig` validates `build` is present and derives `homepage` from `domain` when `homepage` is not explicitly set
2. `setup.ts` checks `HOLOCRON_DEPLOY_TOKEN` (skips with a warning if absent)
3. `GitHubSource.configurePages` creates a secondary client with the deploy token, does `POST` to enable Pages (if not already on), then `PUT` the full desired state (idempotent)

### Token required

`HOLOCRON_DEPLOY_TOKEN` needs `pages:write` + `repo` scope. Store it as an org or repo secret, or set it locally via `holocron auth set github.deploy <PAT>`.

### Dependency

The plugin implementation uses a temporary `PagesApi` interface to bridge the type gap until `theholocron/clients` PR `feat/github-pages-api` is merged, released, and the `pnpm-workspace.yaml` catalog is bumped to pick it up. The comment in `source.ts` marks exactly what to remove at that point.

## Example config

```ts
export default defineConfig({
  docs: {
    build: "workflow",
    domain: "docs.theholocron.dev",
    https: true,
  },
  // homepage is derived as "https://docs.theholocron.dev/" automatically
  ...
});
```