### PR TITLE
fix: 🐛 remove indent_style from markdown editorconfig rule

### DIFF
--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -66,8 +66,6 @@ function editorconfigContent(): string {
 		``,
 		`[*.{md,mdx}]`,
 		`trim_trailing_whitespace = false`,
-		`indent_style = space`,
-		`indent_size = 2`,
 		``,
 		`[.*{rc,ignore}]`,
 		`indent_style = space`,


### PR DESCRIPTION
## Summary

Removes `indent_style = space` and `indent_size = 2` from the `[*.{md,mdx}]` block in the generated `.editorconfig`.

**Problem:** Prettier formats TypeScript code blocks inside markdown files with tabs (following the `[*]` tab rule), but editorconfig-checker enforced spaces for all `.md` content — requiring `<!-- prettier-ignore -->` before every code block.

**Fix:** With no `indent_style` set for markdown, editorconfig-checker skips the indentation check for `.md`/`.mdx` files entirely. Prettier still formats markdown prose and code blocks correctly.

`trim_trailing_whitespace = false` is kept so markdown line-break syntax (`  `) still works.

Replaces #304 which had conflicts from stale commits on its base.

## Test plan

- [ ] Existing tests pass
- [ ] `holocron setup` regenerates `.editorconfig` without `indent_style` in `[*.{md,mdx}]`
- [ ] Markdown files with TypeScript code blocks no longer fail editorconfig-checker