### PR TITLE
fix: drop container from interaction-and-accessibility job in test template

### DIFF
--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -9,7 +9,7 @@ on: # yamllint disable-line rule:truthy
         required: false
         default: false
       run-interaction:
-        description: Run Storybook interaction tests in a full Playwright container
+        description: Run Storybook interaction and accessibility tests with Playwright
         type: boolean
         required: false
         default: false
@@ -134,10 +134,6 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container:
-      # Make sure to grab the latest version of the Playwright image.
-      # https://playwright.dev/docs/docker#pull-the-image
-      image: mcr.microsoft.com/playwright:v1.54.1-noble
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -147,6 +143,9 @@ jobs:
 
       - uses: theholocron/.github/.github/actions/setup@main
         name: Setup
+
+      - run: pnpm exec playwright install --with-deps
+        name: Install Playwright
 
       - run: pnpm test:storybook
         name: Run interaction and accessibility tests


### PR DESCRIPTION
## Summary

- `container:` in a reusable workflow job causes GitHub to reject the **entire** workflow at startup (`startup_failure`) even when the job is gated behind `if: ${{ inputs.run-interaction }}` — the container image is resolved at parse time, not runtime
- This broke the `Test / Run tests and collect coverage` required check for all PRs (including #313), which calls the shared `test.yml@main`
- Fix mirrors the `storybook` job, which already dropped its container and installs Playwright in a step instead

## Test plan

- [ ] Verify CI passes on this PR (test workflow parses successfully)
- [ ] Merge and confirm sync updates `theholocron/.github` — reusable `test.yml` should have no `container:` block
- [ ] Re-trigger test check on #313; confirm it passes