### PR TITLE
fix(setup): use scaffold header for codecov.yml so users can edit freely

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -2242,6 +2242,8 @@ describe("setup: write codecov.yml", () => {
 		const report = await runSetup({ loaded, context: { repoRoot: tmpDir }, loader, print: () => {} });
 
 		expect(written["codecov.yml"]).toBeDefined();
+		expect(written["codecov.yml"]).toContain("Scaffolded by holocron setup");
+		expect(written["codecov.yml"]).not.toContain("AUTO-GENERATED");
 		const step = report.steps.find((s) => s.step === "write codecov.yml");
 		expect(step?.status).toBe("ok");
 		expect(step?.message).toBe("no components");

--- a/packages/cli/src/commands/setup-workflows.ts
+++ b/packages/cli/src/commands/setup-workflows.ts
@@ -33,6 +33,14 @@ export function workflowHeader(source = "packages/cli/src/commands/setup-workflo
 	].join("\n");
 }
 
+export function scaffoldHeader(source = "packages/cli/src/commands/setup.ts"): string {
+	return [
+		`# Scaffolded by holocron setup — edit this file freely.`,
+		`# Source:  theholocron/holocron · ${source}`,
+		``,
+	].join("\n");
+}
+
 export const WORKFLOW_TEMPLATES: Record<string, string> = {
 	lint: lintYml,
 	test: testYml,

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -38,6 +38,7 @@ import {
 	generateThinCallerContent,
 	KNOWN_WORKFLOWS,
 	WORKFLOW_CHECK_CONTEXTS,
+	scaffoldHeader,
 	workflowHeader,
 } from "./setup-workflows.js";
 
@@ -118,7 +119,7 @@ export function mergeCodecovComponents(existing: string, packages: WorkspacePack
 export function codecovContent(packages: WorkspacePackage[]): string {
 	return (
 		[
-			workflowHeader("packages/cli/src/commands/setup.ts"),
+			scaffoldHeader(),
 			`codecov:`,
 			`  require_ci_to_pass: true`,
 			``,

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -37,8 +37,8 @@ import {
 	DEPENDABOT_CONFIG,
 	generateThinCallerContent,
 	KNOWN_WORKFLOWS,
-	WORKFLOW_CHECK_CONTEXTS,
 	scaffoldHeader,
+	WORKFLOW_CHECK_CONTEXTS,
 	workflowHeader,
 } from "./setup-workflows.js";
 


### PR DESCRIPTION
## Summary

- Adds `scaffoldHeader()` to `setup-workflows.ts` alongside `workflowHeader()` — same source attribution, but without "do not edit" and "run to regenerate" messaging
- Switches `codecovContent()` to use `scaffoldHeader()`: `codecov.yml` is a one-time scaffold that users should tune for their project, not a managed file that holocron owns
- All other files (`editorconfig`, `labeler.yml`, `dependabot.yml`, etc.) continue to use `workflowHeader()` unchanged — those are genuinely managed