### PR TITLE
feat(new): add --is-template flag and fix five new/setup bugs

### DIFF
--- a/packages/cli/src/__tests__/new.test.ts
+++ b/packages/cli/src/__tests__/new.test.ts
@@ -783,6 +783,54 @@ describe("runNew — token forwarding to holocron setup", () => {
 		expect(setupCall?.args).not.toContain("--token");
 		expect(setupCall?.env).toEqual({});
 	});
+
+	it("passes env vars through defaultExec when no exec is injected", async () => {
+		// This test intentionally omits the `exec` injection so that defaultExec
+		// (and therefore execFileSync) is exercised with a non-empty env map.
+		const { execFileSync, spawnSync } = await import("node:child_process");
+		const { existsSync } = await import("node:fs");
+		vi.mocked(existsSync)
+			.mockReturnValueOnce(false) // repoDir does not exist → proceed
+			.mockReturnValueOnce(true); // pkgJsonPath exists → read it
+		vi.mocked(spawnSync)
+			.mockReturnValueOnce({ status: 0 } as SpawnResult) // gh --version preflight
+			.mockReturnValueOnce(keychainResult("ghp_adminToken")) // github.admin
+			.mockReturnValueOnce(keychainResult("ghp_orgToken")) // github.org
+			.mockReturnValueOnce(keychainResult("ghp_deployToken")); // github.deploy
+
+		const { readFile, writeFile, walkFiles } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+		});
+
+		await runNew({ ...BASE, readFile, writeFile, walkFiles, print: () => {} });
+
+		const allCalls = vi.mocked(execFileSync).mock.calls;
+		const setupCall = allCalls.find((c) => c[0] === "holocron");
+		expect(setupCall).toBeDefined();
+		const opts = setupCall?.[2] as { env?: Record<string, string> };
+		expect(opts?.env?.["HOLOCRON_ORG_TOKEN"]).toBe("ghp_orgToken");
+		expect(opts?.env?.["HOLOCRON_DEPLOY_TOKEN"]).toBe("ghp_deployToken");
+	});
+
+	it("treats empty-stdout keychain result as no token", async () => {
+		const { spawnSync } = await import("node:child_process");
+		vi.mocked(spawnSync)
+			.mockReturnValueOnce({ status: 0 } as SpawnResult) // gh --version preflight
+			.mockReturnValueOnce({ status: 0, stdout: "" } as SpawnResult) // github.admin → empty
+			.mockReturnValueOnce({ status: 0, stdout: "" } as SpawnResult) // github.org → empty
+			.mockReturnValueOnce({ status: 0, stdout: "" } as SpawnResult); // github.deploy → empty
+
+		const { exec, calls } = makeExec();
+		const { readFile, writeFile, walkFiles } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+		});
+
+		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		const setupCall = calls.find((c) => c.cmd === "holocron" && c.args.includes("setup"));
+		expect(setupCall?.args).not.toContain("--token");
+		expect(setupCall?.env).toEqual({});
+	});
 });
 
 // ── runNew — holocron.config.ts generation ────────────────────────────

