### PR TITLE
fix: bump chromaui/action from v13 to v18

### DIFF
--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -132,7 +132,7 @@ jobs:
       - uses: theholocron/.github/.github/actions/setup@main
         name: Setup
 
-      - uses: chromaui/action@07791f8243f4cb2698bf4d00426baf4b2d1cb7e0 # v13
+      - uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18
         name: Publish to Chromatic
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

- Bumps `chromaui/action` from v13 (SHA `07791f8`) to v18 (SHA `14cfaef`) in the shared test workflow template
- Resolves the "Chromatic CLI version 13.3.5 is significantly outdated" warning — v18 bundles CLI 18.1.0

## Test plan

- [ ] Merge and let `sync-workflow-templates` push the updated shared workflow to `theholocron/.github`
- [ ] Confirm Chromatic builds no longer show the outdated CLI warning