### PR TITLE
feat: restore optional test jobs with statuses:write fix

### DIFF
--- a/packages/cli/src/commands/workflows/test.yml
+++ b/packages/cli/src/commands/workflows/test.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   contents: read
   id-token: write
+  statuses: write
 
 jobs:
   test:

--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -2,7 +2,32 @@ name: Test
 
 on: # yamllint disable-line rule:truthy
   workflow_call:
+    inputs:
+      run-storybook:
+        description: Run Storybook vitest interaction tests (requires .storybook/ setup)
+        type: boolean
+        required: false
+        default: false
+      run-interaction:
+        description: Run Storybook interaction and accessibility tests with Playwright
+        type: boolean
+        required: false
+        default: false
+      run-chromatic:
+        description: Publish Storybook to Chromatic for visual regression testing
+        type: boolean
+        required: false
+        default: false
+      run-user-flow:
+        description: Run Cypress E2E user-flow tests (requires cypress.config.*)
+        type: boolean
+        required: false
+        default: false
     secrets:
+      CHROMATIC_PROJECT_TOKEN:
+        required: false
+      CYPRESS_RECORD_KEY:
+        required: false
       TURBO_TOKEN:
         required: false
 
@@ -38,3 +63,117 @@ jobs:
         with:
           use_oidc: true
           files: '**/test-report.junit.xml'
+
+  storybook:
+    name: Run Storybook interaction tests
+    if: ${{ inputs.run-storybook }}
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        name: Checkout repository
+
+      - uses: theholocron/.github/.github/actions/setup@main
+        name: Setup
+
+      - run: pnpm exec playwright install chromium --with-deps
+        name: Install Playwright
+
+      - run: pnpm test:storybook
+        name: Run Storybook tests
+
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        name: Upload coverage to Codecov
+        with:
+          use_oidc: true
+
+      - uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
+        name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        with:
+          use_oidc: true
+          files: '**/test-report.junit.xml'
+
+  visual-and-composition:
+    name: Test Visual and Composition
+    if: ${{ inputs.run-chromatic }}
+    permissions:
+      contents: read
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        name: Checkout repository
+        with:
+          fetch-depth: 0
+
+      - uses: theholocron/.github/.github/actions/setup@main
+        name: Setup
+
+      - uses: chromaui/action@07791f8243f4cb2698bf4d00426baf4b2d1cb7e0 # v13
+        name: Publish to Chromatic
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ github.token }}
+          buildScriptName: build:storybook
+
+  interaction-and-accessibility:
+    name: Test Interactions and Accessibility
+    if: ${{ inputs.run-interaction }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        name: Checkout repository
+
+      - uses: theholocron/.github/.github/actions/setup@main
+        name: Setup
+
+      - run: pnpm exec playwright install --with-deps
+        name: Install Playwright
+
+      - run: pnpm test:storybook
+        name: Run interaction and accessibility tests
+
+  user-flow:
+    name: Test User Flow
+    if: ${{ inputs.run-user-flow }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1, 2]
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        name: Checkout repository
+
+      - uses: theholocron/.github/.github/actions/setup@main
+        name: Setup
+
+      - uses: cypress-io/github-action@1052aa98bbbe4f55210f844878213c07d9c8c399 # v6.7.13
+        name: Cypress run
+        with:
+          start: pnpm dev
+          wait-on: "http://localhost:5173"
+          record: true
+          parallel: true
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Restores the four conditional jobs stripped in #315 and fixes the root cause of the `startup_failure`.

- **`statuses: write` added to thin caller template** — GitHub validates permissions for all `workflow_call` jobs at startup, even conditionally skipped ones. The `visual-and-composition` job declares `statuses: write` (needed for Chromatic to post commit status checks), but callers only granted `contents: read` and `id-token: write` — causing `startup_failure` on every caller of `test.yml@main`
- **`github.token` instead of `secrets.GITHUB_TOKEN`** in the Chromatic job — correct approach for reusable workflows

## Root cause investigation

Bisected via debug PRs in `theholocron/clients` (#258–#263), adding jobs back one at a time:

| Job | Result |
|---|---|
| `storybook` | ✅ passes |
| `interaction-and-accessibility` | ✅ passes |
| `visual-and-composition` with `statuses: write` | ❌ startup_failure |
| `visual-and-composition` without `statuses: write` | ✅ passes |
| `user-flow` | ✅ passes |

## Test plan

- [ ] Merge → release → `holocron setup` in a consuming repo → confirm `test.yml` gains `statuses: write`
- [ ] Sync to `.github` → confirm `Test / Run tests and collect coverage` passes on a consuming repo PR