--- a/packages/cli/src/__tests__/new.test.ts
+++ b/packages/cli/src/__tests__/new.test.ts
@@ -45,9 +45,9 @@ function makeFs(files: Record<string, FakeFile> = {}) {
 }
 
 function makeExec() {
-	const calls: Array<{ cmd: string; args: string[] }> = [];
-	const exec = (cmd: string, args: string[]) => {
-		calls.push({ cmd, args });
+	const calls: Array<{ cmd: string; args: string[]; env?: Record<string, string> }> = [];
+	const exec = (cmd: string, args: string[], opts?: { env?: Record<string, string> }) => {
+		calls.push({ cmd, args, env: opts?.env });
 	};
 	return { exec, calls };
 }
@@ -517,6 +517,271 @@ describe("runNew — template-only block stripping", () => {
 		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
 
 		expect(written["/workspace/my-tool/README.md"]).toBeUndefined();
+	});
+});
+
+// ── runNew — display_name placeholder ────────────────────────────────
+
+describe("runNew — <display_name> placeholder", () => {
+	it("replaces <display_name> with title-case of the new repo name", async () => {
+		const { exec } = makeExec();
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+			"/workspace/my-tool/tsconfig.json": { content: '{"display": "<display_name>"}' },
+		});
+
+		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		expect(written["/workspace/my-tool/tsconfig.json"]).toContain("My Tool");
+		expect(written["/workspace/my-tool/tsconfig.json"]).not.toContain("<display_name>");
+	});
+
+	it("derives title-case from multi-word repo names", async () => {
+		const { exec } = makeExec();
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/monorepo-react-template/package.json": {
+				content: JSON.stringify({ name: "@theholocron/monorepo-template" }),
+			},
+			"/workspace/monorepo-react-template/tsconfig.json": {
+				content: '{"display": "<display_name>"}',
+			},
+		});
+
+		await runNew({
+			...BASE,
+			type: "monorepo",
+			name: "monorepo-react-template",
+			cwd: "/workspace",
+			exec,
+			readFile,
+			writeFile,
+			walkFiles,
+			print: () => {},
+		});
+
+		expect(written["/workspace/monorepo-react-template/tsconfig.json"]).toContain("Monorepo React Template");
+	});
+});
+
+// ── runNew — description block replacement ────────────────────────────
+
+describe("runNew — description block replacement", () => {
+	it("replaces content inside <!-- holocron:description --> markers", async () => {
+		const { exec } = makeExec();
+		const readme = [
+			"# my-tool",
+			"",
+			"<!-- holocron:description -->",
+			"Old template description from the source repo.",
+			"<!-- /holocron:description -->",
+			"",
+			"## Installation",
+		].join("\n");
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+			"/workspace/my-tool/README.md": { content: readme },
+		});
+
+		await runNew({
+			...BASE,
+			description: "A fast CLI tool for X",
+			exec,
+			readFile,
+			writeFile,
+			walkFiles,
+			print: () => {},
+		});
+
+		expect(written["/workspace/my-tool/README.md"]).toContain("A fast CLI tool for X");
+		expect(written["/workspace/my-tool/README.md"]).not.toContain("Old template description");
+		expect(written["/workspace/my-tool/README.md"]).toContain("<!-- holocron:description -->");
+		expect(written["/workspace/my-tool/README.md"]).toContain("<!-- /holocron:description -->");
+	});
+
+	it("leaves the markers intact when description is undefined", async () => {
+		const { exec } = makeExec();
+		const readme = "<!-- holocron:description -->\nOld.\n<!-- /holocron:description -->\n";
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+			"/workspace/my-tool/README.md": { content: readme },
+		});
+
+		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		// No description → no change → file not written
+		expect(written["/workspace/my-tool/README.md"]).toBeUndefined();
+	});
+});
+
+// ── runNew — visibility update ────────────────────────────────────────
+
+describe("runNew — explicit visibility update", () => {
+	it("calls gh repo edit --visibility=public when openSource is true", async () => {
+		const { exec, calls } = makeExec();
+		const { readFile, writeFile, walkFiles } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+		});
+
+		await runNew({ ...BASE, openSource: true, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		const visibilityCall = calls.find(
+			(c) => c.cmd === "gh" && c.args.includes("edit") && c.args.some((a) => a.includes("visibility"))
+		);
+		expect(visibilityCall).toBeDefined();
+		expect(visibilityCall?.args).toContain("--visibility=public");
+	});
+
+	it("calls gh repo edit --visibility=private when openSource is false", async () => {
+		const { exec, calls } = makeExec();
+		const { readFile, writeFile, walkFiles } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+		});
+
+		await runNew({ ...BASE, openSource: false, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		const visibilityCall = calls.find(
+			(c) => c.cmd === "gh" && c.args.includes("edit") && c.args.some((a) => a.includes("visibility"))
+		);
+		expect(visibilityCall?.args).toContain("--visibility=private");
+	});
+});
+
+// ── runNew — isTemplate flag ──────────────────────────────────────────
+
+describe("runNew — isTemplate flag", () => {
+	it("calls gh repo edit --template=true when isTemplate is true", async () => {
+		const { exec, calls } = makeExec();
+		const { readFile, writeFile, walkFiles } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+		});
+
+		await runNew({ ...BASE, isTemplate: true, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		const templateCall = calls.find(
+			(c) => c.cmd === "gh" && c.args.includes("edit") && c.args.includes("--template=true")
+		);
+		expect(templateCall).toBeDefined();
+	});
+
+	it("does not call gh repo edit --template when isTemplate is not set", async () => {
+		const { exec, calls } = makeExec();
+		const { readFile, writeFile, walkFiles } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+		});
+
+		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		const templateCall = calls.find(
+			(c) => c.cmd === "gh" && c.args.includes("edit") && c.args.includes("--template=true")
+		);
+		expect(templateCall).toBeUndefined();
+	});
+});
+
+// ── runNew — token forwarding to setup ───────────────────────────────
+
+type SpawnResult = ReturnType<typeof import("node:child_process").spawnSync>;
+
+/** Build a spawnSync mock result. */
+function keychainResult(token: string | null): SpawnResult {
+	return {
+		status: token !== null ? 0 : 1,
+		stdout: token ?? "",
+		stderr: "",
+		output: [],
+		pid: 0,
+		signal: null,
+		error: undefined,
+	} as SpawnResult;
+}
+
+describe("runNew — token forwarding to holocron setup", () => {
+	it("passes --token (admin) to holocron setup when token is provided as input", async () => {
+		const { exec, calls } = makeExec();
+		const { readFile, writeFile, walkFiles } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+		});
+
+		await runNew({ ...BASE, token: "ghp_admin", exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		const setupCall = calls.find((c) => c.cmd === "holocron" && c.args.includes("setup"));
+		expect(setupCall?.args).toContain("--token");
+		expect(setupCall?.args).toContain("ghp_admin");
+	});
+
+	it("looks up all three keychain tokens and injects them when none are in env/input", async () => {
+		const { spawnSync } = await import("node:child_process");
+		vi.mocked(spawnSync)
+			.mockReturnValueOnce({ status: 0 } as SpawnResult) // gh --version preflight
+			.mockReturnValueOnce(keychainResult("ghp_adminToken")) // github.admin
+			.mockReturnValueOnce(keychainResult("ghp_orgToken")) // github.org
+			.mockReturnValueOnce(keychainResult("ghp_deployToken")); // github.deploy
+
+		const { exec, calls } = makeExec();
+		const { readFile, writeFile, walkFiles } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+		});
+
+		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		const setupCall = calls.find((c) => c.cmd === "holocron" && c.args.includes("setup"));
+		expect(setupCall?.args).toContain("--token");
+		expect(setupCall?.args).toContain("ghp_adminToken");
+		expect(setupCall?.env?.["HOLOCRON_ORG_TOKEN"]).toBe("ghp_orgToken");
+		expect(setupCall?.env?.["HOLOCRON_DEPLOY_TOKEN"]).toBe("ghp_deployToken");
+	});
+
+	it("skips keychain lookup for org/deploy tokens when already in process.env", async () => {
+		const { spawnSync } = await import("node:child_process");
+		// Only admin lookup should be called; org + deploy are in env
+		vi.mocked(spawnSync)
+			.mockReturnValueOnce({ status: 0 } as SpawnResult) // gh --version preflight
+			.mockReturnValueOnce(keychainResult("ghp_adminToken")); // github.admin only
+
+		const origOrg = process.env["HOLOCRON_ORG_TOKEN"];
+		const origDeploy = process.env["HOLOCRON_DEPLOY_TOKEN"];
+		process.env["HOLOCRON_ORG_TOKEN"] = "env_org";
+		process.env["HOLOCRON_DEPLOY_TOKEN"] = "env_deploy";
+
+		try {
+			const { exec, calls } = makeExec();
+			const { readFile, writeFile, walkFiles } = makeFs({
+				"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+			});
+
+			await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+			const setupCall = calls.find((c) => c.cmd === "holocron" && c.args.includes("setup"));
+			// Org + deploy are already in env, so should NOT appear in the injected env override
+			expect(setupCall?.env?.["HOLOCRON_ORG_TOKEN"]).toBeUndefined();
+			expect(setupCall?.env?.["HOLOCRON_DEPLOY_TOKEN"]).toBeUndefined();
+		} finally {
+			if (origOrg === undefined) delete process.env["HOLOCRON_ORG_TOKEN"];
+			else process.env["HOLOCRON_ORG_TOKEN"] = origOrg;
+			if (origDeploy === undefined) delete process.env["HOLOCRON_DEPLOY_TOKEN"];
+			else process.env["HOLOCRON_DEPLOY_TOKEN"] = origDeploy;
+		}
+	});
+
+	it("calls holocron setup without --token when all keychain lookups fail", async () => {
+		const { spawnSync } = await import("node:child_process");
+		vi.mocked(spawnSync)
+			.mockReturnValueOnce({ status: 0 } as SpawnResult) // gh --version preflight
+			.mockReturnValueOnce(keychainResult(null)) // github.admin not found
+			.mockReturnValueOnce(keychainResult(null)) // github.org not found
+			.mockReturnValueOnce(keychainResult(null)); // github.deploy not found
+
+		const { exec, calls } = makeExec();
+		const { readFile, writeFile, walkFiles } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+		});
+
+		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		const setupCall = calls.find((c) => c.cmd === "holocron" && c.args.includes("setup"));
+		expect(setupCall).toBeDefined();
+		expect(setupCall?.args).not.toContain("--token");
+		expect(setupCall?.env).toEqual({});
 	});
 });
 

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -495,6 +495,93 @@ describe("runSetup", () => {
 		expect(defaultSetupEnabled).toBe(true);
 	});
 
