### PR TITLE
feat: ✨ add sync-readme command

### DIFF
--- a/packages/cli/src/__tests__/sync-readme.test.ts
+++ b/packages/cli/src/__tests__/sync-readme.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { resolveConfig } from "../config.js";
 import { runSyncReadme } from "../commands/sync-readme.js";
+import { resolveConfig } from "../config.js";
 import type { LoadedConfig } from "../load-config.js";
 
 function makeLoaded(overrides: Partial<Parameters<typeof resolveConfig>[0]> = {}): LoadedConfig {

--- a/packages/cli/src/__tests__/sync-readme.test.ts
+++ b/packages/cli/src/__tests__/sync-readme.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveConfig } from "../config.js";
+import { runSyncReadme } from "../commands/sync-readme.js";
+import type { LoadedConfig } from "../load-config.js";
+
+function makeLoaded(overrides: Partial<Parameters<typeof resolveConfig>[0]> = {}): LoadedConfig {
+	return {
+		resolved: resolveConfig({
+			name: "my-cli",
+			providers: { source: "github" },
+			...overrides,
+		}),
+		filepath: "/tmp/test/holocron.config.ts",
+	};
+}
+
+function makeFs(files: Record<string, string>) {
+	const written: Record<string, string> = {};
+	const readFileFn = vi.fn(async (path: string) => {
+		if (path in files) return files[path]!;
+		throw new Error(`ENOENT: ${path}`);
+	}) as unknown as (path: string, encoding: BufferEncoding) => Promise<string>;
+	const writeFileFn = vi.fn(async (path: string, content: string) => {
+		written[path] = content;
+	}) as unknown as (path: string, content: string, encoding: BufferEncoding) => Promise<void>;
+	return { readFileFn, writeFileFn, written };
+}
+
+const CLI_PKG = JSON.stringify({ name: "@scope/my-cli", bin: { "my-cli": "./dist/cli.mjs" } });
+const LIB_PKG = JSON.stringify({ name: "@scope/my-lib" });
+const REACT_PKG = JSON.stringify({ name: "@scope/my-react", peerDependencies: { react: "^19" } });
+
+const README_WITH_MARKERS = [
+	"# My CLI",
+	"<!-- holocron:installation -->",
+	"old content",
+	"<!-- /holocron:installation -->",
+	"## More",
+].join("\n");
+
+const README_WITH_DESC = [
+	"# My CLI",
+	"<!-- holocron:description -->",
+	"A description.",
+	"<!-- /holocron:description -->",
+	"## Releases",
+].join("\n");
+
+const README_BARE = "# My CLI\n## Releases";
+
+// --- runSyncReadme ---
+
+describe("runSyncReadme", () => {
+	it("returns fail when package.json cannot be read", async () => {
+		const { readFileFn, writeFileFn } = makeFs({});
+		const report = await runSyncReadme({
+			loaded: makeLoaded(),
+			context: { repoRoot: "/tmp/test" },
+			print: () => {},
+			readFileFn,
+			writeFileFn,
+		});
+		expect(report).toMatchObject({ status: "fail", updated: false });
+	});
+
+	it("returns fail when README.md cannot be read or has no anchor", async () => {
+		const { readFileFn, writeFileFn } = makeFs({ "/tmp/test/package.json": CLI_PKG });
+		const report = await runSyncReadme({
+			loaded: makeLoaded(),
+			context: { repoRoot: "/tmp/test" },
+			print: () => {},
+			readFileFn,
+			writeFileFn,
+		});
+		expect(report).toMatchObject({ status: "fail", updated: false });
+	});
+
+	it("replaces content between existing markers", async () => {
+		const { readFileFn, writeFileFn, written } = makeFs({
+			"/tmp/test/package.json": CLI_PKG,
+			"/tmp/test/README.md": README_WITH_MARKERS,
+		});
+		const report = await runSyncReadme({
+			loaded: makeLoaded(),
+			context: { repoRoot: "/tmp/test" },
+			print: () => {},
+			readFileFn,
+			writeFileFn,
+		});
+		expect(report).toMatchObject({ status: "ok", updated: true });
+		expect(written["/tmp/test/README.md"]).toContain("npm install --global @scope/my-cli");
+		expect(written["/tmp/test/README.md"]).toContain("my-cli --help");
+		expect(written["/tmp/test/README.md"]).not.toContain("old content");
+	});
+
+	it("inserts markers after description block when none exist", async () => {
+		const { readFileFn, writeFileFn, written } = makeFs({
+			"/tmp/test/package.json": CLI_PKG,
+			"/tmp/test/README.md": README_WITH_DESC,
+		});
+		const report = await runSyncReadme({
+			loaded: makeLoaded(),
+			context: { repoRoot: "/tmp/test" },
+			print: () => {},
+			readFileFn,
+			writeFileFn,
+		});
+		expect(report).toMatchObject({ status: "ok", updated: true });
+		expect(written["/tmp/test/README.md"]).toContain("<!-- holocron:installation -->");
+		expect(written["/tmp/test/README.md"]).toContain("<!-- /holocron:installation -->");
+	});
+
+	it("inserts markers after h1 when no description block exists", async () => {
+		const { readFileFn, writeFileFn, written } = makeFs({
+			"/tmp/test/package.json": CLI_PKG,
+			"/tmp/test/README.md": README_BARE,
+		});
+		const report = await runSyncReadme({
+			loaded: makeLoaded(),
+			context: { repoRoot: "/tmp/test" },
+			print: () => {},
+			readFileFn,
+			writeFileFn,
+		});
+		expect(report).toMatchObject({ status: "ok", updated: true });
+		expect(written["/tmp/test/README.md"]).toContain("<!-- holocron:installation -->");
+	});
+
+	it("does not write in dry-run mode", async () => {
+		const { readFileFn, writeFileFn } = makeFs({
+			"/tmp/test/package.json": CLI_PKG,
+			"/tmp/test/README.md": README_WITH_MARKERS,
+		});
+		const report = await runSyncReadme({
+			loaded: makeLoaded(),
+			context: { repoRoot: "/tmp/test", dryRun: true },
+			print: () => {},
+			readFileFn,
+			writeFileFn,
+		});
+		expect(report).toMatchObject({ status: "dry-run", updated: true });
+		expect(writeFileFn).not.toHaveBeenCalled();
+	});
+
+	it("prints namespaces when env.namespaces is configured", async () => {
+		const printed: string[] = [];
+		const { readFileFn, writeFileFn } = makeFs({
+			"/tmp/test/package.json": CLI_PKG,
+			"/tmp/test/README.md": README_WITH_MARKERS,
+		});
+		await runSyncReadme({
+			loaded: makeLoaded({ env: { namespaces: ["HOLOCRON", "MY_CLI"] } }),
+			context: { repoRoot: "/tmp/test" },
+			print: (l) => printed.push(l),
+			readFileFn,
+			writeFileFn,
+		});
+		expect(printed.some((l) => l.includes("HOLOCRON") && l.includes("MY_CLI"))).toBe(true);
+	});
+
+	// --- block generation by repo type ---
+
+	it("generates npm install --global for CLI repos (has bin)", async () => {
+		const { readFileFn, writeFileFn, written } = makeFs({
+			"/tmp/test/package.json": CLI_PKG,
+			"/tmp/test/README.md": README_WITH_MARKERS,
+		});
+		await runSyncReadme({
+			loaded: makeLoaded(),
+			context: { repoRoot: "/tmp/test" },
+			print: () => {},
+			readFileFn,
+			writeFileFn,
+		});
+		expect(written["/tmp/test/README.md"]).toContain("npm install --global");
+		expect(written["/tmp/test/README.md"]).toContain("my-cli --help");
+	});
+
+	it("generates pnpm install for library repos (no bin, no react peer)", async () => {
+		const { readFileFn, writeFileFn, written } = makeFs({
+			"/tmp/test/package.json": LIB_PKG,
+			"/tmp/test/README.md": README_WITH_MARKERS,
+		});
+		await runSyncReadme({
+			loaded: makeLoaded(),
+			context: { repoRoot: "/tmp/test" },
+			print: () => {},
+			readFileFn,
+			writeFileFn,
+		});
+		expect(written["/tmp/test/README.md"]).toContain("pnpm install");
+		expect(written["/tmp/test/README.md"]).toContain("```typescript");
+	});
+
+	it("generates tsx snippet for React library repos (react peer dep)", async () => {
+		const { readFileFn, writeFileFn, written } = makeFs({
+			"/tmp/test/package.json": REACT_PKG,
+			"/tmp/test/README.md": README_WITH_MARKERS,
+		});
+		await runSyncReadme({
+			loaded: makeLoaded(),
+			context: { repoRoot: "/tmp/test" },
+			print: () => {},
+			readFileFn,
+			writeFileFn,
+		});
+		expect(written["/tmp/test/README.md"]).toContain("```tsx");
+		expect(written["/tmp/test/README.md"]).toContain("function App()");
+	});
+
+	it("handles bin as a plain string", async () => {
+		const pkg = JSON.stringify({ name: "@scope/my-cli", bin: "./dist/cli.mjs" });
+		const { readFileFn, writeFileFn, written } = makeFs({
+			"/tmp/test/package.json": pkg,
+			"/tmp/test/README.md": README_WITH_MARKERS,
+		});
+		await runSyncReadme({
+			loaded: makeLoaded(),
+			context: { repoRoot: "/tmp/test" },
+			print: () => {},
+			readFileFn,
+			writeFileFn,
+		});
+		expect(written["/tmp/test/README.md"]).toContain("npm install --global");
+	});
+});
+
+// --- config: EnvConfig ---
+
+describe("EnvConfig in HolocronConfig", () => {
+	it("resolveConfig passes env.namespaces through to resolved config", () => {
+		const resolved = resolveConfig({
+			name: "my-cli",
+			providers: { source: "github" },
+			env: { namespaces: ["HOLOCRON", "MY_CLI"] },
+		});
+		expect(resolved.env).toEqual({ namespaces: ["HOLOCRON", "MY_CLI"] });
+	});
+
+	it("resolved config has no env field when not set", () => {
+		const resolved = resolveConfig({ name: "my-cli", providers: { source: "github" } });
+		expect(resolved.env).toBeUndefined();
+	});
+});

