### PR TITLE
feat: ✨ wire syncDescription and syncHomepage into holocron setup

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1382,6 +1382,114 @@ describe("runSetup", () => {
 		expect(called).toBe(false);
 	});
 
+	it("calls syncDescription when description is set in config", async () => {
+		let captured: string | null = null;
+		const loaded = loadedFrom({
+			name: "demo",
+			description: "A great CLI tool",
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeRepoFile: async () => {},
+					syncDescription: async (desc: string) => {
+						captured = desc;
+						return "description updated";
+					},
+				},
+			}),
+		});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(captured).toBe("A great CLI tool");
+		const step = report.steps.find((s) => s.step === "sync description");
+		expect(step?.status).toBe("ok");
+	});
+
+	it("skips syncDescription when description is absent from config", async () => {
+		let called = false;
+		const loaded = loadedFrom({ name: "demo", providers: { source: "github" } });
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeRepoFile: async () => {},
+					syncDescription: async () => {
+						called = true;
+						return "description updated";
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(called).toBe(false);
+	});
+
+	it("calls syncHomepage when homepage is set in config", async () => {
+		let captured: string | null = null;
+		const loaded = loadedFrom({
+			name: "demo",
+			homepage: "https://docs.example.com",
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeRepoFile: async () => {},
+					syncHomepage: async (url: string) => {
+						captured = url;
+						return "homepage updated";
+					},
+				},
+			}),
+		});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(captured).toBe("https://docs.example.com");
+		const step = report.steps.find((s) => s.step === "sync homepage");
+		expect(step?.status).toBe("ok");
+	});
+
+	it("skips syncHomepage when homepage is absent from config", async () => {
+		let called = false;
+		const loaded = loadedFrom({ name: "demo", providers: { source: "github" } });
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeRepoFile: async () => {},
+					syncHomepage: async () => {
+						called = true;
+						return "homepage updated";
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		expect(called).toBe(false);
+	});
+
 	it("calls syncTeams and writes CODEOWNERS for writeable teams", async () => {
 		let capturedTeams: unknown = null;
 		const written: Record<string, string> = {};

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -676,19 +676,13 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 
 		if (config.description && source.syncDescription) {
 			steps.push(
-				await runStep("source", "sync description", dryRun, () =>
-					source.syncDescription!(config.description!)
-				)
+				await runStep("source", "sync description", dryRun, () => source.syncDescription!(config.description!))
 			);
 			print(formatStep(steps[steps.length - 1]!));
 		}
 
 		if (config.homepage && source.syncHomepage) {
-			steps.push(
-				await runStep("source", "sync homepage", dryRun, () =>
-					source.syncHomepage!(config.homepage!)
-				)
-			);
+			steps.push(await runStep("source", "sync homepage", dryRun, () => source.syncHomepage!(config.homepage!)));
 			print(formatStep(steps[steps.length - 1]!));
 		}
 

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -674,6 +674,24 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			print(formatStep(steps[steps.length - 1]!));
 		}
 
+		if (config.description && source.syncDescription) {
+			steps.push(
+				await runStep("source", "sync description", dryRun, () =>
+					source.syncDescription!(config.description!)
+				)
+			);
+			print(formatStep(steps[steps.length - 1]!));
+		}
+
+		if (config.homepage && source.syncHomepage) {
+			steps.push(
+				await runStep("source", "sync homepage", dryRun, () =>
+					source.syncHomepage!(config.homepage!)
+				)
+			);
+			print(formatStep(steps[steps.length - 1]!));
+		}
+
 		const teams = repo?.teams ?? [];
 		if (teams.length > 0) {
 			if (source.syncTeams) {


### PR DESCRIPTION
## Summary

- `syncDescription` and `syncHomepage` existed on the Source capability but were never called during `holocron setup`
- Both now run unconditionally (not gated on preset) alongside the other metadata syncs (`syncTopics`, `syncProperties`, etc.) when the value is present in config
- Closes the gap where `pnpm holocron setup` on a repo with `description` and `homepage` in `holocron.config.ts` would leave those fields unset on GitHub

## Test plan

- [ ] `calls syncDescription when description is set in config`
- [ ] `skips syncDescription when description is absent from config`
- [ ] `calls syncHomepage when homepage is set in config`
- [ ] `skips syncHomepage when homepage is absent from config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)