+	it("skips enableSecretScanning when the API returns 422 (public repo)", async () => {
+		const loaded = loadedFrom({
+			name: "demo",
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", { vault: { list: async () => [] } }),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {
+						throw new ProviderApiError("already enabled", 422);
+					},
+					enablePrivateVulnerabilityReporting: async () => {},
+					enableDependencyGraph: async () => {},
+					enableCodeScanning: async () => "run 1",
+					writeRepoFile: async () => {},
+				},
+			}),
+		});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const step = report.steps.find((s) => s.step === "enableSecretScanning");
+		expect(step?.status).toBe("skip");
+		expect(report.summary.fail).toBe(0);
+	});
+
+	it("skips enablePrivateVulnerabilityReporting when the API returns 404 (public repo)", async () => {
+		const loaded = loadedFrom({
+			name: "demo",
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", { vault: { list: async () => [] } }),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {
+						throw new ProviderApiError("not found", 404);
+					},
+					enableDependencyGraph: async () => {},
+					enableCodeScanning: async () => "run 1",
+					writeRepoFile: async () => {},
+				},
+			}),
+		});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const step = report.steps.find((s) => s.step === "enablePrivateVulnerabilityReporting");
+		expect(step?.status).toBe("skip");
+		expect(report.summary.fail).toBe(0);
+	});
+
+	it("skips disableDefaultCodeScanning when the API returns 403 plan restriction", async () => {
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: ["codeql"],
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", { vault: { list: async () => [] } }),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					enableDependencyGraph: async () => {},
+					disableDefaultCodeScanning: async () => {
+						throw new ProviderApiError("GitHub Advanced Security is not enabled", 403);
+					},
+					writeWorkflowFile: async () => {},
+					writeRepoFile: async () => {},
+				},
+			}),
+		});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const step = report.steps.find((s) => s.step === "disableDefaultCodeScanning");
+		expect(step?.status).toBe("skip");
+		expect(step?.reason).toBe("plan");
+		expect(report.summary.fail).toBe(0);
+	});
+
 	it("applies balanced repo settings + creates a ruleset when repo.protection is 'balanced'", async () => {
 		let settingsApplied: Record<string, unknown> | null = null;
 		let rulesetCreated: Record<string, unknown> | null = null;
@@ -1533,6 +1620,41 @@ describe("runSetup", () => {
 		const codeownersStep = report.steps.find((s) => s.step === "write .github/CODEOWNERS");
 		expect(codeownersStep?.status).toBe("ok");
 		expect(written[".github/CODEOWNERS"]).toBe("* @theholocron/gatekeepers\n");
+	});
+
+	it("skips sync teams when the API returns 422 (team already assigned)", async () => {
+		const loaded = loadedFrom({
+			name: "demo",
+			repo: { name: "theholocron/demo", teams: [{ slug: "gatekeepers", permission: "maintain" as const }] },
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", { vault: { list: async () => [] } }),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					enableDependencyGraph: async () => {},
+					enableCodeScanning: async () => "run 1",
+					writeRepoFile: async () => {},
+					syncTeams: async () => {
+						throw new ProviderApiError("team already has access", 422);
+					},
+				},
+			}),
+		});
+
+		const report = await runSetup({
+			loaded,
+			context: { repoRoot: "/tmp/test", repo: "theholocron/demo" },
+			loader,
+			print: () => {},
+		});
+		const teamsStep = report.steps.find((s) => s.step === "sync teams");
+		expect(teamsStep?.status).toBe("skip");
+		expect(report.summary.fail).toBe(0);
 	});
 
 	it("skips CODEOWNERS when all teams have pull/triage permission only", async () => {

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -495,6 +495,34 @@ describe("runSetup", () => {
 		expect(defaultSetupEnabled).toBe(true);
 	});
 
+	it("reports fail (not skip) when a step throws a 403 permissions error", async () => {
+		const loaded = loadedFrom({
+			name: "demo",
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", { vault: { list: async () => [] } }),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {
+						throw new ProviderApiError("Forbidden", 403);
+					},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					enableDependencyGraph: async () => {},
+					enableCodeScanning: async () => "run 1",
+					writeRepoFile: async () => {},
+				},
+			}),
+		});
+
+		const report = await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const step = report.steps.find((s) => s.step === "enableVulnerabilityAlerts");
+		expect(step?.status).toBe("fail");
+		expect(step?.reason).toBe("permissions");
+	});
+
 	it("skips enableSecretScanning when the API returns 422 (public repo)", async () => {
 		const loaded = loadedFrom({
 			name: "demo",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -593,6 +593,10 @@ try {
 						type: "string",
 						describe: "Comma-separated agent skill names (e.g. git-safety,pr-workflow)",
 					})
+					.option("is-template", {
+						type: "boolean",
+						describe: "Mark the new repo as a GitHub template repository",
+					})
 					.option("org", {
 						type: "string",
 						default: "theholocron",
@@ -605,6 +609,10 @@ try {
 					}),
 			async (argv) => {
 				try {
+					const tokens = tokenContext(argv.token);
+					if (!tokens) return;
+					const adminToken = tokens.cliTokens?.["github"] ?? tokens.cliToken;
+
 					let type = argv.type as string | undefined;
 					let name = argv.name as string | undefined;
 					let description = argv.description as string | undefined;
@@ -620,6 +628,7 @@ try {
 					let openSource = argv.openSource as boolean | undefined;
 					let usesExternalPackages = argv.usesExternalPackages as boolean | undefined;
 					let skills: string[] = parseTopics(argv.skills as string | undefined);
+					const isTemplate = argv.isTemplate as boolean | undefined;
 
 					// Interactive wizard — skip any field already supplied as a CLI arg
 					if (!type) {
@@ -778,7 +787,9 @@ try {
 						usesExternalPackages: usesExternalPackages ?? true,
 						topics,
 						skills,
+						isTemplate,
 						org: argv.org,
+						token: adminToken,
 						dryRun: argv.dryRun,
 						noVerify: !argv.verify,
 						cwd: argv.cwd,

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -352,11 +352,9 @@ function defaultExec(
 }
 
 function keychainLookup(key: string): string | undefined {
-	const result = spawnSync(
-		"security",
-		["find-generic-password", "-s", "com.theholocron.cli", "-a", key, "-w"],
-		{ encoding: "utf8" }
-	);
+	const result = spawnSync("security", ["find-generic-password", "-s", "com.theholocron.cli", "-a", key, "-w"], {
+		encoding: "utf8",
+	});
 	return result.status === 0 ? result.stdout?.trim() || undefined : undefined;
 }
 
@@ -423,11 +421,10 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 	// gh repo create --template does not reliably honor --public/--private on all
 	// plan/org combinations, so set visibility explicitly after creation.
 	try {
-		execFn(
-			"gh",
-			["repo", "edit", newRepo, `--visibility=${input.openSource ? "public" : "private"}`],
-			{ cwd, stdio: "inherit" }
-		);
+		execFn("gh", ["repo", "edit", newRepo, `--visibility=${input.openSource ? "public" : "private"}`], {
+			cwd,
+			stdio: "inherit",
+		});
 	} catch {
 		// non-fatal — visibility can be changed manually in repo settings
 	}

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -45,15 +45,19 @@ export interface RunNewInput {
 	usesExternalPackages?: boolean;
 	topics?: string[];
 	skills?: string[];
+	/** Mark the new repo as a GitHub template repository. */
+	isTemplate?: boolean;
 	/** GitHub org that owns both the template and the new repo. Default: "theholocron". */
 	org?: string;
+	/** GitHub admin token forwarded to `holocron setup` during verify. */
+	token?: string;
 	dryRun?: boolean;
 	noVerify?: boolean;
 	/** Parent directory where the repo will be cloned. Default: process.cwd(). */
 	cwd?: string;
 	print?: (line: string) => void;
 	/** Injectable subprocess runner for testing. */
-	exec?: (cmd: string, args: string[], opts: { cwd: string; stdio: "inherit" }) => void;
+	exec?: (cmd: string, args: string[], opts: { cwd: string; stdio: "inherit"; env?: Record<string, string> }) => void;
 	/** Injectable file writer for testing. */
 	writeFile?: (filepath: string, content: string) => void;
 	/** Injectable file reader for testing (returns utf-8 string). */
@@ -293,6 +297,13 @@ function patchFiles(
 		}
 		if (description !== undefined) {
 			content = content.split("<description>").join(description);
+			// Also replace the content of <!-- holocron:description --> blocks so
+			// the README description marker is updated even when the template has
+			// real prose rather than a bare <description> placeholder.
+			content = content.replace(
+				/(<!-- holocron:description -->)[\s\S]*?(<!-- \/holocron:description -->)/g,
+				`$1\n${description}\n$2`
+			);
 		}
 		if (homepage !== undefined) {
 			content = content.split("<homepage>").join(homepage);
@@ -328,8 +339,25 @@ function preflight(): void {
 
 // ── Defaults ──────────────────────────────────────────────────────────
 
-function defaultExec(cmd: string, args: string[], opts: { cwd: string; stdio: "inherit" }): void {
-	execFileSync(cmd, args, { cwd: opts.cwd, stdio: opts.stdio });
+function defaultExec(
+	cmd: string,
+	args: string[],
+	opts: { cwd: string; stdio: "inherit"; env?: Record<string, string> }
+): void {
+	execFileSync(cmd, args, {
+		cwd: opts.cwd,
+		stdio: opts.stdio,
+		...(opts.env && Object.keys(opts.env).length > 0 ? { env: { ...process.env, ...opts.env } } : {}),
+	});
+}
+
+function keychainLookup(key: string): string | undefined {
+	const result = spawnSync(
+		"security",
+		["find-generic-password", "-s", "com.theholocron.cli", "-a", key, "-w"],
+		{ encoding: "utf8" }
+	);
+	return result.status === 0 ? result.stdout?.trim() || undefined : undefined;
 }
 
 function defaultReadFile(filepath: string): string {
@@ -374,13 +402,34 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 	}
 
 	print(`  Creating ${newRepo} from template ${templateRepo}…`);
+	const visibility = input.openSource ? "--public" : "--private";
 	try {
-		execFn("gh", ["repo", "create", newRepo, `--template=${templateRepo}`, "--private", "--clone"], {
+		execFn("gh", ["repo", "create", newRepo, `--template=${templateRepo}`, visibility, "--clone"], {
 			cwd,
 			stdio: "inherit",
 		});
 	} catch (err) {
 		throw new NewError(`gh repo create failed: ${err instanceof Error ? err.message : String(err)}`);
+	}
+
+	if (input.isTemplate) {
+		try {
+			execFn("gh", ["repo", "edit", newRepo, "--template=true"], { cwd, stdio: "inherit" });
+		} catch {
+			// non-fatal — template flag can be set manually in repo settings
+		}
+	}
+
+	// gh repo create --template does not reliably honor --public/--private on all
+	// plan/org combinations, so set visibility explicitly after creation.
+	try {
+		execFn(
+			"gh",
+			["repo", "edit", newRepo, `--visibility=${input.openSource ? "public" : "private"}`],
+			{ cwd, stdio: "inherit" }
+		);
+	} catch {
+		// non-fatal — visibility can be changed manually in repo settings
 	}
 
 	// Detect template slug from cloned package.json
@@ -406,6 +455,10 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 	// priority — e.g. "@theholocron/node-template" becomes "@<org>/<name>"
 	// rather than "@theholocron/<name>".
 	variants.unshift([`theholocron/${templateSlug}`, `${org}/${input.name}`]);
+	// Add <display_name> placeholder → title-case of the new repo name, so
+	// tsconfig.json "display" fields and similar use the correct human label.
+	const displayName = input.name.split("-").map(cap).join(" ");
+	variants.push(["<display_name>", displayName]);
 	const filesPatched = patchFiles(
 		repoDir,
 		variants,
@@ -481,7 +534,28 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 		print("");
 		print("  Running holocron setup…");
 		try {
-			execFn("holocron", ["setup"], { cwd: repoDir, stdio: "inherit" });
+			const setupArgs: string[] = ["setup"];
+			const setupEnv: Record<string, string> = {};
+
+			// Admin token: drives rulesets, repo settings, workflows, Pages.
+			// Prefer the value forwarded via --token; fall back to keychain.
+			const adminToken = input.token ?? keychainLookup("github.admin");
+			if (adminToken) setupArgs.push("--token", adminToken);
+
+			// Org token: drives team assignments and custom properties.
+			// Skip keychain if already in env (subprocess inherits it anyway).
+			if (!process.env["HOLOCRON_ORG_TOKEN"]) {
+				const orgToken = keychainLookup("github.org");
+				if (orgToken) setupEnv["HOLOCRON_ORG_TOKEN"] = orgToken;
+			}
+
+			// Deploy token: drives GitHub Pages configuration.
+			if (!process.env["HOLOCRON_DEPLOY_TOKEN"]) {
+				const deployToken = keychainLookup("github.deploy");
+				if (deployToken) setupEnv["HOLOCRON_DEPLOY_TOKEN"] = deployToken;
+			}
+
+			execFn("holocron", setupArgs, { cwd: repoDir, stdio: "inherit", env: setupEnv });
 		} catch {
 			print("  ✗ holocron setup failed — run it manually after checking your config");
 		}

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -454,6 +454,13 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	if (loader.has("source")) {
 		const source = loader.get("source") as Source;
 		print(style.step("source"));
+		// Secret scanning on public repos is always on (422); private vuln
+		// reporting doesn't exist on public repos (404). Treat both as skip so
+		// a public-repo setup doesn't report spurious failures.
+		const SECURITY_SKIP_CODES: Partial<Record<string, number[]>> = {
+			enableSecretScanning: [422],
+			enablePrivateVulnerabilityReporting: [404],
+		};
 		for (const method of [
 			"enableVulnerabilityAlerts",
 			"enableAutomatedSecurityFixes",
@@ -462,9 +469,15 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			"enableDependencyGraph",
 		] as const) {
 			steps.push(
-				await runStep("source", method, dryRun, async () => {
-					await source[method]();
-				})
+				await runStep(
+					"source",
+					method,
+					dryRun,
+					async () => {
+						await source[method]();
+					},
+					{ skipCodes: SECURITY_SKIP_CODES[method] }
+				)
 			);
 			print(formatStep(steps[steps.length - 1]!));
 		}
@@ -689,7 +702,11 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		const teams = repo?.teams ?? [];
 		if (teams.length > 0) {
 			if (source.syncTeams) {
-				steps.push(await runStep("source", "sync teams", dryRun, () => source.syncTeams!(teams)));
+				// 422 means the team is already assigned — desired state is in place,
+				// so treat it as an idempotent success (skip) rather than a failure.
+				steps.push(
+					await runStep("source", "sync teams", dryRun, () => source.syncTeams!(teams), { skipCodes: [422] })
+				);
 				print(formatStep(steps[steps.length - 1]!));
 
 				// Only split on "/" so a bare repo name (no owner prefix) yields an
@@ -1201,7 +1218,8 @@ async function runStep(
 	capability: string,
 	step: string,
 	dryRun: boolean,
-	body: () => Promise<string | void>
+	body: () => Promise<string | void>,
+	opts: { skipCodes?: number[] } = {}
 ): Promise<SetupStepResult> {
 	if (dryRun) {
 		return { capability, step, status: "dry-run" };
@@ -1212,9 +1230,16 @@ async function runStep(
 		if (typeof note === "string") result.message = note;
 		return result;
 	} catch (err) {
-		if (err instanceof ProviderApiError && err.status === 403) {
-			const reason = classify403(err);
-			return { capability, step, status: "fail", message: err.message, reason };
+		if (err instanceof ProviderApiError) {
+			if (err.status !== undefined && opts.skipCodes?.includes(err.status)) {
+				return { capability, step, status: "skip", message: err.message };
+			}
+			if (err.status === 403) {
+				const reason = classify403(err);
+				// Plan-restriction 403s mean the feature is unavailable on the current
+				// plan — not a setup failure, just a capability gap. Report as skip.
+				return { capability, step, status: reason === "plan" ? "skip" : "fail", message: err.message, reason };
+			}
 		}
 		return {
 			capability,


### PR DESCRIPTION
## Summary

- **#333** — adds `--is-template` CLI flag to `holocron new` (wires up the already-implemented `isTemplate` field in `runNew`)
- **#334** — adds explicit `gh repo edit --visibility=public/private` after repo creation; `gh repo create --template` doesn't reliably honor `--public` on all plan/org combinations
- **#335** — replaces `<display_name>` placeholder with title-case repo name (fixes `tsconfig.json` display field); also replaces content inside `<!-- holocron:description -->` blocks in README
- **#336** — `enableSecretScanning` now skips on 422 (always-on for public repos), `enablePrivateVulnerabilityReporting` skips on 404 (not supported on public repos), 403 "plan restriction" globally emits `skip` instead of `fail`
- **#337** — when `holocron new` spawns `holocron setup`, it now looks up all three keychain PATs (`github.admin` → `--token`, `github.org` → `HOLOCRON_ORG_TOKEN`, `github.deploy` → `HOLOCRON_DEPLOY_TOKEN`) and injects them into the subprocess; env vars already in the environment are not overwritten
- **#338** — `sync teams` now passes `{ skipCodes: [422] }` to treat "team already assigned" as an idempotent skip rather than a failure

## Test plan

- [ ] 626 tests pass (`pnpm --filter @theholocron/cli test`)
- [ ] Typecheck clean (`pnpm --filter @theholocron/cli typecheck`)
- [ ] New tests cover each fix: `<display_name>` replacement, description block replacement, explicit visibility update, `--is-template` flag, all three keychain token lookups, 422/404 security step skips, syncTeams 422 skip, and code scanning 403 plan skip