--- a/packages/cli/src/__tests__/sync-readme.test.ts
+++ b/packages/cli/src/__tests__/sync-readme.test.ts
@@ -127,7 +127,7 @@ describe("runSyncReadme", () => {
 		expect(written["/tmp/test/README.md"]).toContain("<!-- holocron:installation -->");
 	});
 
-	it("does not write in dry-run mode", async () => {
+	it("does not write in dry-run mode (existing markers)", async () => {
 		const { readFileFn, writeFileFn } = makeFs({
 			"/tmp/test/package.json": CLI_PKG,
 			"/tmp/test/README.md": README_WITH_MARKERS,
@@ -141,6 +141,37 @@ describe("runSyncReadme", () => {
 		});
 		expect(report).toMatchObject({ status: "dry-run", updated: true });
 		expect(writeFileFn).not.toHaveBeenCalled();
+	});
+
+	it("does not write in dry-run mode (no markers, inserts after h1)", async () => {
+		const { readFileFn, writeFileFn } = makeFs({
+			"/tmp/test/package.json": CLI_PKG,
+			"/tmp/test/README.md": README_BARE,
+		});
+		const report = await runSyncReadme({
+			loaded: makeLoaded(),
+			context: { repoRoot: "/tmp/test", dryRun: true },
+			print: () => {},
+			readFileFn,
+			writeFileFn,
+		});
+		expect(report).toMatchObject({ status: "dry-run", updated: true });
+		expect(writeFileFn).not.toHaveBeenCalled();
+	});
+
+	it("returns fail when README has no h1 and no markers", async () => {
+		const { readFileFn, writeFileFn } = makeFs({
+			"/tmp/test/package.json": CLI_PKG,
+			"/tmp/test/README.md": "No heading here at all.",
+		});
+		const report = await runSyncReadme({
+			loaded: makeLoaded(),
+			context: { repoRoot: "/tmp/test" },
+			print: () => {},
+			readFileFn,
+			writeFileFn,
+		});
+		expect(report).toMatchObject({ status: "fail", updated: false });
 	});
 
 	it("prints namespaces when env.namespaces is configured", async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -21,6 +21,7 @@ import { runSetup } from "./commands/setup.js";
 import { runSkillsInstall, runSkillsRemove, runSkillsUpdate } from "./commands/skills.js";
 import { runSync } from "./commands/sync.js";
 import { runSyncGithub } from "./commands/sync-github.js";
+import { runSyncReadme } from "./commands/sync-readme.js";
 import { runUpgradeNode } from "./commands/upgrade-node.js";
 import { loadConfig } from "./load-config.js";
 import { captureException, endSession, flush, init, startCommand } from "./telemetry.js";
@@ -504,6 +505,24 @@ try {
 				if (report.status === "fail") {
 					process.exitCode = 1;
 				}
+			}
+		)
+		.command(
+			"sync-readme",
+			"Sync the Installation + Usage block in README.md from package.json",
+			(y) =>
+				y.option("dry-run", {
+					type: "boolean",
+					describe: "Print what would change without writing",
+					default: false,
+				}),
+			async (argv) => {
+				const loaded = await loadConfig(argv.cwd);
+				const report = await runSyncReadme({
+					loaded,
+					context: { repoRoot: argv.cwd, dryRun: argv.dryRun },
+				});
+				if (report.status === "fail") process.exitCode = 1;
 			}
 		)
 		.command(

--- a/packages/cli/src/commands/sync-readme.ts
+++ b/packages/cli/src/commands/sync-readme.ts
@@ -1,0 +1,153 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { LoadedConfig } from "../load-config.js";
+import type { RuntimeContext } from "../loader.js";
+import { style } from "../ui/style.js";
+
+const README_INSTALL_START = "<!-- holocron:installation -->";
+const README_INSTALL_END = "<!-- /holocron:installation -->";
+
+interface PackageJson {
+	name?: string;
+	bin?: Record<string, string> | string;
+	peerDependencies?: Record<string, string>;
+}
+
+export interface RunSyncReadmeInput {
+	loaded: LoadedConfig;
+	context: RuntimeContext;
+	print?: (line: string) => void;
+	readFileFn?: (path: string, encoding: BufferEncoding) => Promise<string>;
+	writeFileFn?: (path: string, content: string, encoding: BufferEncoding) => Promise<void>;
+}
+
+export interface SyncReadmeReport {
+	status: "ok" | "fail" | "dry-run";
+	updated: boolean;
+	message?: string;
+}
+
+function generateInstallBlock(pkg: PackageJson, description: string): string {
+	const { name = "", bin, peerDependencies = {} } = pkg;
+	const isCli = Boolean(bin);
+	const isReact = Boolean(peerDependencies["react"]);
+	const lines: string[] = [];
+
+	lines.push("## Installation", "");
+
+	if (isCli) {
+		lines.push("```bash", `npm install --global ${name}`, "```");
+	} else {
+		lines.push("```bash", `pnpm install ${name}`, "```");
+	}
+
+	lines.push("", "## Usage", "");
+
+	if (isCli) {
+		const commands =
+			typeof bin === "string" || !bin ? [name.split("/").pop() ?? name] : Object.keys(bin);
+		lines.push("```bash");
+		for (const cmd of commands) {
+			lines.push(`${cmd} --help`);
+		}
+		lines.push("```");
+	} else if (isReact) {
+		lines.push(
+			"```tsx",
+			`import { } from "${name}";`,
+			"",
+			"function App() {",
+			`  return <></>;`,
+			"}",
+			"```"
+		);
+	} else {
+		lines.push("```typescript", `import { } from "${name}";`, "```");
+	}
+
+	return lines.join("\n");
+}
+
+async function updateReadmeInstallation(
+	repoRoot: string,
+	block: string,
+	dryRun: boolean,
+	readFileFn: (path: string, encoding: BufferEncoding) => Promise<string>,
+	writeFileFn: (path: string, content: string, encoding: BufferEncoding) => Promise<void>
+): Promise<boolean> {
+	const readmePath = join(repoRoot, "README.md");
+	let content: string;
+	try {
+		content = await readFileFn(readmePath, "utf8");
+	} catch {
+		return false;
+	}
+
+	const lines = content.split("\n");
+	const startIdx = lines.findIndex((l) => l.trim() === README_INSTALL_START);
+	const endIdx = lines.findIndex((l) => l.trim() === README_INSTALL_END);
+
+	const blockLines = block.split("\n");
+
+	if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+		if (dryRun) return true;
+		lines.splice(startIdx + 1, endIdx - startIdx - 1, "", ...blockLines, "");
+		await writeFileFn(readmePath, lines.join("\n"), "utf8");
+		return true;
+	}
+
+	// No markers — find the first ## heading after the description block and insert before it
+	const descEnd = lines.findIndex((l) => l.trim() === "<!-- /holocron:description -->");
+	const insertAfter = descEnd !== -1 ? descEnd : lines.findIndex((l) => /^# /.test(l));
+	if (insertAfter === -1) return false;
+
+	if (dryRun) return true;
+	lines.splice(
+		insertAfter + 1,
+		0,
+		"",
+		README_INSTALL_START,
+		"",
+		...blockLines,
+		"",
+		README_INSTALL_END
+	);
+	await writeFileFn(readmePath, lines.join("\n"), "utf8");
+	return true;
+}
+
+export async function runSyncReadme(input: RunSyncReadmeInput): Promise<SyncReadmeReport> {
+	const {
+		loaded,
+		context,
+		print = console.log,
+		readFileFn = readFile,
+		writeFileFn = writeFile,
+	} = input;
+
+	const { repoRoot, dryRun = false } = context;
+	const { description = "" } = loaded.resolved;
+
+	print(style.header(`Syncing README installation block${dryRun ? " (dry-run)" : ""}…`));
+
+	// Read package.json
+	let pkg: PackageJson = {};
+	try {
+		const raw = await readFileFn(join(repoRoot, "package.json"), "utf8");
+		pkg = JSON.parse(raw) as PackageJson;
+	} catch {
+		return { status: "fail", updated: false, message: "Could not read package.json" };
+	}
+
+	const block = generateInstallBlock(pkg, description);
+	const updated = await updateReadmeInstallation(repoRoot, block, dryRun, readFileFn, writeFileFn);
+
+	if (!updated) {
+		print(style.warn("README.md not found or has no writable location for installation block"));
+		return { status: "fail", updated: false, message: "README.md update failed" };
+	}
+
+	print(dryRun ? style.hint("  would update README.md") : style.success("  updated README.md"));
+	return { status: dryRun ? "dry-run" : "ok", updated };
+}

--- a/packages/cli/src/commands/sync-readme.ts
+++ b/packages/cli/src/commands/sync-readme.ts
@@ -103,7 +103,6 @@ export async function runSyncReadme(input: RunSyncReadmeInput): Promise<SyncRead
 	const { loaded, context, print = console.log, readFileFn = readFile, writeFileFn = writeFile } = input;
 
 	const { repoRoot, dryRun = false } = context;
-	const { description = "" } = loaded.resolved;
 
 	const namespaces = loaded.resolved.env?.namespaces ?? [];
 

--- a/packages/cli/src/commands/sync-readme.ts
+++ b/packages/cli/src/commands/sync-readme.ts
@@ -45,7 +45,7 @@ function generateInstallBlock(pkg: PackageJson): string {
 	lines.push("", "## Usage", "");
 
 	if (isCli) {
-		const commands = typeof bin === "string" || !bin ? [name.split("/").pop() ?? name] : Object.keys(bin);
+		const commands = typeof bin === "string" ? [name.split("/").at(-1)!] : Object.keys(bin);
 		lines.push("```bash");
 		for (const cmd of commands) {
 			lines.push(`${cmd} --help`);
@@ -112,7 +112,7 @@ export async function runSyncReadme(input: RunSyncReadmeInput): Promise<SyncRead
 	}
 
 	// Read package.json
-	let pkg: PackageJson = {};
+	let pkg: PackageJson;
 	try {
 		const raw = await readFileFn(join(repoRoot, "package.json"), "utf8");
 		pkg = JSON.parse(raw) as PackageJson;

--- a/packages/cli/src/commands/sync-readme.ts
+++ b/packages/cli/src/commands/sync-readme.ts
@@ -105,7 +105,12 @@ export async function runSyncReadme(input: RunSyncReadmeInput): Promise<SyncRead
 	const { repoRoot, dryRun = false } = context;
 	const { description = "" } = loaded.resolved;
 
+	const namespaces = loaded.resolved.env?.namespaces ?? [];
+
 	print(style.header(`Syncing README installation block${dryRun ? " (dry-run)" : ""}…`));
+	if (namespaces.length > 0) {
+		print(style.hint(`  namespaces: ${namespaces.join(", ")}`));
+	}
 
 	// Read package.json
 	let pkg: PackageJson = {};

--- a/packages/cli/src/commands/sync-readme.ts
+++ b/packages/cli/src/commands/sync-readme.ts
@@ -28,7 +28,7 @@ export interface SyncReadmeReport {
 	message?: string;
 }
 
-function generateInstallBlock(pkg: PackageJson, description: string): string {
+function generateInstallBlock(pkg: PackageJson): string {
 	const { name = "", bin, peerDependencies = {} } = pkg;
 	const isCli = Boolean(bin);
 	const isReact = Boolean(peerDependencies["react"]);
@@ -121,7 +121,7 @@ export async function runSyncReadme(input: RunSyncReadmeInput): Promise<SyncRead
 		return { status: "fail", updated: false, message: "Could not read package.json" };
 	}
 
-	const block = generateInstallBlock(pkg, description);
+	const block = generateInstallBlock(pkg);
 	const updated = await updateReadmeInstallation(repoRoot, block, dryRun, readFileFn, writeFileFn);
 
 	if (!updated) {

--- a/packages/cli/src/commands/sync-readme.ts
+++ b/packages/cli/src/commands/sync-readme.ts
@@ -45,23 +45,14 @@ function generateInstallBlock(pkg: PackageJson, description: string): string {
 	lines.push("", "## Usage", "");
 
 	if (isCli) {
-		const commands =
-			typeof bin === "string" || !bin ? [name.split("/").pop() ?? name] : Object.keys(bin);
+		const commands = typeof bin === "string" || !bin ? [name.split("/").pop() ?? name] : Object.keys(bin);
 		lines.push("```bash");
 		for (const cmd of commands) {
 			lines.push(`${cmd} --help`);
 		}
 		lines.push("```");
 	} else if (isReact) {
-		lines.push(
-			"```tsx",
-			`import { } from "${name}";`,
-			"",
-			"function App() {",
-			`  return <></>;`,
-			"}",
-			"```"
-		);
+		lines.push("```tsx", `import { } from "${name}";`, "", "function App() {", `  return <></>;`, "}", "```");
 	} else {
 		lines.push("```typescript", `import { } from "${name}";`, "```");
 	}
@@ -103,28 +94,13 @@ async function updateReadmeInstallation(
 	if (insertAfter === -1) return false;
 
 	if (dryRun) return true;
-	lines.splice(
-		insertAfter + 1,
-		0,
-		"",
-		README_INSTALL_START,
-		"",
-		...blockLines,
-		"",
-		README_INSTALL_END
-	);
+	lines.splice(insertAfter + 1, 0, "", README_INSTALL_START, "", ...blockLines, "", README_INSTALL_END);
 	await writeFileFn(readmePath, lines.join("\n"), "utf8");
 	return true;
 }
 
 export async function runSyncReadme(input: RunSyncReadmeInput): Promise<SyncReadmeReport> {
-	const {
-		loaded,
-		context,
-		print = console.log,
-		readFileFn = readFile,
-		writeFileFn = writeFile,
-	} = input;
+	const { loaded, context, print = console.log, readFileFn = readFile, writeFileFn = writeFile } = input;
 
 	const { repoRoot, dryRun = false } = context;
 	const { description = "" } = loaded.resolved;

--- a/packages/cli/src/commands/sync-readme.ts
+++ b/packages/cli/src/commands/sync-readme.ts
@@ -45,7 +45,7 @@ function generateInstallBlock(pkg: PackageJson): string {
 	lines.push("", "## Usage", "");
 
 	if (isCli) {
-		const commands = typeof bin === "string" ? [name.split("/").at(-1)!] : Object.keys(bin);
+		const commands = typeof bin === "string" ? [name.split("/").at(-1)!] : Object.keys(bin ?? {});
 		lines.push("```bash");
 		for (const cmd of commands) {
 			lines.push(`${cmd} --help`);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -131,6 +131,24 @@ export interface DoctorConfig {
 	checks?: string[];
 }
 
+export interface EnvConfig {
+	/**
+	 * Namespace prefixes used by this project's env vars.
+	 * Listed from least- to most-specific (cascade model — last wins).
+	 * Tooling reads this to generate `.env.example`, validate required
+	 * vars, and produce documentation. Runtime code passes the same
+	 * value to `createEnvParser({ namespaces })` from `@theholocron/env-utils`.
+	 *
+	 * @example
+	 * // Project-only prefix
+	 * namespaces: ["CLI_TEMPLATE"]
+	 *
+	 * // Org-wide defaults + project-specific overrides
+	 * namespaces: ["HOLOCRON", "MY_CLI"]
+	 */
+	namespaces?: string[];
+}
+
 export interface HolocronConfig {
 	/** Project name. Derived from package.json when absent. */
 	name?: string;
@@ -193,6 +211,16 @@ export interface HolocronConfig {
 	 * { build: "workflow", domain: "docs.theholocron.dev", https: true }
 	 */
 	docs?: DocsConfig;
+	/**
+	 * Environment variable namespace configuration.
+	 * Declares the prefix(es) this project uses for its env vars so that
+	 * tooling can generate `.env.example`, validate required vars, and
+	 * produce accurate documentation without hard-coding prefix strings.
+	 *
+	 * @example
+	 * { namespaces: ["HOLOCRON", "MY_CLI"] }
+	 */
+	env?: EnvConfig;
 }
 
 // ───────────────────────────────────────────────────────────────────────
@@ -225,6 +253,7 @@ export interface ResolvedHolocronConfig {
 	skills?: string[];
 	/** Resolved Pages config. `build` is guaranteed present when this field exists. */
 	docs?: PagesConfig;
+	env?: EnvConfig;
 }
 
 // ───────────────────────────────────────────────────────────────────────
@@ -360,5 +389,6 @@ export function resolveConfig(raw: HolocronConfig): ResolvedHolocronConfig {
 		agent: raw.agent,
 		skills: raw.skills,
 		docs,
+		env: raw.env,
 	};
 }


### PR DESCRIPTION
## Summary

- Adds `holocron sync-readme` — reads `package.json` and writes an Installation + Usage block into `README.md` between `<!-- holocron:installation -->` markers
- Generates content based on repo type: CLI (`bin`) → `npm install --global` + `<cmd> --help`; React library → tsx snippet; generic library → TypeScript import
- Inserts markers after `<!-- /holocron:description -->` when they don't yet exist
- Respects `--dry-run` flag
- Follows the same marker-splice pattern `sync` uses for the description block

## Usage

```bash
holocron sync-readme             # update README.md in place
holocron sync-readme --dry-run   # preview without writing
```

## Test plan

- [x] `pnpm --filter @theholocron/cli typecheck` — passes
- [ ] Manual: run in cli-template, node-template, react-template and verify output
- [ ] CI lint, typecheck, test pass