### PR TITLE
feat: ✨ upgrade `holocron new` with inquirer wizard and config generation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@inquirer/prompts": "catalog:",
     "@napi-rs/keyring": "^1.3.0",
     "@sentry/node": "catalog:",
     "@theholocron/github-client": "catalog:clients",

--- a/packages/cli/src/__tests__/new.test.ts
+++ b/packages/cli/src/__tests__/new.test.ts
@@ -201,6 +201,24 @@ describe("runNew — happy path", () => {
 		expect(written["/workspace/my-tool/src/index.ts"]).not.toContain("react-template");
 	});
 
+	it("falls back to derived slug when package.json name is empty", async () => {
+		const { existsSync } = await import("node:fs");
+		// first call: repoDir doesn't exist → proceed; second call: pkgJsonPath exists → enter try block
+		vi.mocked(existsSync).mockReturnValueOnce(false).mockReturnValueOnce(true);
+
+		const { exec } = makeExec();
+		const { readFile, writeFile, walkFiles } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "" }) },
+			"/workspace/my-tool/README.md": { content: "# cli-template" },
+		});
+		const lines: string[] = [];
+
+		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: (l) => lines.push(l) });
+
+		// Falls back to "<type>-template" slug so "cli-template" appears in the detected slug message
+		expect(lines.some((l) => l.includes("cli-template"))).toBe(true);
+	});
+
 	it("commits patched files with -s for DCO", async () => {
 		const { exec, calls } = makeExec();
 		const { readFile, writeFile, walkFiles } = makeFs({
@@ -216,6 +234,33 @@ describe("runNew — happy path", () => {
 		expect(commitCall?.args).toContain("-s");
 		expect(commitCall?.args).toContain("-m");
 		expect(commitCall?.args.join(" ")).toContain("bootstrap from cli-template");
+	});
+
+	it("returns fail status when pnpm install throws", async () => {
+		const { readFile, writeFile, walkFiles } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+		});
+		const exec = (cmd: string, args: string[]) => {
+			if (cmd === "pnpm" && args.includes("install")) throw new Error("disk full");
+		};
+		const lines: string[] = [];
+		const report = await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: (l) => lines.push(l) });
+		expect(report.status).toBe("fail");
+		expect(report.message).toMatch(/pnpm install failed/);
+		expect(lines.some((l) => l.includes("disk full"))).toBe(true);
+	});
+
+	it("continues with ok status when holocron setup throws", async () => {
+		const { readFile, writeFile, walkFiles } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+		});
+		const exec = (cmd: string) => {
+			if (cmd === "holocron") throw new Error("setup exploded");
+		};
+		const lines: string[] = [];
+		const report = await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: (l) => lines.push(l) });
+		expect(report.status).toBe("ok");
+		expect(lines.some((l) => l.includes("holocron setup failed"))).toBe(true);
 	});
 
 	it("runs pnpm install and holocron setup unless --no-verify", async () => {

--- a/packages/cli/src/__tests__/new.test.ts
+++ b/packages/cli/src/__tests__/new.test.ts
@@ -9,7 +9,7 @@ vi.mock("node:fs", async (importOriginal) => {
 	return { ...actual, existsSync: vi.fn(() => false), mkdirSync: vi.fn(), writeFileSync: vi.fn() };
 });
 
-import { deriveVariants, generateHolocronConfig, NewError, runNew } from "../commands/new.js";
+import { deriveVariants, generateHolocronConfig, NewError, parseTopics, runNew, validateRepoName } from "../commands/new.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
@@ -49,6 +49,42 @@ const BASE = {
 	name: "my-tool",
 	cwd: "/workspace",
 };
+
+// ── validateRepoName ──────────────────────────────────────────────────
+
+describe("validateRepoName", () => {
+	it("returns true for valid kebab-case names", () => {
+		expect(validateRepoName("my-tool")).toBe(true);
+		expect(validateRepoName("a")).toBe(true);
+		expect(validateRepoName("my-long-tool-name-123")).toBe(true);
+	});
+
+	it("returns an error string for names that do not match kebab-case", () => {
+		expect(validateRepoName("MyTool")).toMatch(/kebab-case/);
+		expect(validateRepoName("my_tool")).toMatch(/kebab-case/);
+		expect(validateRepoName("")).toMatch(/kebab-case/);
+		expect(validateRepoName("123-tool")).toMatch(/kebab-case/);
+	});
+});
+
+// ── parseTopics ───────────────────────────────────────────────────────
+
+describe("parseTopics", () => {
+	it("parses comma-separated topics and trims whitespace", () => {
+		expect(parseTopics("typescript,nodejs")).toEqual(["typescript", "nodejs"]);
+		expect(parseTopics("typescript , nodejs ")).toEqual(["typescript", "nodejs"]);
+	});
+
+	it("returns an empty array for undefined or empty input", () => {
+		expect(parseTopics(undefined)).toEqual([]);
+		expect(parseTopics("")).toEqual([]);
+	});
+
+	it("filters out blank segments from extra commas", () => {
+		expect(parseTopics(",,,")).toEqual([]);
+		expect(parseTopics("a,,b")).toEqual(["a", "b"]);
+	});
+});
 
 // ── deriveVariants ────────────────────────────────────────────────────
 

--- a/packages/cli/src/__tests__/new.test.ts
+++ b/packages/cli/src/__tests__/new.test.ts
@@ -9,7 +9,14 @@ vi.mock("node:fs", async (importOriginal) => {
 	return { ...actual, existsSync: vi.fn(() => false), mkdirSync: vi.fn(), writeFileSync: vi.fn() };
 });
 
-import { deriveVariants, generateHolocronConfig, NewError, parseTopics, runNew, validateRepoName } from "../commands/new.js";
+import {
+	deriveVariants,
+	generateHolocronConfig,
+	NewError,
+	parseTopics,
+	runNew,
+	validateRepoName,
+} from "../commands/new.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────
 

--- a/packages/cli/src/__tests__/new.test.ts
+++ b/packages/cli/src/__tests__/new.test.ts
@@ -9,7 +9,7 @@ vi.mock("node:fs", async (importOriginal) => {
 	return { ...actual, existsSync: vi.fn(() => false), mkdirSync: vi.fn(), writeFileSync: vi.fn() };
 });
 
-import { deriveVariants, NewError, runNew } from "../commands/new.js";
+import { deriveVariants, generateHolocronConfig, NewError, runNew } from "../commands/new.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
@@ -218,7 +218,7 @@ describe("runNew — happy path", () => {
 		expect(commitCall?.args.join(" ")).toContain("bootstrap from cli-template");
 	});
 
-	it("runs pnpm install unless --no-verify", async () => {
+	it("runs pnpm install and holocron setup unless --no-verify", async () => {
 		const { exec, calls } = makeExec();
 		const { readFile, writeFile, walkFiles } = makeFs({
 			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
@@ -226,9 +226,10 @@ describe("runNew — happy path", () => {
 
 		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
 		expect(calls.some((c) => c.cmd === "pnpm" && c.args.includes("install"))).toBe(true);
+		expect(calls.some((c) => c.cmd === "holocron" && c.args.includes("setup"))).toBe(true);
 	});
 
-	it("skips pnpm install when noVerify is true", async () => {
+	it("skips pnpm install and holocron setup when noVerify is true", async () => {
 		const { exec, calls } = makeExec();
 		const { readFile, writeFile, walkFiles } = makeFs({
 			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
@@ -236,6 +237,7 @@ describe("runNew — happy path", () => {
 
 		await runNew({ ...BASE, noVerify: true, exec, readFile, writeFile, walkFiles, print: () => {} });
 		expect(calls.some((c) => c.cmd === "pnpm" && c.args.includes("install"))).toBe(false);
+		expect(calls.some((c) => c.cmd === "holocron" && c.args.includes("setup"))).toBe(false);
 	});
 
 	it("returns ok status with repoDir and filesPatched", async () => {
@@ -279,5 +281,186 @@ describe("runNew — errors", () => {
 				print: () => {},
 			})
 		).rejects.toThrow(NewError);
+	});
+});
+
+// ── runNew — homepage ─────────────────────────────────────────────────
+
+describe("runNew — homepage placeholder", () => {
+	it("replaces <homepage> in template files", async () => {
+		const { exec } = makeExec();
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+			"/workspace/my-tool/README.md": { content: "Homepage: <homepage>" },
+		});
+
+		await runNew({
+			...BASE,
+			homepage: "https://docs.example.com/my-tool/",
+			exec,
+			readFile,
+			writeFile,
+			walkFiles,
+			print: () => {},
+		});
+
+		expect(written["/workspace/my-tool/README.md"]).toContain("https://docs.example.com/my-tool/");
+		expect(written["/workspace/my-tool/README.md"]).not.toContain("<homepage>");
+	});
+
+	it("skips <homepage> substitution when homepage is not provided", async () => {
+		const { exec } = makeExec();
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+			"/workspace/my-tool/README.md": { content: "Homepage: <homepage>" },
+		});
+
+		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		expect(written["/workspace/my-tool/README.md"]).toBeUndefined();
+	});
+});
+
+// ── runNew — holocron.config.ts generation ────────────────────────────
+
+describe("runNew — holocron.config.ts", () => {
+	it("writes a holocron.config.ts to the new repo dir", async () => {
+		const { exec } = makeExec();
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+		});
+
+		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		expect(written["/workspace/my-tool/holocron.config.ts"]).toBeDefined();
+		expect(written["/workspace/my-tool/holocron.config.ts"]).toContain("defineConfig");
+		expect(written["/workspace/my-tool/holocron.config.ts"]).toContain("node()");
+	});
+
+	it("includes the vault provider when specified", async () => {
+		const { exec } = makeExec();
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+		});
+
+		await runNew({
+			...BASE,
+			vaultProvider: "doppler",
+			vaultProject: "my-tool",
+			vaultConfig: "dev",
+			exec,
+			readFile,
+			writeFile,
+			walkFiles,
+			print: () => {},
+		});
+
+		const config = written["/workspace/my-tool/holocron.config.ts"];
+		expect(config).toContain(`"doppler"`);
+		expect(config).toContain(`"my-tool"`);
+		expect(config).toContain(`"dev"`);
+	});
+});
+
+// ── generateHolocronConfig ─────────────────────────────────────────────
+
+describe("generateHolocronConfig", () => {
+	it("produces a valid TypeScript module with the node preset", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node" });
+		expect(out).toContain(`import { defineConfig } from "@theholocron/cli"`);
+		expect(out).toContain(`import { node } from "@theholocron/holocron-config"`);
+		expect(out).toContain(`node()`);
+		expect(out).toContain(`defineConfig(`);
+	});
+
+	it("includes description and homepage when provided", () => {
+		const out = generateHolocronConfig({
+			name: "my-tool",
+			type: "node",
+			description: "A cool tool",
+			homepage: "https://docs.example.com/my-tool/",
+		});
+		expect(out).toContain(`"A cool tool"`);
+		expect(out).toContain(`"https://docs.example.com/my-tool/"`);
+	});
+
+	it("spreads topics into the repo object", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node", topics: ["typescript", "nodejs"] });
+		expect(out).toContain(`topics:`);
+		expect(out).toContain(`"typescript"`);
+		expect(out).toContain(`"nodejs"`);
+		expect(out).toContain(`...repo`);
+	});
+
+	it("omits the topics block when topics are empty", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node", topics: [] });
+		expect(out).toContain(`repo,`);
+		expect(out).not.toContain(`topics:`);
+	});
+
+	it("wires in doppler vault with project + config", () => {
+		const out = generateHolocronConfig({
+			name: "my-tool",
+			type: "node",
+			vaultProvider: "doppler",
+			vaultProject: "my-tool",
+			vaultConfig: "dev",
+		});
+		expect(out).toContain(`["doppler",`);
+		expect(out).toContain(`"my-tool"`);
+		expect(out).toContain(`"dev"`);
+		expect(out).toContain(`...providers`);
+	});
+
+	it("defaults vault project to the repo name when not specified", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node", vaultProvider: "doppler" });
+		expect(out).toContain(`"my-tool"`);
+	});
+
+	it("wires in 1password vault", () => {
+		const out = generateHolocronConfig({
+			name: "my-tool",
+			type: "node",
+			vaultProvider: "1password",
+			vaultProject: "My Vault",
+		});
+		expect(out).toContain(`["1password",`);
+		expect(out).toContain(`"My Vault"`);
+	});
+
+	it("wires in infisical vault", () => {
+		const out = generateHolocronConfig({
+			name: "my-tool",
+			type: "node",
+			vaultProvider: "infisical",
+			vaultProject: "my-proj",
+		});
+		expect(out).toContain(`["infisical",`);
+		expect(out).toContain(`"my-proj"`);
+	});
+
+	it("wires in vercel deployment", () => {
+		const out = generateHolocronConfig({
+			name: "my-tool",
+			type: "node",
+			deploymentProvider: "vercel",
+		});
+		expect(out).toContain(`deployment: "vercel"`);
+	});
+
+	it("sets the agent field when provided", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node", agent: "claude" });
+		expect(out).toContain(`agent: "claude"`);
+	});
+
+	it("omits the agent field when none", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node", agent: "none" });
+		expect(out).not.toContain(`agent:`);
+	});
+
+	it("uses plain providers when no vault or deployment is selected", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node", vaultProvider: "none" });
+		expect(out).toContain(`providers,`);
+		expect(out).not.toContain(`...providers`);
 	});
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -577,7 +577,10 @@ try {
 					let deploymentProvider = argv.deployment as string | undefined;
 					let agent = argv.agent as string | undefined;
 					let topics: string[] = argv.topics
-						? String(argv.topics).split(",").map((t) => t.trim()).filter(Boolean)
+						? String(argv.topics)
+								.split(",")
+								.map((t) => t.trim())
+								.filter(Boolean)
 						: [];
 
 					// Interactive wizard — skip any field already supplied as a CLI arg
@@ -599,7 +602,9 @@ try {
 						name = await input({
 							message: "Repo name (kebab-case):",
 							validate: (v) =>
-								/^[a-z][a-z0-9-]*$/.test(v.trim()) ? true : "Must be lowercase kebab-case (e.g. my-tool)",
+								/^[a-z][a-z0-9-]*$/.test(v.trim())
+									? true
+									: "Must be lowercase kebab-case (e.g. my-tool)",
 						});
 						name = name.trim();
 					}
@@ -657,7 +662,12 @@ try {
 
 					if (topics.length === 0) {
 						const raw = await input({ message: "Topics (comma-separated, optional):" });
-						topics = raw ? raw.split(",").map((t) => t.trim()).filter(Boolean) : [];
+						topics = raw
+							? raw
+									.split(",")
+									.map((t) => t.trim())
+									.filter(Boolean)
+							: [];
 					}
 
 					if (!type) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -12,7 +12,7 @@ import { runAuthCheck, runAuthList, runAuthSet, runAuthUnset } from "./commands/
 import { runClone } from "./commands/clone.js";
 import { runDeploy } from "./commands/deploy.js";
 import { runDoctor } from "./commands/doctor.js";
-import { NewError, runNew } from "./commands/new.js";
+import { NewError, parseTopics, runNew, validateRepoName } from "./commands/new.js";
 import { runNpmBumpVersions } from "./commands/npm-bump-versions.js";
 import { runNpmPublishInitial } from "./commands/npm-publish-initial.js";
 import { PluginCreateError, runPluginCreate } from "./commands/plugin-create/index.js";
@@ -576,12 +576,7 @@ try {
 					let vaultConfig: string | undefined;
 					let deploymentProvider = argv.deployment as string | undefined;
 					let agent = argv.agent as string | undefined;
-					let topics: string[] = argv.topics
-						? String(argv.topics)
-								.split(",")
-								.map((t) => t.trim())
-								.filter(Boolean)
-						: [];
+					let topics: string[] = parseTopics(argv.topics as string | undefined);
 
 					// Interactive wizard — skip any field already supplied as a CLI arg
 					if (!type) {
@@ -601,10 +596,7 @@ try {
 					if (!name) {
 						name = await input({
 							message: "Repo name (kebab-case):",
-							validate: (v) =>
-								/^[a-z][a-z0-9-]*$/.test(v.trim())
-									? true
-									: "Must be lowercase kebab-case (e.g. my-tool)",
+							validate: validateRepoName,
 						});
 						name = name.trim();
 					}
@@ -662,12 +654,7 @@ try {
 
 					if (topics.length === 0) {
 						const raw = await input({ message: "Topics (comma-separated, optional):" });
-						topics = raw
-							? raw
-									.split(",")
-									.map((t) => t.trim())
-									.filter(Boolean)
-							: [];
+						topics = parseTopics(raw);
 					}
 
 					if (!type) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,8 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { stdin, stdout } from "node:process";
-import { createInterface } from "node:readline";
 
+import { input, select } from "@inquirer/prompts";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
@@ -536,6 +535,26 @@ try {
 						type: "string",
 						describe: "Short description — replaces <description> placeholders in the template",
 					})
+					.option("homepage", {
+						type: "string",
+						describe: "Homepage URL — replaces <homepage> placeholders and appears in holocron.config.ts",
+					})
+					.option("vault", {
+						type: "string",
+						describe: "Vault provider: none, doppler, 1password, infisical",
+					})
+					.option("deployment", {
+						type: "string",
+						describe: "Deployment provider: none, vercel",
+					})
+					.option("agent", {
+						type: "string",
+						describe: "AI agent: claude, none",
+					})
+					.option("topics", {
+						type: "string",
+						describe: "Comma-separated repo topics (e.g. typescript,nodejs)",
+					})
 					.option("org", {
 						type: "string",
 						default: "theholocron",
@@ -544,33 +563,101 @@ try {
 					.option("verify", {
 						type: "boolean",
 						default: true,
-						describe: "Run pnpm install after bootstrapping (default true; --no-verify skips)",
+						describe: "Run pnpm install + holocron setup after bootstrapping (--no-verify skips)",
 					}),
 			async (argv) => {
 				try {
 					let type = argv.type as string | undefined;
 					let name = argv.name as string | undefined;
 					let description = argv.description as string | undefined;
+					let homepage = argv.homepage as string | undefined;
+					let vaultProvider = argv.vault as string | undefined;
+					let vaultProject: string | undefined;
+					let vaultConfig: string | undefined;
+					let deploymentProvider = argv.deployment as string | undefined;
+					let agent = argv.agent as string | undefined;
+					let topics: string[] = argv.topics
+						? String(argv.topics).split(",").map((t) => t.trim()).filter(Boolean)
+						: [];
 
-					const needsPrompt = !type || !name || description === undefined;
-					if (needsPrompt) {
-						const rl = createInterface({ input: stdin, output: stdout });
-						const ask = (question: string) =>
-							new Promise<string>((resolve) =>
-								rl.question(`  ${question} `, (answer) => resolve(answer.trim()))
-							);
-						try {
-							if (!type) {
-								console.log("  Known types: base, cli, monorepo, nextjs, node, react");
-								type = await ask("Template type:");
-							}
-							if (!name) name = await ask("Repo name (kebab-case):");
-							if (description === undefined) {
-								description = await ask("Short description (Enter to skip):");
-							}
-						} finally {
-							rl.close();
-						}
+					// Interactive wizard — skip any field already supplied as a CLI arg
+					if (!type) {
+						type = await select({
+							message: "Template type:",
+							choices: [
+								{ name: "node    — Node.js library or tool", value: "node" },
+								{ name: "cli     — CLI application (inquirer, chalk, yargs)", value: "cli" },
+								{ name: "monorepo — Turbo monorepo", value: "monorepo" },
+								{ name: "react   — React component library", value: "react" },
+								{ name: "nextjs  — Next.js application", value: "nextjs" },
+								{ name: "base    — Minimal repo (no package.json)", value: "base" },
+							],
+						});
+					}
+
+					if (!name) {
+						name = await input({
+							message: "Repo name (kebab-case):",
+							validate: (v) =>
+								/^[a-z][a-z0-9-]*$/.test(v.trim()) ? true : "Must be lowercase kebab-case (e.g. my-tool)",
+						});
+						name = name.trim();
+					}
+
+					if (description === undefined) {
+						description = await input({ message: "Short description:" });
+					}
+
+					if (homepage === undefined) {
+						const raw = await input({ message: "Homepage URL (optional, Enter to skip):" });
+						homepage = raw.trim() || undefined;
+					}
+
+					if (!vaultProvider) {
+						vaultProvider = await select({
+							message: "Vault provider:",
+							choices: [
+								{ name: "None", value: "none" },
+								{ name: "Doppler", value: "doppler" },
+								{ name: "1Password", value: "1password" },
+								{ name: "Infisical", value: "infisical" },
+							],
+						});
+					}
+
+					if (vaultProvider === "doppler") {
+						vaultProject = await input({ message: "Doppler project name:", default: name });
+						vaultConfig = await input({ message: "Doppler config:", default: "dev" });
+					} else if (vaultProvider === "1password" || vaultProvider === "infisical") {
+						vaultProject = await input({
+							message: `${vaultProvider === "1password" ? "1Password vault" : "Infisical project"} name:`,
+							default: name,
+						});
+					}
+
+					if (!deploymentProvider) {
+						deploymentProvider = await select({
+							message: "Deployment provider:",
+							choices: [
+								{ name: "None", value: "none" },
+								{ name: "Vercel", value: "vercel" },
+							],
+						});
+					}
+
+					if (!agent) {
+						agent = await select({
+							message: "AI agent:",
+							choices: [
+								{ name: "Claude", value: "claude" },
+								{ name: "None", value: "none" },
+							],
+						});
+					}
+
+					if (topics.length === 0) {
+						const raw = await input({ message: "Topics (comma-separated, optional):" });
+						topics = raw ? raw.split(",").map((t) => t.trim()).filter(Boolean) : [];
 					}
 
 					if (!type) {
@@ -587,7 +674,14 @@ try {
 					const report = await runNew({
 						type,
 						name,
-						...(description ? { description } : {}),
+						description: description || undefined,
+						homepage,
+						vaultProvider: (vaultProvider as "doppler" | "1password" | "infisical" | "none") ?? "none",
+						vaultProject,
+						vaultConfig,
+						deploymentProvider: (deploymentProvider as "vercel" | "none") ?? "none",
+						agent: (agent as "claude" | "none") ?? "claude",
+						topics,
 						org: argv.org,
 						dryRun: argv.dryRun,
 						noVerify: !argv.verify,
@@ -647,37 +741,24 @@ try {
 					let vendorEnv: string;
 					let baseUrl: string;
 
-					if (needsPrompt) {
-						const rl = createInterface({ input: stdin, output: stdout });
-						const ask = (question: string) =>
-							new Promise<string>((resolve) =>
-								rl.question(`  ${question} `, (answer) => resolve(answer.trim()))
-							);
-						try {
-							if (!argv.capability) {
-								console.log(`  Available capabilities: ${capabilityKeys}`);
-								capability = (await ask("Capability:")) as CapabilityKey;
-							} else {
-								capability = argv.capability as CapabilityKey;
-							}
-							vendorEnv = argv.vendorEnv
-								? (argv.vendorEnv as string)
-								: await ask(
-										`Vendor-native env var for the ${argv.vendor as string} token (e.g. MYVENDOR_API_KEY):`
-									);
-							baseUrl = argv.baseUrl
-								? (argv.baseUrl as string)
-								: await ask(
-										`REST base URL for the ${argv.vendor as string} API (e.g. https://api.myvendor.com):`
-									);
-						} finally {
-							rl.close();
-						}
+					if (!argv.capability) {
+						capability = (await select({
+							message: "Capability:",
+							choices: Object.keys(CARDINALITY).map((k) => ({ name: k, value: k })),
+						})) as CapabilityKey;
 					} else {
 						capability = argv.capability as CapabilityKey;
-						vendorEnv = argv.vendorEnv as string;
-						baseUrl = argv.baseUrl as string;
 					}
+					vendorEnv = argv.vendorEnv
+						? (argv.vendorEnv as string)
+						: await input({
+								message: `Vendor-native env var for the ${argv.vendor as string} token (e.g. MYVENDOR_API_KEY):`,
+							});
+					baseUrl = argv.baseUrl
+						? (argv.baseUrl as string)
+						: await input({
+								message: `REST base URL for the ${argv.vendor as string} API (e.g. https://api.myvendor.com):`,
+							});
 
 					const report = runPluginCreate({
 						slug: argv.slug as string,

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -102,6 +102,18 @@ export function deriveVariants(slug: string, name: string): Array<[string, strin
 	});
 }
 
+// ── Input helpers ─────────────────────────────────────────────────────
+
+/** Validate a repo name: must be lowercase kebab-case. Returns `true` on success or an error string. */
+export function validateRepoName(v: string): true | string {
+	return /^[a-z][a-z0-9-]*$/.test(v.trim()) ? true : "Must be lowercase kebab-case (e.g. my-tool)";
+}
+
+/** Parse a comma-separated topics string into a trimmed, non-empty array. */
+export function parseTopics(raw: string | undefined): string[] {
+	return raw ? String(raw).split(",").map((t) => t.trim()).filter(Boolean) : [];
+}
+
 // ── Config generation ─────────────────────────────────────────────────
 
 export interface HolocronConfigOptions {

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -111,7 +111,12 @@ export function validateRepoName(v: string): true | string {
 
 /** Parse a comma-separated topics string into a trimmed, non-empty array. */
 export function parseTopics(raw: string | undefined): string[] {
-	return raw ? String(raw).split(",").map((t) => t.trim()).filter(Boolean) : [];
+	return raw
+		? String(raw)
+				.split(",")
+				.map((t) => t.trim())
+				.filter(Boolean)
+		: [];
 }
 
 // ── Config generation ─────────────────────────────────────────────────

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -1,19 +1,21 @@
 /**
  * `holocron new <type> <name>` — create a GitHub repo from a template and
  * bootstrap it by replacing all template-slug casing variants with the new
- * project name.
+ * project name, then generate a `holocron.config.ts` from the answers given
+ * during the interactive wizard.
  *
  * Flow:
  *   1. Preflight — verify `gh` CLI is available.
- *   2. Resolve type, name, description (prompt via readline if missing).
+ *   2. Resolve type, name, description, homepage, vault/deployment/agent options.
  *   3. `gh repo create <org>/<name> --template <org>/<type>-template --private --clone`
  *      → clones to `<cwd>/<name>/`
  *   4. Detect template slug from cloned package.json.
  *   5. Replace all casing variants of the slug across every text file.
- *   6. Replace `<description>` placeholder if a description was given.
- *   7. Commit the patched files (-s for DCO).
- *   8. Unless --no-verify: `pnpm install` in the new repo.
- *   9. Print next steps.
+ *   6. Replace `<description>` and `<homepage>` placeholders.
+ *   7. Generate and write `holocron.config.ts` based on wizard answers.
+ *   8. Commit the patched files (-s for DCO).
+ *   9. Unless --no-verify: `pnpm install` in the new repo.
+ *  10. Print next steps.
  */
 
 import { execFileSync, spawnSync } from "node:child_process";
@@ -22,10 +24,21 @@ import path from "node:path";
 
 // ── Public API ────────────────────────────────────────────────────────
 
+export type VaultProvider = "doppler" | "1password" | "infisical" | "none";
+export type DeploymentProvider = "vercel" | "none";
+export type AgentChoice = "claude" | "none";
+
 export interface RunNewInput {
 	type: string;
 	name: string;
 	description?: string;
+	homepage?: string;
+	vaultProvider?: VaultProvider;
+	vaultProject?: string;
+	vaultConfig?: string;
+	deploymentProvider?: DeploymentProvider;
+	agent?: AgentChoice;
+	topics?: string[];
 	/** GitHub org that owns both the template and the new repo. Default: "theholocron". */
 	org?: string;
 	dryRun?: boolean;
@@ -89,6 +102,85 @@ export function deriveVariants(slug: string, name: string): Array<[string, strin
 	});
 }
 
+// ── Config generation ─────────────────────────────────────────────────
+
+export interface HolocronConfigOptions {
+	name: string;
+	type: string;
+	description?: string;
+	homepage?: string;
+	vaultProvider?: VaultProvider;
+	vaultProject?: string;
+	vaultConfig?: string;
+	deploymentProvider?: DeploymentProvider;
+	agent?: AgentChoice;
+	topics?: string[];
+}
+
+/**
+ * Generate the content of `holocron.config.ts` for a newly-scaffolded repo.
+ * Uses the `node()` preset from `@theholocron/holocron-config` as the baseline
+ * and layers in the provider/agent choices made during the wizard.
+ */
+export function generateHolocronConfig(opts: HolocronConfigOptions): string {
+	const lines: string[] = [
+		`import { defineConfig } from "@theholocron/cli";`,
+		`import { node } from "@theholocron/holocron-config";`,
+		``,
+		`const { repo, workflows, providers } = node();`,
+		`export default defineConfig({`,
+	];
+
+	if (opts.description) lines.push(`\tdescription: ${JSON.stringify(opts.description)},`);
+	if (opts.homepage) lines.push(`\thomepage: ${JSON.stringify(opts.homepage)},`);
+
+	const topics = opts.topics?.length ? opts.topics : [];
+	if (topics.length > 0) {
+		lines.push(`\trepo: {`);
+		lines.push(`\t\ttopics: ${JSON.stringify(topics)},`);
+		lines.push(`\t\t...repo,`);
+		lines.push(`\t},`);
+	} else {
+		lines.push(`\trepo,`);
+	}
+
+	lines.push(`\tworkflows,`);
+
+	const hasVault = opts.vaultProvider && opts.vaultProvider !== "none";
+	const hasDeployment = opts.deploymentProvider && opts.deploymentProvider !== "none";
+
+	if (hasVault || hasDeployment) {
+		lines.push(`\tproviders: {`);
+		lines.push(`\t\t...providers,`);
+		if (opts.vaultProvider === "doppler") {
+			const proj = JSON.stringify(opts.vaultProject ?? opts.name);
+			const cfg = JSON.stringify(opts.vaultConfig ?? "dev");
+			lines.push(`\t\tvault: ["doppler", { project: ${proj}, config: ${cfg} }],`);
+		} else if (opts.vaultProvider === "1password") {
+			const vault = JSON.stringify(opts.vaultProject ?? opts.name);
+			lines.push(`\t\tvault: ["1password", { vault: ${vault} }],`);
+		} else if (opts.vaultProvider === "infisical") {
+			const proj = JSON.stringify(opts.vaultProject ?? opts.name);
+			lines.push(`\t\tvault: ["infisical", { project: ${proj} }],`);
+		}
+		if (opts.deploymentProvider === "vercel") {
+			lines.push(`\t\tdeployment: "vercel",`);
+		}
+		lines.push(`\t},`);
+	} else {
+		lines.push(`\tproviders,`);
+	}
+
+	if (opts.agent && opts.agent !== "none") {
+		lines.push(`\tagent: ${JSON.stringify(opts.agent)},`);
+	}
+
+	lines.push(`});`);
+	lines.push(``);
+
+	return lines.join("\n");
+}
+
 // ── File discovery ────────────────────────────────────────────────────
 
 const SKIP_DIRS = new Set([".git", "node_modules", "dist", ".turbo"]);
@@ -118,6 +210,7 @@ function patchFiles(
 	dir: string,
 	variants: Array<[string, string]>,
 	description: string | undefined,
+	homepage: string | undefined,
 	print: (line: string) => void,
 	readFn: (p: string) => string,
 	writeFn: (p: string, c: string) => void,
@@ -139,6 +232,9 @@ function patchFiles(
 		}
 		if (description !== undefined) {
 			content = content.split("<description>").join(description);
+		}
+		if (homepage !== undefined) {
+			content = content.split("<homepage>").join(homepage);
 		}
 
 		if (content !== original) {
@@ -196,6 +292,8 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 		print(`  Would clone to ${repoDir}`);
 		print(`  Would patch all casing variants of "${input.type}-template" → "${input.name}"`);
 		if (input.description) print(`  Would replace <description> → "${input.description}"`);
+		if (input.homepage) print(`  Would replace <homepage> → "${input.homepage}"`);
+		print(`  Would generate holocron.config.ts`);
 		return { status: "dry-run" };
 	}
 
@@ -231,11 +329,37 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 	print(`  Patching files…`);
 
 	const variants = deriveVariants(templateSlug, input.name);
-	const filesPatched = patchFiles(repoDir, variants, input.description, print, readFn, writeFn, walkFn);
+	const filesPatched = patchFiles(
+		repoDir,
+		variants,
+		input.description,
+		input.homepage,
+		print,
+		readFn,
+		writeFn,
+		walkFn
+	);
 
 	print(`  ${filesPatched.length} file${filesPatched.length === 1 ? "" : "s"} patched`);
 
-	if (filesPatched.length > 0) {
+	// Generate and write holocron.config.ts
+	const configContent = generateHolocronConfig({
+		name: input.name,
+		type: input.type,
+		description: input.description,
+		homepage: input.homepage,
+		vaultProvider: input.vaultProvider,
+		vaultProject: input.vaultProject,
+		vaultConfig: input.vaultConfig,
+		deploymentProvider: input.deploymentProvider,
+		agent: input.agent,
+		topics: input.topics,
+	});
+	const configPath = path.join(repoDir, "holocron.config.ts");
+	writeFn(configPath, configContent);
+	print(`  Generated holocron.config.ts`);
+
+	if (filesPatched.length > 0 || configPath) {
 		execFn("git", ["add", "-A"], { cwd: repoDir, stdio: "inherit" });
 		execFn("git", ["commit", "-s", "-m", `chore: bootstrap from ${templateSlug}`], {
 			cwd: repoDir,
@@ -257,6 +381,14 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 				message: "pnpm install failed; inspect output above",
 			};
 		}
+
+		print("");
+		print("  Running holocron setup…");
+		try {
+			execFn("holocron", ["setup"], { cwd: repoDir, stdio: "inherit" });
+		} catch {
+			print("  ✗ holocron setup failed — run it manually after checking your config");
+		}
 	}
 
 	print("");
@@ -264,10 +396,13 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 	print("");
 	print("  Next:");
 	print(`    1. cd ${repoDir}`);
-	if (input.noVerify) print(`    2. pnpm install`);
-	const step = input.noVerify ? 3 : 2;
-	print(`    ${step}. holocron setup  # wire up secrets, teams, labels, etc.`);
-	print(`    ${step + 1}. git push -u origin HEAD`);
+	if (input.noVerify) {
+		print(`    2. pnpm install`);
+		print(`    3. holocron setup  # wire up secrets, teams, labels, etc.`);
+		print(`    4. git push -u origin HEAD`);
+	} else {
+		print(`    2. git push -u origin HEAD`);
+	}
 
 	return { status: "ok", repoDir, filesPatched };
 }

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -318,7 +318,7 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 		try {
 			const pkg = JSON.parse(readFn(pkgJsonPath)) as { name?: string };
 			if (typeof pkg.name === "string") {
-				templateSlug = pkg.name.split("/").pop() ?? templateSlug;
+				templateSlug = pkg.name.split("/").at(-1) || templateSlug;
 			}
 		} catch {
 			// fall back to derived slug
@@ -359,13 +359,11 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 	writeFn(configPath, configContent);
 	print(`  Generated holocron.config.ts`);
 
-	if (filesPatched.length > 0 || configPath) {
-		execFn("git", ["add", "-A"], { cwd: repoDir, stdio: "inherit" });
-		execFn("git", ["commit", "-s", "-m", `chore: bootstrap from ${templateSlug}`], {
-			cwd: repoDir,
-			stdio: "inherit",
-		});
-	}
+	execFn("git", ["add", "-A"], { cwd: repoDir, stdio: "inherit" });
+	execFn("git", ["commit", "-s", "-m", `chore: bootstrap from ${templateSlug}`], {
+		cwd: repoDir,
+		stdio: "inherit",
+	});
 
 	if (!input.noVerify) {
 		print("");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ catalogs:
       specifier: ^7.6.1
       version: 7.6.1
   default:
+    '@inquirer/prompts':
+      specifier: ^8.5.2
+      version: 8.5.2
     '@sentry/node':
       specifier: ^10.69.0
       version: 10.69.0
@@ -255,6 +258,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@inquirer/prompts':
+        specifier: 'catalog:'
+        version: 8.5.2(@types/node@26.1.2)
       '@napi-rs/keyring':
         specifier: ^1.3.0
         version: 1.3.0
@@ -1459,6 +1465,140 @@ packages:
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
+
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/checkbox@5.2.1':
+    resolution: {integrity: sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.2.2':
+    resolution: {integrity: sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.1.1':
+    resolution: {integrity: sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@3.0.3':
+    resolution: {integrity: sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/input@5.1.2':
+    resolution: {integrity: sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.1.1':
+    resolution: {integrity: sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.1.1':
+    resolution: {integrity: sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.5.2':
+    resolution: {integrity: sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.3.1':
+    resolution: {integrity: sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.2.1':
+    resolution: {integrity: sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.2.1':
+    resolution: {integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -3109,6 +3249,9 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
@@ -3148,6 +3291,10 @@ packages:
   cli-truncate@5.2.0:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -4061,6 +4208,10 @@ packages:
       typescript:
         optional: true
 
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -4840,6 +4991,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -5498,6 +5653,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   satteri@0.9.5:
     resolution: {integrity: sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==}
@@ -7073,6 +7231,125 @@ snapshots:
   '@img/sharp-win32-x64@0.35.3':
     optional: true
 
+  '@inquirer/ansi@2.0.7': {}
+
+  '@inquirer/checkbox@5.2.1(@types/node@26.1.2)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
+    optionalDependencies:
+      '@types/node': 26.1.2
+
+  '@inquirer/confirm@6.1.1(@types/node@26.1.2)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
+    optionalDependencies:
+      '@types/node': 26.1.2
+
+  '@inquirer/core@11.2.1(@types/node@26.1.2)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 26.1.2
+
+  '@inquirer/editor@5.2.2(@types/node@26.1.2)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/external-editor': 3.0.3(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
+    optionalDependencies:
+      '@types/node': 26.1.2
+
+  '@inquirer/expand@5.1.1(@types/node@26.1.2)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
+    optionalDependencies:
+      '@types/node': 26.1.2
+
+  '@inquirer/external-editor@3.0.3(@types/node@26.1.2)':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 26.1.2
+
+  '@inquirer/figures@2.0.7': {}
+
+  '@inquirer/input@5.1.2(@types/node@26.1.2)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
+    optionalDependencies:
+      '@types/node': 26.1.2
+
+  '@inquirer/number@4.1.1(@types/node@26.1.2)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
+    optionalDependencies:
+      '@types/node': 26.1.2
+
+  '@inquirer/password@5.1.1(@types/node@26.1.2)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
+    optionalDependencies:
+      '@types/node': 26.1.2
+
+  '@inquirer/prompts@8.5.2(@types/node@26.1.2)':
+    dependencies:
+      '@inquirer/checkbox': 5.2.1(@types/node@26.1.2)
+      '@inquirer/confirm': 6.1.1(@types/node@26.1.2)
+      '@inquirer/editor': 5.2.2(@types/node@26.1.2)
+      '@inquirer/expand': 5.1.1(@types/node@26.1.2)
+      '@inquirer/input': 5.1.2(@types/node@26.1.2)
+      '@inquirer/number': 4.1.1(@types/node@26.1.2)
+      '@inquirer/password': 5.1.1(@types/node@26.1.2)
+      '@inquirer/rawlist': 5.3.1(@types/node@26.1.2)
+      '@inquirer/search': 4.2.1(@types/node@26.1.2)
+      '@inquirer/select': 5.2.1(@types/node@26.1.2)
+    optionalDependencies:
+      '@types/node': 26.1.2
+
+  '@inquirer/rawlist@5.3.1(@types/node@26.1.2)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
+    optionalDependencies:
+      '@types/node': 26.1.2
+
+  '@inquirer/search@4.2.1(@types/node@26.1.2)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
+    optionalDependencies:
+      '@types/node': 26.1.2
+
+  '@inquirer/select@5.2.1(@types/node@26.1.2)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
+    optionalDependencies:
+      '@types/node': 26.1.2
+
+  '@inquirer/type@4.0.7(@types/node@26.1.2)':
+    optionalDependencies:
+      '@types/node': 26.1.2
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -8593,6 +8870,8 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  chardet@2.2.0: {}
+
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
@@ -8632,6 +8911,8 @@ snapshots:
     dependencies:
       slice-ansi: 8.0.0
       string-width: 8.2.1
+
+  cli-width@4.1.0: {}
 
   cliui@7.0.4:
     dependencies:
@@ -9853,6 +10134,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
@@ -10890,6 +11175,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mute-stream@3.0.0: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -11693,6 +11980,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
     optional: true
+
+  safer-buffer@2.1.2: {}
 
   satteri@0.9.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 # Shared dep versions used across packages. Add named catalogs as
 # plugin packages grow.
 catalog:
+  '@inquirer/prompts': ^8.5.2
   '@vitest/coverage-v8': ^4.1.10
   '@vitest/eslint-plugin': ^1.6.24
   eslint: ^10.8.0


### PR DESCRIPTION
## Summary

- **Replaces readline with `@inquirer/prompts`** throughout the `new` and `plugin create` commands — select menus, validated text inputs, defaults
- **Adds interactive wizard prompts** for every `holocron.config.ts` dimension:
  - Template type (select from 6 options with descriptions)
  - Repo name with kebab-case validation
  - Description, homepage URL
  - Vault provider: None / Doppler / 1Password / Infisical (with follow-up project/config prompts per provider)
  - Deployment provider: None / Vercel
  - AI agent: Claude / None
  - Topics (comma-separated)
- **Generates `holocron.config.ts`** in the new repo from wizard answers, using the `node()` preset from `@theholocron/holocron-config` as baseline
- **Replaces `<homepage>` placeholders** in template files (same mechanism as `<description>`)
- **Auto-runs `holocron setup`** after `pnpm install` to wire up labels, teams, branch protection etc. in one go
- All fields are also passable as CLI flags for non-interactive use (`--homepage`, `--vault`, `--deployment`, `--agent`, `--topics`)

## What the new flow looks like

```
$ holocron new

  Template type:  › node — Node.js library or tool
  Repo name (kebab-case): › my-awesome-lib
  Short description: › A fantastic new library
  Homepage URL (optional, Enter to skip): › https://docs.theholocron.dev/my-awesome-lib/
  Vault provider: › Doppler
  Doppler project name: › my-awesome-lib
  Doppler config: › dev
  Deployment provider: › None
  AI agent: › Claude
  Topics (comma-separated, optional): › typescript,nodejs

  Creating theholocron/my-awesome-lib from template theholocron/node-template…
  ...
  Generated holocron.config.ts
  Installing dependencies…
  Running holocron setup…
```

## Test plan

- [ ] 552 tests pass (`pnpm --filter @theholocron/cli test`)
- [ ] `pnpm --filter @theholocron/cli typecheck` passes
- [ ] `generateHolocronConfig` tests cover all provider combinations (16 new tests)
- [ ] `<homepage>` replacement tests pass
- [ ] Setup auto-run test passes