### PR TITLE
fix(test): add explicit cypress install step before cypress-io action

### DIFF
--- a/packages/cli/src/templates/workflows/test.yml
+++ b/packages/cli/src/templates/workflows/test.yml
@@ -198,6 +198,9 @@ jobs:
       - uses: theholocron/.github/.github/actions/setup@main
         name: Setup
 
+      - run: pnpm exec cypress install
+        name: Install Cypress binary
+
       - uses: cypress-io/github-action@1052aa98bbbe4f55210f844878213c07d9c8c399 # v6.7.13
         name: Cypress run
         with:


### PR DESCRIPTION
## Summary

When pnpm's node_modules cache is warm, `pnpm install --frozen-lockfile` outputs "Already up to date" and skips postinstall scripts — including the Cypress binary download. The `cypress-io/github-action` then runs `verify` and fails with "Cypress binary is missing."

Adding an explicit `pnpm exec cypress install` step after setup and before the action ensures the binary is always present. `cypress install` is a no-op if the binary is already cached at `~/.cache/Cypress`, so there's no overhead on warm runs.

## Why not `prepare`

The alternative (adding `cypress install` to the root `prepare` script) runs on every local `pnpm install`, forcing the binary download for contributors who don't use Cypress. This is a CI concern and belongs here.