### PR TITLE
fix: make Cypress wait-on URL configurable in test workflow template

### DIFF
--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -28,6 +28,11 @@ on: # yamllint disable-line rule:truthy
         type: boolean
         required: false
         default: false
+      wait-on-url:
+        description: URL to wait for before running Cypress tests (default is Vite dev server; override for non-Vite stacks e.g. http://localhost:3000 for Next.js)
+        type: string
+        required: false
+        default: "http://localhost:5173"
     secrets:
       CHROMATIC_PROJECT_TOKEN:
         required: false
@@ -177,7 +182,7 @@ jobs:
         name: Cypress run
         with:
           start: pnpm dev
-          wait-on: "http://localhost:5173"
+          wait-on: ${{ inputs.wait-on-url }}
           record: true
           parallel: true
         env:


### PR DESCRIPTION
## Summary

- Add `wait-on-url` string input (default: `http://localhost:5173`) to the test workflow template
- Thread it through to the Cypress action's `wait-on` parameter

## Why

The hardcoded port 5173 (Vite default) breaks any project using a different dev server. Next.js (port 3000) is the immediate case — user-flow tests in `theholocron/nextjs-template` were disabled because of this.

## Test plan

- [ ] Existing Vite-based repos unaffected (default preserved)
- [ ] After merging and syncing: `nextjs-template` passes `wait-on-url: http://localhost:3000` and user-flow tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)