### PR TITLE
feat: ✨ extend new command with full repo config and skills

### DIFF
--- a/packages/cli/src/__tests__/new.test.ts
+++ b/packages/cli/src/__tests__/new.test.ts
@@ -565,6 +565,44 @@ describe("generateHolocronConfig", () => {
 		expect(out).not.toContain(`...providers`);
 	});
 
+	it("generates full explicit repo block when org is provided", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node", org: "theholocron" });
+		expect(out).toContain(`name: "theholocron/my-tool"`);
+		expect(out).toContain(`teams: [{ slug: "gatekeepers", permission: "maintain" }]`);
+		expect(out).toContain(`topics:`);
+		expect(out).toContain(`...repo`);
+	});
+
+	it("includes protection override when not strict", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node", org: "theholocron", protection: "balanced" });
+		expect(out).toContain(`protection: "balanced"`);
+	});
+
+	it("omits protection override when strict (preset default)", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node", org: "theholocron", protection: "strict" });
+		expect(out).not.toContain(`protection:`);
+	});
+
+	it("includes properties overrides for open_source false", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node", org: "theholocron", openSource: false });
+		expect(out).toContain(`open_source: false`);
+	});
+
+	it("includes properties overrides for uses_external_packages false", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node", org: "theholocron", usesExternalPackages: false });
+		expect(out).toContain(`uses_external_packages: false`);
+	});
+
+	it("emits skills array when provided", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node", skills: ["git-safety", "pr-workflow"] });
+		expect(out).toContain(`skills: ["git-safety","pr-workflow"]`);
+	});
+
+	it("omits skills when empty", () => {
+		const out = generateHolocronConfig({ name: "my-tool", type: "node", skills: [] });
+		expect(out).not.toContain(`skills:`);
+	});
+
 	it("emits a properties override for non-node runtime environments", () => {
 		const cases: RuntimeEnvironment[] = ["browser", "universal", "none"];
 		for (const env of cases) {

--- a/packages/cli/src/__tests__/new.test.ts
+++ b/packages/cli/src/__tests__/new.test.ts
@@ -574,7 +574,12 @@ describe("generateHolocronConfig", () => {
 	});
 
 	it("includes protection override when not strict", () => {
-		const out = generateHolocronConfig({ name: "my-tool", type: "node", org: "theholocron", protection: "balanced" });
+		const out = generateHolocronConfig({
+			name: "my-tool",
+			type: "node",
+			org: "theholocron",
+			protection: "balanced",
+		});
 		expect(out).toContain(`protection: "balanced"`);
 	});
 
@@ -589,7 +594,12 @@ describe("generateHolocronConfig", () => {
 	});
 
 	it("includes properties overrides for uses_external_packages false", () => {
-		const out = generateHolocronConfig({ name: "my-tool", type: "node", org: "theholocron", usesExternalPackages: false });
+		const out = generateHolocronConfig({
+			name: "my-tool",
+			type: "node",
+			org: "theholocron",
+			usesExternalPackages: false,
+		});
 		expect(out).toContain(`uses_external_packages: false`);
 	});
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -558,6 +558,22 @@ try {
 						type: "string",
 						describe: "Comma-separated repo topics (e.g. typescript,nodejs)",
 					})
+					.option("protection", {
+						type: "string",
+						describe: "Branch protection level: strict, balanced, minimal",
+					})
+					.option("open-source", {
+						type: "boolean",
+						describe: "Whether the repo is open source (default: true)",
+					})
+					.option("uses-external-packages", {
+						type: "boolean",
+						describe: "Whether the repo calls external APIs or services (default: true)",
+					})
+					.option("skills", {
+						type: "string",
+						describe: "Comma-separated agent skill names (e.g. git-safety,pr-workflow)",
+					})
 					.option("org", {
 						type: "string",
 						default: "theholocron",
@@ -581,6 +597,10 @@ try {
 					let agent = argv.agent as string | undefined;
 					let runtimeEnvironment = argv.runtimeEnvironment as string | undefined;
 					let topics: string[] = parseTopics(argv.topics as string | undefined);
+					let protection = argv.protection as string | undefined;
+					let openSource = argv.openSource as boolean | undefined;
+					let usesExternalPackages = argv.usesExternalPackages as boolean | undefined;
+					let skills: string[] = parseTopics(argv.skills as string | undefined);
 
 					// Interactive wizard — skip any field already supplied as a CLI arg
 					if (!type) {
@@ -674,6 +694,44 @@ try {
 						topics = parseTopics(raw);
 					}
 
+					if (!protection) {
+						protection = await select({
+							message: "Branch protection:",
+							choices: [
+								{ name: "strict    — required reviews + passing checks", value: "strict" },
+								{ name: "balanced  — required reviews, flexible checks", value: "balanced" },
+								{ name: "minimal   — branch protection only", value: "minimal" },
+							],
+						});
+					}
+
+					if (openSource === undefined) {
+						const ans = await select({
+							message: "Open source?",
+							choices: [
+								{ name: "Yes", value: "yes" },
+								{ name: "No", value: "no" },
+							],
+						});
+						openSource = ans === "yes";
+					}
+
+					if (usesExternalPackages === undefined) {
+						const ans = await select({
+							message: "Uses external APIs or services?",
+							choices: [
+								{ name: "Yes", value: "yes" },
+								{ name: "No", value: "no" },
+							],
+						});
+						usesExternalPackages = ans === "yes";
+					}
+
+					if (skills.length === 0) {
+						const raw = await input({ message: "Agent skills (comma-separated, optional):" });
+						skills = parseTopics(raw);
+					}
+
 					if (!type) {
 						console.error("new: template type is required");
 						process.exitCode = 1;
@@ -696,7 +754,11 @@ try {
 						deploymentProvider: (deploymentProvider as "vercel" | "none") ?? "none",
 						agent: (agent as "claude" | "none") ?? "claude",
 						runtimeEnvironment: (runtimeEnvironment as "node" | "browser" | "universal" | "none") ?? "node",
+						protection: protection ?? "strict",
+						openSource: openSource ?? true,
+						usesExternalPackages: usesExternalPackages ?? true,
 						topics,
+						skills,
 						org: argv.org,
 						dryRun: argv.dryRun,
 						noVerify: !argv.verify,

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -40,7 +40,11 @@ export interface RunNewInput {
 	deploymentProvider?: DeploymentProvider;
 	agent?: AgentChoice;
 	runtimeEnvironment?: RuntimeEnvironment;
+	protection?: string;
+	openSource?: boolean;
+	usesExternalPackages?: boolean;
 	topics?: string[];
+	skills?: string[];
 	/** GitHub org that owns both the template and the new repo. Default: "theholocron". */
 	org?: string;
 	dryRun?: boolean;
@@ -126,6 +130,7 @@ export function parseTopics(raw: string | undefined): string[] {
 export interface HolocronConfigOptions {
 	name: string;
 	type: string;
+	org?: string;
 	description?: string;
 	homepage?: string;
 	vaultProvider?: VaultProvider;
@@ -134,7 +139,11 @@ export interface HolocronConfigOptions {
 	deploymentProvider?: DeploymentProvider;
 	agent?: AgentChoice;
 	runtimeEnvironment?: RuntimeEnvironment;
+	protection?: string;
+	openSource?: boolean;
+	usesExternalPackages?: boolean;
 	topics?: string[];
+	skills?: string[];
 }
 
 /**
@@ -156,12 +165,30 @@ export function generateHolocronConfig(opts: HolocronConfigOptions): string {
 
 	const topics = opts.topics?.length ? opts.topics : [];
 	const hasRuntimeOverride = opts.runtimeEnvironment != null && opts.runtimeEnvironment !== "node";
+	const hasFullRepo = opts.org != null;
 
-	if (topics.length > 0 || hasRuntimeOverride) {
+	if (hasFullRepo) {
+		// Full explicit repo block when org is known (always the case from the CLI).
+		const repoName = `${opts.org}/${opts.name}`;
 		lines.push(`\trepo: {`);
-		if (topics.length > 0) {
-			lines.push(`\t\ttopics: ${JSON.stringify(topics)},`);
+		lines.push(`\t\tname: ${JSON.stringify(repoName)},`);
+		lines.push(`\t\tteams: [{ slug: "gatekeepers", permission: "maintain" }],`);
+		lines.push(`\t\ttopics: ${JSON.stringify(topics)},`);
+		lines.push(`\t\t...repo,`);
+		if (opts.protection && opts.protection !== "strict") {
+			lines.push(`\t\tprotection: ${JSON.stringify(opts.protection)},`);
 		}
+		const propParts: string[] = [];
+		if (hasRuntimeOverride) propParts.push(`runtime_environment: ${JSON.stringify(opts.runtimeEnvironment)}`);
+		if (opts.openSource === false) propParts.push(`open_source: false`);
+		if (opts.usesExternalPackages === false) propParts.push(`uses_external_packages: false`);
+		if (propParts.length > 0) {
+			lines.push(`\t\tproperties: { ...repo.properties, ${propParts.join(", ")} },`);
+		}
+		lines.push(`\t},`);
+	} else if (topics.length > 0 || hasRuntimeOverride) {
+		lines.push(`\trepo: {`);
+		if (topics.length > 0) lines.push(`\t\ttopics: ${JSON.stringify(topics)},`);
 		lines.push(`\t\t...repo,`);
 		if (hasRuntimeOverride) {
 			lines.push(
@@ -202,6 +229,10 @@ export function generateHolocronConfig(opts: HolocronConfigOptions): string {
 
 	if (opts.agent && opts.agent !== "none") {
 		lines.push(`\tagent: ${JSON.stringify(opts.agent)},`);
+	}
+
+	if (opts.skills?.length) {
+		lines.push(`\tskills: ${JSON.stringify(opts.skills)},`);
 	}
 
 	lines.push(`});`);
@@ -381,6 +412,7 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 	const configContent = generateHolocronConfig({
 		name: input.name,
 		type: input.type,
+		org,
 		description: input.description,
 		homepage: input.homepage,
 		vaultProvider: input.vaultProvider,
@@ -389,7 +421,11 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 		deploymentProvider: input.deploymentProvider,
 		agent: input.agent,
 		runtimeEnvironment: input.runtimeEnvironment,
+		protection: input.protection,
+		openSource: input.openSource,
+		usesExternalPackages: input.usesExternalPackages,
 		topics: input.topics,
+		skills: input.skills,
 	});
 	const configPath = path.join(repoDir, "holocron.config.ts");
 	writeFn(configPath, configContent);


### PR DESCRIPTION
## Summary

- `generateHolocronConfig` now emits a full explicit `repo` block when `org` is known (always from the CLI), including `name`, `teams`, `topics`, `protection`, and `properties` overrides
- Adds `skills` array to the generated config
- Wizard adds four new prompts: branch protection level, open source (y/n), uses external packages (y/n), and agent skills
- All new fields also available as CLI flags: `--protection`, `--open-source`, `--no-open-source`, `--uses-external-packages`, `--no-uses-external-packages`, `--skills`
- Backwards compatible: existing tests without `org` still use the minimal repo spread

## Generated config example

```ts
repo: {
    name: "theholocron/my-tool",
    teams: [{ slug: "gatekeepers", permission: "maintain" }],
    topics: ["nodejs", "typescript"],
    ...repo,
    protection: "balanced",
    properties: { ...repo.properties, open_source: true, uses_external_packages: false },
},
...
skills: ["git-safety", "pr-workflow"],
```