### PR TITLE
fix: add deploy-storybook to REUSABLE_WORKFLOWS so it syncs to .github/workflows/

### DIFF
--- a/packages/cli/src/templates/index.ts
+++ b/packages/cli/src/templates/index.ts
@@ -15,6 +15,7 @@ import bookkeepingWorkflow from "./workflows/bookkeeping.yml";
 import codeqlWorkflow from "./workflows/codeql.yml";
 import dependenciesWorkflow from "./workflows/dependencies.yml";
 import deployDocsWorkflow from "./workflows/deploy-docs.yml";
+import deployStorybookWorkflow from "./workflows/deploy-storybook.yml";
 import greetingsWorkflow from "./workflows/greetings.yml";
 import lintWorkflow from "./workflows/lint.yml";
 import releaseWorkflow from "./workflows/release.yml";
@@ -36,6 +37,7 @@ export const REUSABLE_WORKFLOWS: Record<string, string> = {
 	codeql: codeqlWorkflow,
 	dependencies: dependenciesWorkflow,
 	"deploy-docs": deployDocsWorkflow,
+	"deploy-storybook": deployStorybookWorkflow,
 	greetings: greetingsWorkflow,
 	lint: lintWorkflow,
 	release: releaseWorkflow,


### PR DESCRIPTION
## Summary

`deploy-storybook` was added to `WORKFLOW_TEMPLATES` in `setup-workflows.ts` (correct — gives consuming repos the thin-caller) but was missing from `REUSABLE_WORKFLOWS` in `templates/index.ts`. This caused the sync to place it in `workflow-templates/` (GitHub org starter templates) instead of `.github/workflows/` (shared reusable workflows).

Without this fix, thin-callers referencing `uses: theholocron/.github/.github/workflows/deploy-storybook.yml@main` would 404.

## Test plan

- [ ] Merge and verify sync PR moves `deploy-storybook.yml` into `.github/workflows/` in `theholocron/.github`

🤖 Generated with [Claude Code](https://claude.com/claude-code)