### PR TITLE
feat(test): support multiple Chromatic projects via matrix strategy

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1133,6 +1133,50 @@ describe("runSetup", () => {
 		expect(written.some((c) => c.includes("run-unit: true"))).toBe(true);
 	});
 
+	it("expands run-chromatic object to run-chromatic: true + chromatic-projects", async () => {
+		const written: string[] = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [
+				{
+					name: "test",
+					with: {
+						"run-unit": false,
+						"run-storybook": true,
+						"run-chromatic": {
+							projects: [
+								{ tokenName: "WEB", workingDir: "apps/web" },
+								{ tokenName: "UI", workingDir: "packages/ui" },
+							],
+						},
+					},
+				},
+			],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (_: string, content: string) => {
+						written.push(content);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const testWorkflow = written.find((c) => c.includes("run-chromatic"));
+		expect(testWorkflow).toBeDefined();
+		expect(testWorkflow).toContain("run-chromatic: true");
+		expect(testWorkflow).toContain("chromatic-projects:");
+		expect(testWorkflow).toContain("WEB");
+		expect(testWorkflow).toContain("UI");
+	});
+
 	it("dry-run skips workflow writes", async () => {
 		let writeCallCount = 0;
 		const loaded = loadedFrom({

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -541,13 +541,11 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		const runChromatic = raw["run-chromatic"];
 		if (runChromatic !== null && typeof runChromatic === "object" && "projects" in runChromatic) {
 			result["run-chromatic"] = true;
-			const projects = (runChromatic as { projects: Record<string, unknown>[] }).projects.map(
-				(p) => ({
-					...p,
-					// chromaui/action expects untraced as newline-separated string
-					...(Array.isArray(p.untraced) ? { untraced: p.untraced.join("\n") } : {}),
-				})
-			);
+			const projects = (runChromatic as { projects: Record<string, unknown>[] }).projects.map((p) => ({
+				...p,
+				// chromaui/action expects untraced as newline-separated string
+				...(Array.isArray(p.untraced) ? { untraced: p.untraced.join("\n") } : {}),
+			}));
 			result["chromatic-projects"] = JSON.stringify(projects);
 		}
 		return result;

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -534,12 +534,21 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	// generating the thin caller. Currently handles:
 	//   run-chromatic: { projects: [...] }
 	//   → run-chromatic: true, chromatic-projects: JSON.stringify(projects)
+	// Within each project, arrays (e.g. untraced) are joined to newline-
+	// separated strings as expected by the chromaui/action input schema.
 	function normalizeWorkflowWith(raw: Record<string, unknown>): Record<string, unknown> {
 		const result = { ...raw };
 		const runChromatic = raw["run-chromatic"];
 		if (runChromatic !== null && typeof runChromatic === "object" && "projects" in runChromatic) {
 			result["run-chromatic"] = true;
-			result["chromatic-projects"] = JSON.stringify((runChromatic as { projects: unknown[] }).projects);
+			const projects = (runChromatic as { projects: Record<string, unknown>[] }).projects.map(
+				(p) => ({
+					...p,
+					// chromaui/action expects untraced as newline-separated string
+					...(Array.isArray(p.untraced) ? { untraced: p.untraced.join("\n") } : {}),
+				})
+			);
+			result["chromatic-projects"] = JSON.stringify(projects);
 		}
 		return result;
 	}

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -530,13 +530,30 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	}
 
 	// ── source: workflow thin wrappers ──────────────────────────────────
+	// Expand structured with-values to flat GitHub Actions inputs before
+	// generating the thin caller. Currently handles:
+	//   run-chromatic: { projects: [...] }
+	//   → run-chromatic: true, chromatic-projects: JSON.stringify(projects)
+	function normalizeWorkflowWith(raw: Record<string, unknown>): Record<string, unknown> {
+		const result = { ...raw };
+		const runChromatic = raw["run-chromatic"];
+		if (runChromatic !== null && typeof runChromatic === "object" && "projects" in runChromatic) {
+			result["run-chromatic"] = true;
+			result["chromatic-projects"] = JSON.stringify(
+				(runChromatic as { projects: unknown[] }).projects
+			);
+		}
+		return result;
+	}
+
 	const workflows = config.workflows;
 	if (loader.has("source") && workflows && workflows.length > 0) {
 		const source = loader.get("source") as Source;
 		print(style.step("workflows"));
 		for (const entry of workflows) {
 			const name = typeof entry === "string" ? entry : entry.name;
-			const withOverrides = typeof entry === "object" ? entry.with : undefined;
+			const rawWith = typeof entry === "object" ? entry.with : undefined;
+			const withOverrides = rawWith ? normalizeWorkflowWith(rawWith) : undefined;
 			const additionalPaths = typeof entry === "object" ? entry.paths : undefined;
 
 			// Enforce that the test workflow has at least one test type enabled.

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -539,9 +539,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		const runChromatic = raw["run-chromatic"];
 		if (runChromatic !== null && typeof runChromatic === "object" && "projects" in runChromatic) {
 			result["run-chromatic"] = true;
-			result["chromatic-projects"] = JSON.stringify(
-				(runChromatic as { projects: unknown[] }).projects
-			);
+			result["chromatic-projects"] = JSON.stringify((runChromatic as { projects: unknown[] }).projects);
 		}
 		return result;
 	}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -149,6 +149,67 @@ export interface EnvConfig {
 	namespaces?: string[];
 }
 
+/**
+ * A single Chromatic project entry in a monorepo `run-chromatic` config.
+ * Each entry produces one matrix job in CI, publishing to a separate Chromatic project.
+ *
+ * The `tokenName` maps to a repository secret named `CHROMATIC_PROJECT_TOKEN_<TOKENNAME>`.
+ * Additional fields correspond to chromaui/action inputs and are passed through directly.
+ *
+ * @see https://www.chromatic.com/docs/monorepos/
+ */
+export interface ChromaticProjectConfig {
+	/**
+	 * Secret suffix. The CI job reads `CHROMATIC_PROJECT_TOKEN_<tokenName>`.
+	 * Must be uppercase (e.g. `"WEB"`, `"UI"`).
+	 */
+	tokenName: string;
+	/**
+	 * Path to run the Chromatic build from, relative to the repo root.
+	 * Typically the package directory (e.g. `"apps/web"`, `"packages/ui"`).
+	 */
+	workingDir: string;
+	/**
+	 * Script name to build Storybook. Defaults to `"build:storybook"`.
+	 * Must accept `--output-dir` pass-through (use `turbo run … --` at root).
+	 */
+	buildScript?: string;
+	/**
+	 * Path to the Storybook folder relative to `workingDir`, for TurboSnap.
+	 * Tells Chromatic where to find `.storybook/` when the Storybook config
+	 * is in a subdirectory. Corresponds to `--storybook-base-dir`.
+	 */
+	storybookBaseDir?: string;
+	/**
+	 * Glob patterns of files/dirs that should NOT trigger a TurboSnap bailout
+	 * when changed. Useful for ignoring non-UI changes in a monorepo
+	 * (e.g. `"./packages/!(ui)/**"` to focus TurboSnap on the UI package).
+	 * Corresponds to `--untraced`. Accepts a single glob string or array.
+	 */
+	untraced?: string | string[];
+	/**
+	 * Glob patterns matching story files to snapshot. When set, only matching
+	 * stories are captured. Corresponds to `--only-story-files`.
+	 * Cannot be combined with `onlyStoryNames`.
+	 */
+	onlyStoryFiles?: string;
+	/**
+	 * Exit with code 0 even when visual changes are detected.
+	 * Useful during initial setup before baselines are approved.
+	 * Corresponds to `--exit-zero-on-changes`.
+	 */
+	exitZeroOnChanges?: boolean;
+}
+
+/**
+ * Typed `with:` inputs for the `test` reusable workflow.
+ * `run-chromatic` accepts either a plain boolean (single-project) or a
+ * `ChromaticProjectConfig[]` object (multi-project monorepo).
+ */
+export type WorkflowWithConfig = Record<string, unknown> & {
+	"run-chromatic"?: boolean | { projects: ChromaticProjectConfig[] };
+};
+
 export interface HolocronConfig {
 	/** Project name. Derived from package.json when absent. */
 	name?: string;
@@ -178,11 +239,29 @@ export interface HolocronConfig {
 	 * Use `paths` to append additional `on.push.paths` entries beyond the
 	 * template default (e.g. the repo-specific docs content package path).
 	 *
+	 * ### run-chromatic
+	 * For a single-project repo, use `"run-chromatic": true` with a
+	 * `CHROMATIC_PROJECT_TOKEN` repository secret.
+	 *
+	 * For monorepos with multiple Storybooks, use the object form:
+	 * ```ts
+	 * "run-chromatic": {
+	 *   projects: [
+	 *     { tokenName: "WEB", workingDir: "apps/web" },
+	 *     { tokenName: "UI",  workingDir: "packages/ui" },
+	 *   ]
+	 * }
+	 * ```
+	 * Each `tokenName` maps to a repository secret named
+	 * `CHROMATIC_PROJECT_TOKEN_<TOKENNAME>`. `holocron setup` expands this
+	 * to the flat `run-chromatic: true` + `chromatic-projects: <json>` inputs
+	 * that the reusable workflow accepts.
+	 *
 	 * @example
 	 * ["lint", { "name": "release", "with": { "run-build": false } }]
 	 * { "name": "deploy-docs", "with": { "name": "configs" }, "paths": ["packages/configs-docs/**"] }
 	 */
-	workflows?: Array<string | { name: string; with?: Record<string, unknown>; paths?: string[] }>;
+	workflows?: Array<string | { name: string; with?: WorkflowWithConfig; paths?: string[] }>;
 	providers: RawProvidersConfig;
 	apps?: AppConfig[];
 	doctor?: DoctorConfig;
@@ -245,7 +324,7 @@ export interface ResolvedHolocronConfig {
 	description?: string;
 	homepage?: string;
 	repo?: RepoConfig;
-	workflows?: Array<string | { name: string; with?: Record<string, unknown>; paths?: string[] }>;
+	workflows?: Array<string | { name: string; with?: WorkflowWithConfig; paths?: string[] }>;
 	providers: ResolvedProvidersConfig;
 	apps: AppConfig[];
 	doctor: DoctorConfig;

--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -23,6 +23,17 @@ on: # yamllint disable-line rule:truthy
         type: boolean
         required: false
         default: false
+      chromatic-projects:
+        description: >
+          JSON array of Chromatic projects to build, one matrix job per entry.
+          Each entry: { "tokenName": "WEB", "workingDir": "apps/web", "buildScript": "build:storybook" }.
+          tokenName maps to secret CHROMATIC_PROJECT_TOKEN_<TOKENNAME>; omit or
+          leave empty to use the bare CHROMATIC_PROJECT_TOKEN secret (single-project default).
+          buildScript defaults to "build:storybook" when omitted.
+          Default runs a single job from the repo root using CHROMATIC_PROJECT_TOKEN.
+        type: string
+        required: false
+        default: '[{"tokenName":"","workingDir":".","buildScript":"build:storybook"}]'
       run-user-flow:
         description: Run Cypress E2E user-flow tests (requires cypress.config.*)
         type: boolean
@@ -112,8 +123,12 @@ jobs:
           files: '**/test-report.junit.xml'
 
   visual-and-composition:
-    name: Test Visual and Composition
+    name: Test Visual and Composition (${{ matrix.project.tokenName || 'default' }})
     if: ${{ inputs.run-chromatic }}
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ${{ fromJSON(inputs.chromatic-projects) }}
     permissions:
       contents: read
       statuses: write
@@ -130,9 +145,10 @@ jobs:
       - uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18
         name: Publish to Chromatic
         with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          projectToken: ${{ matrix.project.tokenName == '' && secrets.CHROMATIC_PROJECT_TOKEN || secrets[format('CHROMATIC_PROJECT_TOKEN_{0}', matrix.project.tokenName)] }}
           token: ${{ github.token }}
-          buildScriptName: build:storybook
+          buildScriptName: ${{ matrix.project.buildScript || 'build:storybook' }}
+          workingDir: ${{ matrix.project.workingDir || '.' }}
 
   interaction-and-accessibility:
     name: Test Interactions and Accessibility

--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -149,6 +149,10 @@ jobs:
           token: ${{ github.token }}
           buildScriptName: ${{ matrix.project.buildScript || 'build:storybook' }}
           workingDir: ${{ matrix.project.workingDir || '.' }}
+          storybookBaseDir: ${{ matrix.project.storybookBaseDir || '' }}
+          untraced: ${{ matrix.project.untraced || '' }}
+          onlyStoryFiles: ${{ matrix.project.onlyStoryFiles || '' }}
+          exitZeroOnChanges: ${{ matrix.project.exitZeroOnChanges || false }}
 
   interaction-and-accessibility:
     name: Test Interactions and Accessibility


### PR DESCRIPTION
## Summary

Adds a `chromatic-projects` input (JSON array) to the test reusable workflow so monorepos can publish multiple Storybooks to separate Chromatic projects without forking or modifying the central workflow.

Each entry in the array:
| Field | Required | Description |
|---|---|---|
| `tokenName` | yes | Suffix for the secret: `CHROMATIC_PROJECT_TOKEN_<TOKENNAME>`. Empty string → uses bare `CHROMATIC_PROJECT_TOKEN` (single-project backwards compat) |
| `workingDir` | yes | Directory to run Chromatic from (e.g. `apps/web`, `packages/ui`) |
| `buildScript` | no | Defaults to `build:storybook` |

**Default** (no change for single-project repos): `[{"tokenName":"","workingDir":".","buildScript":"build:storybook"}]` — same behaviour as today using `CHROMATIC_PROJECT_TOKEN`.

**Monorepo usage** in `holocron.config.ts`:
```ts
{
  name: "test",
  with: {
    "run-chromatic": true,
    "chromatic-projects": '[{"tokenName":"WEB","workingDir":"apps/web"},{"tokenName":"UI","workingDir":"packages/ui"}]',
  }
}
```
Secrets: `CHROMATIC_PROJECT_TOKEN_WEB`, `CHROMATIC_PROJECT_TOKEN_UI`.

## Test plan
- [ ] Single-project repo with `CHROMATIC_PROJECT_TOKEN`: matrix runs once, backwards compat preserved
- [ ] Monorepo with two entries: two matrix jobs, each using the correct token