### PR TITLE
fix: ✨ replace org/slug pair in new command so GitHub URLs and package scope use correct org

### DIFF
--- a/packages/cli/src/__tests__/new.test.ts
+++ b/packages/cli/src/__tests__/new.test.ts
@@ -355,6 +355,58 @@ describe("runNew — happy path", () => {
 	});
 });
 
+// ── runNew — org replacement ──────────────────────────────────────────
+
+describe("runNew — org/slug replacement", () => {
+	it("replaces theholocron/<slug> with <org>/<name> in file content", async () => {
+		const { exec } = makeExec();
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/my-tool/package.json": {
+				content: JSON.stringify({ name: "@theholocron/cli-template" }),
+			},
+			"/workspace/my-tool/README.md": {
+				content: "bugs: https://github.com/theholocron/cli-template/issues",
+			},
+		});
+
+		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		expect(written["/workspace/my-tool/README.md"]).toContain("theholocron/my-tool");
+		expect(written["/workspace/my-tool/README.md"]).not.toContain("theholocron/cli-template");
+	});
+
+	it("replaces org in scoped package name when org differs from theholocron", async () => {
+		const { exec } = makeExec();
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/my-tool/package.json": {
+				content: JSON.stringify({ name: "@theholocron/cli-template" }),
+			},
+		});
+
+		await runNew({ ...BASE, org: "acme", exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		const pkg = JSON.parse(written["/workspace/my-tool/package.json"]!);
+		expect(pkg.name).toBe("@acme/my-tool");
+	});
+
+	it("does not replace @theholocron/ in devDependency package names", async () => {
+		const { exec } = makeExec();
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/my-tool/package.json": {
+				content: JSON.stringify({
+					name: "@theholocron/cli-template",
+					devDependencies: { "@theholocron/eslint-config": "^1.0.0" },
+				}),
+			},
+		});
+
+		await runNew({ ...BASE, org: "acme", exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		const pkg = JSON.parse(written["/workspace/my-tool/package.json"]!);
+		expect(pkg.devDependencies["@theholocron/eslint-config"]).toBe("^1.0.0");
+	});
+});
+
 // ── runNew — error cases ──────────────────────────────────────────────
 
 describe("runNew — errors", () => {

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -363,6 +363,11 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 	print(`  Patching files…`);
 
 	const variants = deriveVariants(templateSlug, input.name);
+	// Prepend the full org/slug pair so GitHub URLs and scoped package names
+	// use the correct org. Must come before the slug-only pairs so it takes
+	// priority — e.g. "@theholocron/node-template" becomes "@<org>/<name>"
+	// rather than "@theholocron/<name>".
+	variants.unshift([`theholocron/${templateSlug}`, `${org}/${input.name}`]);
 	const filesPatched = patchFiles(
 		repoDir,
 		variants,


### PR DESCRIPTION
## Summary

- Prepends `["theholocron/<slug>", "<org>/<name>"]` to the variant list before the slug-only pairs in `runNew`
- Ensures `@theholocron/node-template` → `@<org>/<name>` and GitHub URLs like `github.com/theholocron/node-template` → `github.com/<org>/<name>`
- Unrelated `@theholocron/*` devDependencies (e.g. `@theholocron/eslint-config`) are unaffected since they don't contain the template slug
- No source template changes needed — the fix lives entirely in `new.ts`

## Test plan

- [ ] `@theholocron/cli-template` in `package.json` name becomes `@acme/my-tool` when `org: "acme"` is passed
- [ ] GitHub URL references to `theholocron/cli-template` are replaced with `acme/my-tool`
- [ ] `@theholocron/eslint-config` in devDependencies is NOT touched