### PR TITLE
fix: 🐛 exclude .md from editorconfig-checker alongside .mdx

### DIFF
--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -180,7 +180,7 @@ const EDITORCONFIG_CHECKER_CONFIG =
 			IgnoreDefaults: false,
 			SpacesAfterTabs: false,
 			NoColor: false,
-			Exclude: ["(^|.+/)LICENSE$", "^public/.*", "\\.mdx$"],
+			Exclude: ["(^|.+/)LICENSE$", "^public/.*", "\\.md$", "\\.mdx$"],
 			AllowedContentTypes: [],
 			PassedFiles: [],
 			Disable: {

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,7 @@
     },
     "test": {
       "inputs": ["src/**", "vitest.config.ts", "package.json"],
-      "outputs": [],
+      "outputs": ["test-report.junit.xml"],
       "dependsOn": ["build", "^build"]
     },
     "test:coverage": {


### PR DESCRIPTION
## Summary

Adds `\.md$` to the editorconfig-checker Exclude list, matching the existing `\.mdx$` exclusion.

Markdown files have inherently mixed indentation: YAML frontmatter requires spaces (YAML spec forbids tabs), while code blocks follow the embedded language's formatter. editorconfig-checker can't handle per-section rules, so markdown files can't satisfy a single `indent_style` rule. Prettier is the right tool for enforcing markdown formatting — editorconfig-checker is excluded entirely.

## Test plan

- [ ] Existing tests pass
- [ ] Markdown files with tabs in code blocks no longer fail editorconfig-checker
- [ ] Markdown files with spaces in YAML frontmatter no longer fail editorconfig-checker