### PR TITLE
fix: replace hashFiles job conditions with boolean inputs in reusable workflows

### DIFF
--- a/packages/cli/src/templates/workflows/audit.yml
+++ b/packages/cli/src/templates/workflows/audit.yml
@@ -13,6 +13,11 @@ on: # yamllint disable-line rule:truthy
         type: boolean
         required: false
         default: false
+      run-performance:
+        description: Run Lighthouse CI performance audit (requires a lighthouse config file)
+        type: boolean
+        required: false
+        default: false
       knip-script:
         description: Script that invokes Knip (must exit non-zero on findings)
         type: string
@@ -81,9 +86,7 @@ jobs:
 
   performance:
     name: Audit the performance
-    # Skip when no Lighthouse config exists. Detects the org-standard
-    # lighthouse.config.{js,cjs} and legacy .lighthouserc.* names.
-    if: ${{ hashFiles('lighthouse.config.js', 'lighthouse.config.cjs', 'lighthouse.config.json', '.lighthouserc.js', '.lighthouserc.cjs', '.lighthouserc.json', '.lighthouserc.yml', '.lighthouserc.yaml') != '' }}
+    if: ${{ inputs.run-performance }}
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -2,6 +2,27 @@ name: Test
 
 on: # yamllint disable-line rule:truthy
   workflow_call:
+    inputs:
+      run-storybook:
+        description: Run Storybook vitest interaction tests (requires .storybook/ setup)
+        type: boolean
+        required: false
+        default: false
+      run-interaction:
+        description: Run Storybook interaction tests in a full Playwright container
+        type: boolean
+        required: false
+        default: false
+      run-user-flow:
+        description: Run Cypress E2E user-flow tests (requires cypress.config.*)
+        type: boolean
+        required: false
+        default: false
+      run-chromatic:
+        description: Publish Storybook to Chromatic for visual regression testing
+        type: boolean
+        required: false
+        default: false
     secrets:
       CHROMATIC_PROJECT_TOKEN:
         required: false
@@ -45,8 +66,7 @@ jobs:
 
   storybook:
     name: Run Storybook interaction tests
-    # Skip when no Storybook config exists.
-    if: ${{ hashFiles('.storybook/main.ts', '.storybook/main.js', '.storybook/main.cjs') != '' }}
+    if: ${{ inputs.run-storybook }}
     permissions:
       contents: read
       id-token: write
@@ -86,8 +106,7 @@ jobs:
 
   visual-and-composition:
     name: Test Visual and Composition
-    # Skip when no Chromatic config exists.
-    if: ${{ hashFiles('chromatic.config.json', 'chromatic.config.ts', 'chromatic.config.js') != '' }}
+    if: ${{ inputs.run-chromatic }}
     permissions:
       contents: read
       statuses: write # Chromatic posts a commit status check back to the PR
@@ -110,8 +129,7 @@ jobs:
 
   interaction-and-accessibility:
     name: Test Interactions and Accessibility
-    # Skip when no Storybook config exists.
-    if: ${{ hashFiles('.storybook/main.ts', '.storybook/main.js', '.storybook/main.cjs') != '' }}
+    if: ${{ inputs.run-interaction }}
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -135,8 +153,7 @@ jobs:
 
   user-flow:
     name: Test User Flow
-    # Skip when no Cypress config exists.
-    if: ${{ hashFiles('cypress.config.ts', 'cypress.config.js', 'cypress.config.cjs') != '' }}
+    if: ${{ inputs.run-user-flow }}
     permissions:
       contents: read
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `hashFiles()` is not allowed in `jobs.<job_id>.if:` conditions inside `workflow_call` reusable workflows — the sync validator blocked the `.github` PR with this error
- Replaces all conditional jobs with explicit boolean inputs (defaulting to `false`), matching the existing pattern `run-knip` uses in the audit template
- `audit` template: adds `run-performance` input
- `test` template: adds `run-storybook`, `run-interaction`, `run-user-flow`, `run-chromatic` inputs
- Consumers opt in via `with:` in their `holocron.config.ts` workflows array

## Test plan

- [ ] Verify sync to `.github` succeeds after merge
- [ ] Confirm `audit.yml` in a consumer repo with `run-performance: true` runs the Lighthouse job
- [ ] Confirm `test.yml` in a consumer with no overrides only runs `unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)