### PR TITLE
fix(lint): always enable VALIDATE_CSS in super-linter, drop enable-stylelint opt-in

### DIFF
--- a/packages/cli/src/templates/workflows/lint.yml
+++ b/packages/cli/src/templates/workflows/lint.yml
@@ -40,14 +40,6 @@ on: # yamllint disable-line rule:truthy
         type: boolean
         required: false
         default: false
-      enable-stylelint:
-        description: >
-          Run stylelint on CSS, SCSS, and Sass files. Opt-in for repos that
-          have CSS and a stylelint config. Requires pnpm and stylelint to be
-          installed as dev dependencies.
-        type: boolean
-        required: false
-        default: false
     secrets:
       SUPER_LINTER_APP_ID:
         required: false
@@ -145,13 +137,11 @@ jobs:
           VALIDATE_JSX_PRETTIER: true
           VALIDATE_MARKDOWN_PRETTIER: true
           VALIDATE_TSX: true
+          VALIDATE_CSS: true
           VALIDATE_TYPESCRIPT_PRETTIER: true
           VALIDATE_YAML: true
           YAML_CONFIG_FILE: ${{ inputs.yaml-config }}
-
-      - name: Run Stylelint
-        if: inputs.enable-stylelint == true && hashFiles('pnpm-lock.yaml') != ''
-        run: pnpm exec stylelint "**/*.{css,scss,sass}" --ignore-path .gitignore
+          STYLELINT_CONFIG_FILE: stylelint.config.ts
 
       - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         name: Commit and push linting fixes

--- a/packages/cli/src/templates/workflows/lint.yml
+++ b/packages/cli/src/templates/workflows/lint.yml
@@ -42,18 +42,12 @@ on: # yamllint disable-line rule:truthy
         default: false
       enable-stylelint:
         description: >
-          Enable super-linter's built-in stylelint for CSS, SCSS, and Less files.
-          Opt-in for repos that have CSS and a stylelint config.
+          Run stylelint on CSS, SCSS, and Sass files. Opt-in for repos that
+          have CSS and a stylelint config. Requires pnpm and stylelint to be
+          installed as dev dependencies.
         type: boolean
         required: false
         default: false
-      stylelint-config:
-        description: >
-          Path to the stylelint config file. Defaults to stylelint.config.ts
-          (the org standard). Override if your repo uses a different filename.
-        type: string
-        required: false
-        default: stylelint.config.ts
     secrets:
       SUPER_LINTER_APP_ID:
         required: false
@@ -152,10 +146,12 @@ jobs:
           VALIDATE_MARKDOWN_PRETTIER: true
           VALIDATE_TSX: true
           VALIDATE_TYPESCRIPT_PRETTIER: true
-          VALIDATE_CSS: ${{ inputs.enable-stylelint }}
           VALIDATE_YAML: true
           YAML_CONFIG_FILE: ${{ inputs.yaml-config }}
-          STYLELINT_CONFIG_FILE: ${{ inputs.stylelint-config }}
+
+      - name: Run Stylelint
+        if: inputs.enable-stylelint == true && hashFiles('pnpm-lock.yaml') != ''
+        run: pnpm exec stylelint "**/*.{css,scss,sass}" --ignore-path .gitignore
 
       - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         name: Commit and push linting fixes


### PR DESCRIPTION
## Summary

- Adds `VALIDATE_CSS: true` and `STYLELINT_CONFIG_FILE: stylelint.config.ts` permanently to the super-linter env
- Removes the `enable-stylelint` opt-in input — no longer needed
- Super-linter skips gracefully when no CSS files are found, and auto-lints when they are

## Why

Setting `VALIDATE_CSS: ${{ inputs.enable-stylelint }}` evaluates to `false` for repos that don't opt in, which conflicts with the other `VALIDATE_*: true` entries — super-linter forbids mixing include and exclude modes.

The simpler fix: always enable `VALIDATE_CSS: true`. Super-linter only runs stylelint when CSS/SCSS files exist, so repos without CSS are unaffected.

## Test plan

- [ ] Merge and sync to `theholocron/.github`
- [ ] Confirm CSS-less repos pass lint (no files found = pass)
- [ ] Confirm react-template lint catches CSS errors