### PR TITLE
fix(new): update tsconfig display via JSON parse instead of placeholder

### DIFF
--- a/packages/cli/src/__tests__/new.test.ts
+++ b/packages/cli/src/__tests__/new.test.ts
@@ -559,9 +559,9 @@ describe("runNew — tsconfig.json display update", () => {
 			print: () => {},
 		});
 
-		const tsconfig = JSON.parse(
-			written["/workspace/monorepo-react-template/tsconfig.json"]!
-		) as { display: string };
+		const tsconfig = JSON.parse(written["/workspace/monorepo-react-template/tsconfig.json"]!) as {
+			display: string;
+		};
 		expect(tsconfig.display).toBe("Monorepo React Template");
 	});
 

--- a/packages/cli/src/__tests__/new.test.ts
+++ b/packages/cli/src/__tests__/new.test.ts
@@ -520,30 +520,30 @@ describe("runNew — template-only block stripping", () => {
 	});
 });
 
-// ── runNew — display_name placeholder ────────────────────────────────
+// ── runNew — tsconfig.json display update ────────────────────────────
 
-describe("runNew — <display_name> placeholder", () => {
-	it("replaces <display_name> with title-case of the new repo name", async () => {
+describe("runNew — tsconfig.json display update", () => {
+	it("sets root tsconfig display to title-case of the new repo name", async () => {
 		const { exec } = makeExec();
 		const { readFile, writeFile, walkFiles, written } = makeFs({
 			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
-			"/workspace/my-tool/tsconfig.json": { content: '{"display": "<display_name>"}' },
+			"/workspace/my-tool/tsconfig.json": { content: '{"display": "CLI Template"}' },
 		});
 
 		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
 
-		expect(written["/workspace/my-tool/tsconfig.json"]).toContain("My Tool");
-		expect(written["/workspace/my-tool/tsconfig.json"]).not.toContain("<display_name>");
+		const tsconfig = JSON.parse(written["/workspace/my-tool/tsconfig.json"]!) as { display: string };
+		expect(tsconfig.display).toBe("My Tool");
 	});
 
-	it("derives title-case from multi-word repo names", async () => {
+	it("overwrites any existing display value — no placeholder required in templates", async () => {
 		const { exec } = makeExec();
 		const { readFile, writeFile, walkFiles, written } = makeFs({
 			"/workspace/monorepo-react-template/package.json": {
 				content: JSON.stringify({ name: "@theholocron/monorepo-template" }),
 			},
 			"/workspace/monorepo-react-template/tsconfig.json": {
-				content: '{"display": "<display_name>"}',
+				content: '{"display": "Monorepo Template"}',
 			},
 		});
 
@@ -559,7 +559,22 @@ describe("runNew — <display_name> placeholder", () => {
 			print: () => {},
 		});
 
-		expect(written["/workspace/monorepo-react-template/tsconfig.json"]).toContain("Monorepo React Template");
+		const tsconfig = JSON.parse(
+			written["/workspace/monorepo-react-template/tsconfig.json"]!
+		) as { display: string };
+		expect(tsconfig.display).toBe("Monorepo React Template");
+	});
+
+	it("leaves tsconfig files without a display field unchanged", async () => {
+		const { exec } = makeExec();
+		const { readFile, writeFile, walkFiles, written } = makeFs({
+			"/workspace/my-tool/package.json": { content: JSON.stringify({ name: "@theholocron/cli-template" }) },
+			"/workspace/my-tool/tsconfig.json": { content: '{"extends": "@theholocron/tsconfig/node-lts"}' },
+		});
+
+		await runNew({ ...BASE, exec, readFile, writeFile, walkFiles, print: () => {} });
+
+		expect(written["/workspace/my-tool/tsconfig.json"]).toBeUndefined();
 	});
 });
 

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -452,10 +452,6 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 	// priority — e.g. "@theholocron/node-template" becomes "@<org>/<name>"
 	// rather than "@theholocron/<name>".
 	variants.unshift([`theholocron/${templateSlug}`, `${org}/${input.name}`]);
-	// Add <display_name> placeholder → title-case of the new repo name, so
-	// tsconfig.json "display" fields and similar use the correct human label.
-	const displayName = input.name.split("-").map(cap).join(" ");
-	variants.push(["<display_name>", displayName]);
 	const filesPatched = patchFiles(
 		repoDir,
 		variants,
@@ -482,6 +478,23 @@ export async function runNew(input: RunNewInput): Promise<NewReport> {
 		} catch {
 			// non-fatal — placeholder replacement already covered it
 		}
+	}
+
+	// Update the root tsconfig.json "display" field by parsing the JSON directly
+	// rather than relying on a <display_name> placeholder. Templates can use their
+	// real human-readable display name; we always overwrite it with the title-case
+	// of the new repo name on scaffolding.
+	const displayName = input.name.split("-").map(cap).join(" ");
+	const rootTsconfigPath = path.join(repoDir, "tsconfig.json");
+	try {
+		const tsconfig = JSON.parse(readFn(rootTsconfigPath)) as Record<string, unknown>;
+		if (typeof tsconfig["display"] === "string") {
+			tsconfig["display"] = displayName;
+			writeFn(rootTsconfigPath, JSON.stringify(tsconfig, null, 2) + "\n");
+			print(`  ✓ tsconfig.json (display)`);
+		}
+	} catch {
+		// non-fatal — no tsconfig or no display field
 	}
 
 	// Generate and write holocron.config.ts


### PR DESCRIPTION
## Summary

The `<display_name>` string-replacement variant added in #339 was a leaky abstraction: it required template authors to put a literal `<display_name>` string in their `tsconfig.json` rather than a real, human-readable value.

Since `tsconfig.json` is structured JSON, parse it directly — the same pattern already used for `package.json` `description`/`homepage` — and overwrite the `display` field with the title-case repo name. Templates now carry their actual display name (e.g. `"Monorepo Next.js Template"`) and scaffolding always sets it correctly regardless of what it currently says.

## Changes

- `new.ts`: remove `<display_name>` from variants; add a JSON-aware step that reads root `tsconfig.json`, updates `display` if present, and writes it back
- `new.test.ts`: rename describe block; update test fixtures to use real display values (not placeholders); add a case for tsconfigs without a `display` field
- `monorepo-nextjs-template/tsconfig.json`: replace `"<display_name>"` with `"Monorepo Next.js Template"`

## Test plan

- [ ] 630 tests pass
- [ ] Typecheck clean
- [ ] `holocron new monorepo-nextjs my-app` → `my-app/tsconfig.json` display becomes `"My App"`
- [ ] Template `tsconfig.json` displays real name, not a placeholder