### PR TITLE
feat: ✨ enforce test workflow config at setup time, remove validate job

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -986,9 +986,9 @@ describe("runSetup", () => {
 			}),
 		});
 
-		await expect(
-			runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} })
-		).rejects.toThrow("at least one of");
+		await expect(runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} })).rejects.toThrow(
+			"at least one of"
+		);
 	});
 
 	it("does not throw when test workflow has run-unit: true and run-storybook: false", async () => {

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -968,6 +968,56 @@ describe("runSetup", () => {
 		expect(unknownStep?.message).toContain("unknown workflow");
 	});
 
+	it("throws ConfigError when test workflow has both run-unit and run-storybook set to false", async () => {
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [{ name: "test", with: { "run-unit": false, "run-storybook": false } }],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async () => {},
+				},
+			}),
+		});
+
+		await expect(
+			runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} })
+		).rejects.toThrow("at least one of");
+	});
+
+	it("does not throw when test workflow has run-unit: true and run-storybook: false", async () => {
+		const written: string[] = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [{ name: "test", with: { "run-unit": true, "run-storybook": false } }],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (_: string, content: string) => {
+						written.push(content);
+					},
+				},
+			}),
+		});
+
+		await expect(
+			runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} })
+		).resolves.not.toThrow();
+		expect(written.some((c) => c.includes("run-unit: true"))).toBe(true);
+	});
+
 	it("dry-run skips workflow writes", async () => {
 		let writeCallCount = 0;
 		const loaded = loadedFrom({

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -27,6 +27,7 @@ import { pathToFileURL } from "node:url";
 
 import type { Auth, Deployment, Environments, RepoSettings, Source, Tooling, Vault } from "../capabilities/index.js";
 import { ProviderApiError } from "../capabilities/index.js";
+import { ConfigError } from "../config.js";
 import type { LoadedConfig } from "../load-config.js";
 import { PluginLoader, type RuntimeContext } from "../loader.js";
 import { withSpinner } from "../ui/progress.js";
@@ -520,6 +521,24 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			const name = typeof entry === "string" ? entry : entry.name;
 			const withOverrides = typeof entry === "object" ? entry.with : undefined;
 			const additionalPaths = typeof entry === "object" ? entry.paths : undefined;
+
+			// Enforce that the test workflow has at least one test type enabled.
+			// This check lives here so it fails at setup time rather than silently
+			// producing a CI job that never runs any tests.
+			if (name === "test" && withOverrides) {
+				const runUnit = withOverrides["run-unit"];
+				const runStorybook = withOverrides["run-storybook"];
+				const unitDisabled = runUnit === false;
+				const storybookDisabled = runStorybook === false;
+				const neitherEnabled = unitDisabled && storybookDisabled;
+				if (neitherEnabled) {
+					throw new ConfigError(
+						'test workflow: at least one of "run-unit" or "run-storybook" must be true. ' +
+							"Library repos use run-unit: true; UI/Storybook repos use run-storybook: true."
+					);
+				}
+			}
+
 			if (!KNOWN_WORKFLOWS.has(name)) {
 				steps.push({
 					capability: "source",

--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -37,16 +37,6 @@ on: # yamllint disable-line rule:truthy
         required: false
 
 jobs:
-  validate:
-    name: Validate — at least one test type must be enabled
-    if: ${{ !inputs.run-unit && !inputs.run-storybook }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fail — set run-unit or run-storybook to true
-        run: |
-          echo "::error::At least one of run-unit or run-storybook must be true. Library repos use run-unit: true; UI/Storybook repos use run-storybook: true."
-          exit 1
-
   unit:
     name: Run tests and collect coverage
     if: ${{ inputs.run-unit }}


### PR DESCRIPTION
## Summary

- Adds a `ConfigError` in `setup.ts` when the `test` workflow entry has both `run-unit: false` and `run-storybook: false` — fails immediately at `holocron setup` rather than silently generating a broken workflow
- Removes the `validate` job from the shared `test.yml` template — it was a redundant runtime guard that appeared as a noisy "skipped" job in every PR's check list

## Before / After

**Before:** `validate` job appeared in every PR's check list (always skipped when run-unit is true), with a name that read like an error message. Misconfigured callers would only fail hours later in CI.

**After:** No `validate` job in the check list. Misconfigured callers (`run-unit: false, run-storybook: false`) get a `ConfigError` the moment they run `holocron setup`.

## Test plan

- [x] `pnpm --filter @theholocron/cli typecheck` — passes
- [x] `pnpm --filter @theholocron/cli test` — 603/603 tests pass (2 new tests for the ConfigError and the happy path)
- [ ] CI passes