### PR TITLE
fix(lint): remove deprecated TYPESCRIPT_STANDARD_TSCONFIG_FILE from super-linter

### DIFF
--- a/packages/cli/src/templates/workflows/lint.yml
+++ b/packages/cli/src/templates/workflows/lint.yml
@@ -20,13 +20,6 @@ on: # yamllint disable-line rule:truthy
         type: string
         required: false
         default: prettier.config.ts
-      typescript-tsconfig:
-        description: >
-          tsconfig.json path passed to TYPESCRIPT_STANDARD_TSCONFIG_FILE.
-          Defaults to tsconfig.json (super-linter's own default).
-        type: string
-        required: false
-        default: tsconfig.json
       yaml-config:
         description: >
           Filename for the yamllint config. Defaults to yamllint.config.yml.
@@ -182,7 +175,6 @@ jobs:
           JAVASCRIPT_ES_CONFIG_FILE: ${{ steps.detect.outputs.eslint == 'true' && inputs.eslint-config || '' }}
           TYPESCRIPT_ES_CONFIG_FILE: ${{ steps.detect.outputs.eslint == 'true' && inputs.eslint-config || '' }}
           PRETTIER_CONFIG: ${{ inputs.prettier-config }}
-          TYPESCRIPT_STANDARD_TSCONFIG_FILE: ${{ inputs.typescript-tsconfig }}
           YAML_CONFIG_FILE: ${{ inputs.yaml-config }}
           # Always-on linters
           FIX_MARKDOWN_PRETTIER: true


### PR DESCRIPTION
## Summary

super-linter v8 deprecated `TYPESCRIPT_STANDARD_TSCONFIG_FILE` — it logs a warning on every run ("this warning may turn into a fatal error in a future version"). Removes both the `typescript-tsconfig` workflow input and the env var from the super-linter step.