### PR TITLE
test: 🧪 cover Pages branch misses — no configurePages and https false path

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -2250,7 +2250,10 @@ describe("setup: Pages step", () => {
 
 	it("omits 'https: enforced' from the result message when https is not set", async () => {
 		process.env.HOLOCRON_DEPLOY_TOKEN = "deploy-pat";
-		const { loaded, loader } = makePagedLoader({ build: "workflow", domain: "docs.theholocron.dev" }, async () => {});
+		const { loaded, loader } = makePagedLoader(
+			{ build: "workflow", domain: "docs.theholocron.dev" },
+			async () => {}
+		);
 
 		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
 

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -2238,4 +2238,24 @@ describe("setup: Pages step", () => {
 
 		expect(report.steps.find((s) => s.step === PAGES_STEP)).toBeUndefined();
 	});
+
+	it("does not add a Pages step when token is set but source has no configurePages", async () => {
+		process.env.HOLOCRON_DEPLOY_TOKEN = "deploy-pat";
+		const { loaded, loader } = makePagedLoader({ build: "workflow" });
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(report.steps.find((s) => s.step === PAGES_STEP)).toBeUndefined();
+	});
+
+	it("omits 'https: enforced' from the result message when https is not set", async () => {
+		process.env.HOLOCRON_DEPLOY_TOKEN = "deploy-pat";
+		const { loaded, loader } = makePagedLoader({ build: "workflow", domain: "docs.theholocron.dev" }, async () => {});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		const step = report.steps.find((s) => s.step === PAGES_STEP);
+		expect(step?.status).toBe("ok");
+		expect(step?.message).not.toContain("https: enforced");
+	});
 });


### PR DESCRIPTION
## Summary

- Adds test: token set but source has no `configurePages` → no Pages step emitted (covers the `else if (source.configurePages)` false branch)
- Adds test: `configurePages` called but `docs.https` not set → message omits `"https: enforced"` (covers the `if (config.docs!.https)` false branch)

Both were flagged by Codecov as uncovered branch misses on the new Pages setup step added in #292.

## Test plan

- [ ] `pnpm --filter @theholocron/cli test` passes (536 tests)
- [ ] Codecov branch coverage no longer flags these two paths