### PR TITLE
feat(lint): add enable-stylelint opt-in input to shared lint workflow

### DIFF
--- a/packages/cli/src/templates/workflows/lint.yml
+++ b/packages/cli/src/templates/workflows/lint.yml
@@ -40,6 +40,14 @@ on: # yamllint disable-line rule:truthy
         type: boolean
         required: false
         default: false
+      enable-stylelint:
+        description: >
+          Run stylelint on CSS files after super-linter. Opt-in for repos that
+          have CSS and a stylelint config. Requires pnpm and stylelint to be
+          installed as dev dependencies.
+        type: boolean
+        required: false
+        default: false
     secrets:
       SUPER_LINTER_APP_ID:
         required: false
@@ -140,6 +148,10 @@ jobs:
           VALIDATE_TYPESCRIPT_PRETTIER: true
           VALIDATE_YAML: true
           YAML_CONFIG_FILE: ${{ inputs.yaml-config }}
+
+      - name: Run Stylelint
+        if: inputs.enable-stylelint == true && hashFiles('pnpm-lock.yaml') != ''
+        run: pnpm exec stylelint "**/*.{css,scss,sass}" --ignore-path .gitignore
 
       - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         name: Commit and push linting fixes

--- a/packages/cli/src/templates/workflows/lint.yml
+++ b/packages/cli/src/templates/workflows/lint.yml
@@ -42,12 +42,18 @@ on: # yamllint disable-line rule:truthy
         default: false
       enable-stylelint:
         description: >
-          Run stylelint on CSS files after super-linter. Opt-in for repos that
-          have CSS and a stylelint config. Requires pnpm and stylelint to be
-          installed as dev dependencies.
+          Enable super-linter's built-in stylelint for CSS, SCSS, and Less files.
+          Opt-in for repos that have CSS and a stylelint config.
         type: boolean
         required: false
         default: false
+      stylelint-config:
+        description: >
+          Path to the stylelint config file. Defaults to stylelint.config.ts
+          (the org standard). Override if your repo uses a different filename.
+        type: string
+        required: false
+        default: stylelint.config.ts
     secrets:
       SUPER_LINTER_APP_ID:
         required: false
@@ -146,12 +152,10 @@ jobs:
           VALIDATE_MARKDOWN_PRETTIER: true
           VALIDATE_TSX: true
           VALIDATE_TYPESCRIPT_PRETTIER: true
+          VALIDATE_CSS: ${{ inputs.enable-stylelint }}
           VALIDATE_YAML: true
           YAML_CONFIG_FILE: ${{ inputs.yaml-config }}
-
-      - name: Run Stylelint
-        if: inputs.enable-stylelint == true && hashFiles('pnpm-lock.yaml') != ''
-        run: pnpm exec stylelint "**/*.{css,scss,sass}" --ignore-path .gitignore
+          STYLELINT_CONFIG_FILE: ${{ inputs.stylelint-config }}
 
       - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         name: Commit and push linting fixes


### PR DESCRIPTION
## Summary

- Adds `enable-stylelint` boolean input (default `false`) to the shared `lint.yml` workflow
- When `true`, runs `pnpm exec stylelint "**/*.{css,scss,sass}"` after super-linter
- Guard: only runs in repos with a `pnpm-lock.yaml` (i.e. pnpm workspaces with stylelint installed)
- Repos opt in via `holocron.config.ts` — e.g. `{ name: "lint", with: { "enable-stylelint": true } }`

## Test plan

- [ ] Merge and let `sync-workflow-templates` push the updated shared workflow to `theholocron/.github`
- [ ] Wire opt-in in a consuming repo (react-template) and confirm the step runs on PR