### PR TITLE
fix(setup): single-quote JSON values in generated YAML with: blocks

### DIFF
--- a/packages/cli/src/commands/setup-workflows.ts
+++ b/packages/cli/src/commands/setup-workflows.ts
@@ -94,7 +94,15 @@ export function generateThinCallerContent(
 	const base = WORKFLOW_TEMPLATES[name];
 	if (!base) return "";
 
-	const fmt = (k: string, v: unknown) => `      ${k}: ${v === true ? "true" : v === false ? "false" : String(v)}`;
+	// YAML treats bare [ and { as sequence/mapping nodes; single-quote them so
+	// values like JSON arrays are kept as strings.
+	const yamlScalar = (v: unknown): string => {
+		if (v === true) return "true";
+		if (v === false) return "false";
+		const s = String(v);
+		return s.startsWith("[") || s.startsWith("{") ? `'${s}'` : s;
+	};
+	const fmt = (k: string, v: unknown) => `      ${k}: ${yamlScalar(v)}`;
 
 	let result = base;
 
@@ -129,7 +137,7 @@ export function generateThinCallerContent(
 				.filter((e): e is [string, string] => e !== null)
 		);
 		for (const [k, v] of Object.entries(withOverrides)) {
-			existingEntries.set(k, v === true ? "true" : v === false ? "false" : String(v));
+			existingEntries.set(k, yamlScalar(v));
 		}
 		const merged = [...existingEntries.entries()].map(([k, v]) => `      ${k}: ${v}`).join("\n");
 		return result.replace(withBlockRe, `    with:\n${merged}\n`);


### PR DESCRIPTION
## Summary

YAML treats a bare `[` as a sequence node opener and `{` as a mapping node opener. Generated `with:` blocks containing JSON values (e.g. `chromatic-projects: [{"tokenName":"WEB",...}]`) were failing yamllint with `expected scalar node but found sequence node` and `too few spaces after comma` errors.

Single-quoting values that start with `[` or `{` fixes both errors — the whole thing becomes an opaque string to the YAML parser.