### PR TITLE
fix(setup): add commit-message prefix to dependabot.yml template

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -1,6 +1,6 @@
 import starlight from "@astrojs/starlight";
-import { docsTheme } from "@theholocron/docs-theme";
 import { defineConfig } from "@theholocron/astro-config";
+import { docsTheme } from "@theholocron/docs-theme";
 import holocronConfig from "@theholocron/holocron-docs";
 
 export default defineConfig({

--- a/packages/cli/src/commands/dependabot.yml
+++ b/packages/cli/src/commands/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     groups:
       security-patches:
         applies-to: security-updates
@@ -18,6 +21,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
     groups:
       all-actions:
         patterns:

--- a/packages/holocron-docs/vitest.config.ts
+++ b/packages/holocron-docs/vitest.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vitest/config";
 import { node } from "@theholocron/vitest-config/node";
+import { defineConfig } from "vitest/config";
 
 const base = node();
 


### PR DESCRIPTION
## Summary

Dependabot's default commit messages ("Bump X from Y to Z") don't follow Conventional Commits, causing `GIT_COMMITLINT` to fail on every Dependabot PR across all repos.

Adding `commit-message: prefix: "chore(deps)"` makes Dependabot generate messages like `chore(deps): bump @types/node from 18 to 26`, which satisfies commitlint and also matches the existing `^chore\(deps` pattern in `labeler.yml` so Dependabot PRs get the `dependencies` label automatically.

Applies to both the `npm` and `github-actions` ecosystems. The `prefix-development` is set to `chore(deps-dev)` for dev-only npm packages.