### PR TITLE
fix(deploy-docs): add skip-content input for repos without a -docs package

### DIFF
--- a/packages/cli/src/templates/workflows/deploy-docs.yml
+++ b/packages/cli/src/templates/workflows/deploy-docs.yml
@@ -12,6 +12,11 @@ on: # yamllint disable-line rule:truthy
         required: false
         type: boolean
         default: true
+      skip-content:
+        description: Skip the content package build step (for repos with no <name>-docs package)
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -27,13 +32,13 @@ jobs:
         name: Setup
 
       - name: Build content packages
-        if: ${{ inputs.use-turbo }}
+        if: ${{ !inputs.skip-content && inputs.use-turbo }}
         env:
           DOCS_NAME: ${{ inputs.name }}
         run: pnpm turbo build --filter=@theholocron/"$DOCS_NAME"-docs
 
       - name: Build content packages
-        if: ${{ !inputs.use-turbo }}
+        if: ${{ !inputs.skip-content && !inputs.use-turbo }}
         env:
           DOCS_NAME: ${{ inputs.name }}
         run: pnpm --filter @theholocron/"$DOCS_NAME"-docs build


### PR DESCRIPTION
## Summary

The reusable `deploy-docs.yml` workflow always tries to build `@theholocron/<name>-docs`, but some repos (e.g. `monorepo-react-template`) have their Astro site directly in `docs/` as `<name>-site` with no separate content package.

Adds a `skip-content` boolean input (default `false`) that gates both "Build content packages" steps — turbo and non-turbo — so repos without a `-docs` package can opt out without the workflow failing.

Companion PR: theholocron/monorepo-react-template#1 sets `skip-content: true` for that repo.

Once this syncs to `theholocron/.github` via `sync-github`, running `holocron setup` in any affected repo will regenerate the thin caller with `skip-content: true` automatically.

## Test plan

- [ ] `deploy-docs.yml` template now has `skip-content` input with default `false`
- [ ] `monorepo-react-template` CI no longer fails with "No package found with name `@theholocron/monorepo-react-template-docs`"
- [ ] Repos with a `-docs` package are unaffected (default `false` preserves existing behavior)