### PR TITLE
fix: pin chromaui/action to SHA instead of floating v13 tag

### DIFF
--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: theholocron/.github/.github/actions/setup@main
         name: Setup
 
-      - uses: chromaui/action@v13
+      - uses: chromaui/action@07791f8243f4cb2698bf4d00426baf4b2d1cb7e0 # v13
         name: Publish to Chromatic
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

Pins `chromaui/action@v13` to the commit SHA `07791f8243f4cb2698bf4d00426baf4b2d1cb7e0` per the org convention of SHA-pinning all third-party actions.

## Test plan

- [ ] Merge and verify sync updates `.github/workflows/test.yml` with the pinned SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)