### PR TITLE
fix(lint): group GITHUB_ENV redirects to satisfy shellcheck SC2129

### DIFF
--- a/packages/cli/src/templates/workflows/lint.yml
+++ b/packages/cli/src/templates/workflows/lint.yml
@@ -114,40 +114,52 @@ jobs:
           has() { find . -not -path '*/node_modules/*' -name "$1" -print -quit 2>/dev/null | grep -q .; }
 
           if { has 'eslint.config.ts' || has 'eslint.config.mjs' || has 'eslint.config.js' || has '.eslintrc.json' || has '.eslintrc.yml'; }; then
-            echo "VALIDATE_JAVASCRIPT_ES=true" >> "$GITHUB_ENV"
-            echo "VALIDATE_TYPESCRIPT_ES=true" >> "$GITHUB_ENV"
+            {
+              echo "VALIDATE_JAVASCRIPT_ES=true"
+              echo "VALIDATE_TYPESCRIPT_ES=true"
+            } >> "$GITHUB_ENV"
             echo "eslint=true" >> "$GITHUB_OUTPUT"
           fi
 
           if { has '*.js' || has '*.jsx' || has '*.mjs' || has '*.cjs' || has '*.ts' || has '*.tsx'; }; then
-            echo "VALIDATE_JAVASCRIPT_PRETTIER=true" >> "$GITHUB_ENV"
-            echo "VALIDATE_JSX_PRETTIER=true" >> "$GITHUB_ENV"
-            echo "VALIDATE_TYPESCRIPT_PRETTIER=true" >> "$GITHUB_ENV"
-            echo "VALIDATE_TSX=true" >> "$GITHUB_ENV"
-            echo "FIX_JAVASCRIPT_PRETTIER=true" >> "$GITHUB_ENV"
-            echo "FIX_JSX_PRETTIER=true" >> "$GITHUB_ENV"
-            echo "FIX_TYPESCRIPT_PRETTIER=true" >> "$GITHUB_ENV"
-            echo "FIX_TSX=true" >> "$GITHUB_ENV"
+            {
+              echo "VALIDATE_JAVASCRIPT_PRETTIER=true"
+              echo "VALIDATE_JSX_PRETTIER=true"
+              echo "VALIDATE_TYPESCRIPT_PRETTIER=true"
+              echo "VALIDATE_TSX=true"
+              echo "FIX_JAVASCRIPT_PRETTIER=true"
+              echo "FIX_JSX_PRETTIER=true"
+              echo "FIX_TYPESCRIPT_PRETTIER=true"
+              echo "FIX_TSX=true"
+            } >> "$GITHUB_ENV"
           fi
 
           if { has '*.css' || has '*.scss' || has 'stylelint.config.ts' || has 'stylelint.config.mjs' || has 'stylelint.config.js'; }; then
-            echo "VALIDATE_CSS=true" >> "$GITHUB_ENV"
-            echo "STYLELINT_CONFIG_FILE=stylelint.config.ts" >> "$GITHUB_ENV"
+            {
+              echo "VALIDATE_CSS=true"
+              echo "STYLELINT_CONFIG_FILE=stylelint.config.ts"
+            } >> "$GITHUB_ENV"
           fi
 
           if { has '*.graphql' || has '*.gql'; }; then
-            echo "VALIDATE_GRAPHQL_PRETTIER=true" >> "$GITHUB_ENV"
-            echo "FIX_GRAPHQL_PRETTIER=true" >> "$GITHUB_ENV"
+            {
+              echo "VALIDATE_GRAPHQL_PRETTIER=true"
+              echo "FIX_GRAPHQL_PRETTIER=true"
+            } >> "$GITHUB_ENV"
           fi
 
           if { has '*.html' || has '*.htm'; }; then
-            echo "VALIDATE_HTML_PRETTIER=true" >> "$GITHUB_ENV"
-            echo "FIX_HTML_PRETTIER=true" >> "$GITHUB_ENV"
+            {
+              echo "VALIDATE_HTML_PRETTIER=true"
+              echo "FIX_HTML_PRETTIER=true"
+            } >> "$GITHUB_ENV"
           fi
 
           if { has '.env' || has '.env.example' || has '.env.local'; }; then
-            echo "VALIDATE_ENV=true" >> "$GITHUB_ENV"
-            echo "FIX_ENV=true" >> "$GITHUB_ENV"
+            {
+              echo "VALIDATE_ENV=true"
+              echo "FIX_ENV=true"
+            } >> "$GITHUB_ENV"
           fi
 
           if { has 'Dockerfile' || has '*.Dockerfile'; }; then


### PR DESCRIPTION
## Summary

Individual `echo >> "$GITHUB_ENV"` redirects inside the detect step blocks trigger shellcheck SC2129 ("Consider using `{ cmd1; cmd2; } >> file` instead of individual redirects"), which actionlint treats as a hard failure and blocks the sync-to-.github validation step.

Groups each block's writes with `{ ...; } >> "$GITHUB_ENV"` per the shellcheck suggestion. Single-line redirects (Dockerfile, GITHUB_OUTPUT) are left as-is since SC2129 only fires on 2+ consecutive redirects to the same file.

This unblocks the `sync-to-.github` workflow so the ESLint detect fix from #343 actually lands in the central `theholocron/.github` lint workflow.