### PR TITLE
feat: ✨ strip holocron:template-only blocks in holocron new

### DIFF
--- a/packages/cli/src/__tests__/new.test.ts
+++ b/packages/cli/src/__tests__/new.test.ts
@@ -474,6 +474,52 @@ describe("runNew — homepage placeholder", () => {
 	});
 });
 
+// ── runNew — template-only block stripping ───────────────────────────
+
+describe("runNew — template-only block stripping", () => {
+	it("removes holocron:template-only blocks from all files", async () => {
+		const { exec } = makeExec();
+		const readme = [
+			"# My CLI",
+			"",
+			"<!-- holocron:template-only -->",
+			"## Getting Started",
+			"",
+			"Clone this template to get started.",
+			"<!-- /holocron:template-only -->",
+			"",
+			"## Installation",
+			"",
+			"```bash",
+			"npm install -g my-cli",
+			"```",
+		].join("\n");
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+			"/workspace/my-tool/README.md": { content: readme },
+		});
+
+		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		expect(written["/workspace/my-tool/README.md"]).not.toContain("holocron:template-only");
+		expect(written["/workspace/my-tool/README.md"]).not.toContain("Getting Started");
+		expect(written["/workspace/my-tool/README.md"]).toContain("## Installation");
+	});
+
+	it("leaves files without template-only blocks unchanged", async () => {
+		const { exec } = makeExec();
+		const readme = "# My CLI\n\n## Installation\n\nnpm install -g my-cli\n";
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+			"/workspace/my-tool/README.md": { content: readme },
+		});
+
+		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		expect(written["/workspace/my-tool/README.md"]).toBeUndefined();
+	});
+});
+
 // ── runNew — holocron.config.ts generation ────────────────────────────
 
 describe("runNew — holocron.config.ts", () => {

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -300,6 +300,13 @@ function patchFiles(
 		if (runtimeEnvironment !== undefined) {
 			content = content.split("<runtime_environment>").join(runtimeEnvironment);
 		}
+		// Strip template-only blocks — sections relevant only to the template
+		// repo itself (e.g. "Getting Started" scaffolding instructions) that
+		// should not appear in projects generated from the template.
+		content = content.replace(
+			/\n?<!-- holocron:template-only -->[\s\S]*?<!-- \/holocron:template-only -->\n?/g,
+			""
+		);
 
 		if (content !== original) {
 			writeFn(filepath, content);


### PR DESCRIPTION
## Summary

When `holocron new` scaffolds a project from a template, it now strips any content wrapped in `<!-- holocron:template-only -->` / `<!-- /holocron:template-only -->` markers from all files.

This lets template repos include sections that are only relevant on the template repo itself — like a "Getting Started" section explaining how to use the template — without that content appearing in generated projects.

## Usage (in a template repo's README)

```markdown
<!-- holocron:template-only -->

## Getting Started

Use `holocron new cli my-cli` to scaffold from this template.

<!-- /holocron:template-only -->

<!-- holocron:installation -->
## Installation
...
```

When a user runs `holocron new cli my-cli`, the Getting Started block is stripped; the Installation block remains.

## Test plan

- [x] `pnpm --filter @theholocron/cli typecheck` — passes
- [x] `pnpm --filter @theholocron/cli test` — 605/605 pass (2 new tests)
- [ ] CI passes