### PR TITLE
feat: add HOLOCRON_ORG_TOKEN for org-scoped setup operations

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1712,7 +1712,7 @@ describe("runSetup — 403 handling", () => {
 		expect(output).toContain("⚠");
 		expect(output).toContain("insufficient token permissions");
 		expect(output).toContain("personal-access-tokens/new");
-		expect(output).toContain("--token <your-temp-pat>");
+		expect(output).toContain("--token <your-admin-pat>");
 	});
 
 	it("does not emit the hint when all failures are plan restrictions", async () => {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -875,8 +875,8 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	if (steps.some((s) => s.reason === "permissions")) {
 		print("");
 		print(style.warn("Some steps failed with 403 (insufficient token permissions)."));
-		print(style.hint("     These operations require a temporary fine-grained PAT with the"));
-		print(style.hint("     following repository permissions:"));
+		print(style.hint("     Repo-scoped operations (rulesets, settings, workflows) require a"));
+		print(style.hint("     fine-grained PAT passed via --token or HOLOCRON_ADMIN_TOKEN:"));
 		print("");
 		print(style.hint("       · Administration          — read and write"));
 		print(style.hint("       · Code scanning alerts    — read and write"));
@@ -885,9 +885,15 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		print(style.hint("       · Workflows               — read and write"));
 		print(style.hint("       · Metadata                — read (added automatically)"));
 		print("");
-		print(style.hint("     Create one at: https://github.com/settings/personal-access-tokens/new"));
-		print(style.hint("     Then re-run:   holocron setup --token <your-temp-pat>"));
-		print(style.hint("     You can revoke it immediately after setup completes."));
+		print(style.hint("     Org-scoped operations (teams, custom properties) additionally require"));
+		print(style.hint("     HOLOCRON_ORG_TOKEN — a PAT scoped to the org with:"));
+		print("");
+		print(style.hint("       · Members                     — read and write"));
+		print(style.hint("       · Organization custom properties — read and write"));
+		print("");
+		print(style.hint("     Create tokens at: https://github.com/settings/personal-access-tokens/new"));
+		print(style.hint("     Then re-run:      holocron setup --token <your-admin-pat>"));
+		print(style.hint("     Store org token:  HOLOCRON_ORG_TOKEN env var or keyring key github.org"));
 	}
 
 	return { steps, summary };

--- a/packages/holocron-plugin-github/src/auth.ts
+++ b/packages/holocron-plugin-github/src/auth.ts
@@ -32,3 +32,8 @@ export const resolveDeployToken = createFeatureResolver({
 	envName: "HOLOCRON_DEPLOY_TOKEN",
 	keyringKey: "github.deploy",
 });
+
+export const resolveOrgToken = createFeatureResolver({
+	envName: "HOLOCRON_ORG_TOKEN",
+	keyringKey: "github.org",
+});

--- a/packages/holocron-plugin-github/src/capabilities/source.ts
+++ b/packages/holocron-plugin-github/src/capabilities/source.ts
@@ -17,6 +17,8 @@ import { syncTopics } from "./topics.js";
 export interface SourceOptions {
 	repo: string;
 	repoRoot: string;
+	/** Secondary client authenticated with HOLOCRON_ORG_TOKEN for org-scoped operations (teams, custom properties). */
+	orgClient?: GitHubClient;
 	/** Forwarded to a secondary client created for Pages calls (HOLOCRON_DEPLOY_TOKEN). */
 	baseUrl?: string;
 	fetch?: typeof fetch;
@@ -31,6 +33,7 @@ export class GitHubSource implements Source {
 	private readonly repo: string;
 	private readonly repoRoot: string;
 	private readonly workflowDir: string;
+	private readonly orgClient?: GitHubClient;
 	private readonly baseUrl?: string;
 	private readonly fetchImpl?: typeof fetch;
 
@@ -44,6 +47,7 @@ export class GitHubSource implements Source {
 		this.repo = opts.repo;
 		this.repoRoot = opts.repoRoot;
 		this.workflowDir = join(opts.repoRoot, ".github", "workflows");
+		this.orgClient = opts.orgClient;
 		this.baseUrl = opts.baseUrl;
 		this.fetchImpl = opts.fetch;
 	}
@@ -155,11 +159,11 @@ export class GitHubSource implements Source {
 	}
 
 	async syncProperties(values: Record<string, string>): Promise<string> {
-		return syncProperties(this.client, this.repo, values);
+		return syncProperties(this.orgClient ?? this.client, this.repo, values);
 	}
 
 	async syncTeams(teams: TeamEntry[]): Promise<string> {
-		return syncTeams(this.client, this.repo, teams);
+		return syncTeams(this.orgClient ?? this.client, this.repo, teams);
 	}
 
 	async syncTopics(topics: string[]): Promise<string> {

--- a/packages/holocron-plugin-github/src/index.ts
+++ b/packages/holocron-plugin-github/src/index.ts
@@ -11,7 +11,13 @@
 import type { Auth, Ci, Environments, Issues, Secrets, Source } from "@theholocron/cli";
 import { createGitHubClient, type GitHubClient } from "@theholocron/github-client";
 
-import { resolveAdminToken, resolveIssuesToken, resolveOrgToken, resolveReadToken, type ResolveTokenInput } from "./auth.js";
+import {
+	resolveAdminToken,
+	resolveIssuesToken,
+	resolveOrgToken,
+	resolveReadToken,
+	type ResolveTokenInput,
+} from "./auth.js";
 import { GitHubCi } from "./capabilities/ci.js";
 import { GitHubEnvironments } from "./capabilities/environments.js";
 import { GitHubIssues, type IssuesOptions } from "./capabilities/issues.js";

--- a/packages/holocron-plugin-github/src/index.ts
+++ b/packages/holocron-plugin-github/src/index.ts
@@ -11,7 +11,7 @@
 import type { Auth, Ci, Environments, Issues, Secrets, Source } from "@theholocron/cli";
 import { createGitHubClient, type GitHubClient } from "@theholocron/github-client";
 
-import { resolveAdminToken, resolveIssuesToken, resolveReadToken, type ResolveTokenInput } from "./auth.js";
+import { resolveAdminToken, resolveIssuesToken, resolveOrgToken, resolveReadToken, type ResolveTokenInput } from "./auth.js";
 import { GitHubCi } from "./capabilities/ci.js";
 import { GitHubEnvironments } from "./capabilities/environments.js";
 import { GitHubIssues, type IssuesOptions } from "./capabilities/issues.js";
@@ -41,10 +41,11 @@ export interface PluginContext {
 
 // ── Capability factories ──────────────────────────────────────────────
 
-export function source(ctx: PluginContext): Source {
+export function source(ctx: PluginContext, orgClient?: GitHubClient): Source {
 	return new GitHubSource(ctx.client, {
 		repo: ctx.repo,
 		repoRoot: ctx.repoRoot,
+		orgClient,
 		baseUrl: ctx.options.baseUrl,
 		fetch: ctx.options.fetch,
 	});
@@ -86,10 +87,19 @@ export function createPlugin(options: GitHubPluginOptions) {
 		};
 	}
 
+	function makeOrgClient(): GitHubClient | undefined {
+		try {
+			const token = resolveOrgToken(options);
+			return createGitHubClient({ token, baseUrl: options.baseUrl, fetch: options.fetch });
+		} catch {
+			return undefined;
+		}
+	}
+
 	return {
 		name: "@theholocron/holocron-plugin-github",
 		capabilities: {
-			source: () => source(makeCtx(resolveAdminToken)),
+			source: () => source(makeCtx(resolveAdminToken), makeOrgClient()),
 			ci: () => ci(makeCtx(resolveReadToken)),
 			secrets: () => secrets(makeCtx(resolveAdminToken)),
 			environments: () => environments(makeCtx(resolveAdminToken)),


### PR DESCRIPTION
## Summary

- Adds `resolveOrgToken` to `auth.ts` — reads from `HOLOCRON_ORG_TOKEN` env var or keyring key `github.org`
- `GitHubSource` accepts an optional `orgClient` and routes `syncTeams` and `syncProperties` through it (falls back to the admin client if not set)
- `createPlugin` tries to resolve the org token and creates a secondary client — silently skips if not configured so existing setups are unaffected
- Updates the 403 hint in `setup.ts` to distinguish repo-scoped vs org-scoped permission requirements and mention `HOLOCRON_ORG_TOKEN`

## Why

Team and custom property sync require org-level GitHub API permissions that can't be granted to a repo-scoped PAT. A separate org-scoped PAT (`HOLOCRON_ORG_TOKEN`) allows these two operations to succeed without requiring a fully privileged token for everything.

## Required scopes for `HOLOCRON_ORG_TOKEN`

Fine-grained PAT scoped to the **org** (not individual repos):
- `Members` — read and write
- `Organization custom properties` — read and write

## Keyring key

`github.org` — consistent with the existing `github.admin`, `github.read`, etc. pattern.