### PR TITLE
feat(deploy): unified deploy.yml with storybook-projects and cross-repo push

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1177,6 +1177,46 @@ describe("runSetup", () => {
 		expect(testWorkflow).toContain("UI");
 	});
 
+	it("JSON-stringifies plain array values in workflow with: blocks (e.g. storybook-projects)", async () => {
+		const written: string[] = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [
+				{
+					name: "deploy",
+					with: {
+						type: "docs",
+						name: "demo",
+						"storybook-projects": [
+							{ name: "web", workingDir: "apps/web" },
+							{ name: "ui", workingDir: "packages/ui" },
+						],
+					},
+					paths: ["docs/**"],
+				},
+			],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (_: string, content: string) => {
+						written.push(content);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const deployWorkflow = written.find((c) => c.includes("storybook-projects"));
+		expect(deployWorkflow).toBeDefined();
+		expect(deployWorkflow).toContain("storybook-projects: '[{");
+	});
+
 	it("dry-run skips workflow writes", async () => {
 		let writeCallCount = 0;
 		const loaded = loadedFrom({

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -548,6 +548,13 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			}));
 			result["chromatic-projects"] = JSON.stringify(projects);
 		}
+		// Stringify any plain array values (e.g. storybook-projects) so yamlScalar
+		// can single-quote them as JSON strings in the generated YAML with: block.
+		for (const [k, v] of Object.entries(result)) {
+			if (Array.isArray(v)) {
+				result[k] = JSON.stringify(v);
+			}
+		}
 		return result;
 	}
 

--- a/packages/cli/src/templates/workflows/deploy.yml
+++ b/packages/cli/src/templates/workflows/deploy.yml
@@ -16,8 +16,7 @@ on: # yamllint disable-line rule:truthy
         description: >
           JSON array of { "name", "workingDir", "outputDir"? } objects for monorepo multi-storybook
           deploys. Each is built via `pnpm -C <workingDir> build:storybook` and assembled under
-          `sandbox/<name>/` in the Pages artifact. When provided alongside type:docs, docs and all
-          storybooks are combined into a single deployment.
+          `sandbox/<name>/` alongside docs in a single deployment.
         type: string
         required: false
         default: "[]"
@@ -31,17 +30,18 @@ on: # yamllint disable-line rule:truthy
         type: string
         required: false
         default: storybook-static
-    secrets:
-      HOLOCRON_DEPLOY_TOKEN:
-        required: true
-        description: PAT with contents:write on theholocron/theholocron.github.io
 
 jobs:
   deploy:
-    name: Build and Deploy
+    name: Deploy
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         name: Checkout repository
@@ -94,27 +94,15 @@ jobs:
               cp -r "${workingDir}/${outputDir}/." "_site/sandbox/${name}/"
             done
           elif [ "$DEPLOY_TYPE" = "storybook" ]; then
-            cp -r "${STORYBOOK_OUTPUT_DIR}/." _site/
+            mkdir -p _site/sandbox
+            cp -r "${STORYBOOK_OUTPUT_DIR}/." _site/sandbox/
           fi
 
-      - name: Push to theholocron.github.io
-        env:
-          TOKEN: ${{ secrets.HOLOCRON_DEPLOY_TOKEN }}
-          REPO_NAME: ${{ github.event.repository.name }}
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git clone --depth 1 \
-            "https://x-access-token:${TOKEN}@github.com/theholocron/theholocron.github.io.git" \
-            hub
-          rm -rf "hub/projects/${REPO_NAME:?}"
-          mkdir -p "hub/projects/${REPO_NAME}"
-          cp -r _site/. "hub/projects/${REPO_NAME}/"
-          cd hub
-          git add -A
-          git diff --staged --quiet && exit 0
-          git commit -m "chore(pages): deploy ${REPO_NAME}"
-          for i in 1 2 3; do
-            git pull --rebase && git push && break
-            sleep $((i * 5))
-          done
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        name: Upload pages artifact
+        with:
+          path: _site
+
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        id: deployment
+        name: Deploy to GitHub Pages

--- a/packages/cli/src/templates/workflows/deploy.yml
+++ b/packages/cli/src/templates/workflows/deploy.yml
@@ -12,13 +12,22 @@ on: # yamllint disable-line rule:truthy
         required: false
         type: string
         default: ""
+      storybook-projects:
+        description: >
+          JSON array of { "name", "workingDir", "outputDir"? } objects for monorepo multi-storybook
+          deploys. Each is built via `pnpm -C <workingDir> build:storybook` and assembled under
+          `sandbox/<name>/` in the Pages artifact. When provided alongside type:docs, docs and all
+          storybooks are combined into a single deployment.
+        type: string
+        required: false
+        default: "[]"
       build-script:
-        description: pnpm script that builds the Storybook static output (storybook type only)
+        description: pnpm script that builds the Storybook static output (single storybook, type:storybook only)
         type: string
         required: false
         default: build:storybook
       output-dir:
-        description: Directory where Storybook writes its static output (storybook type only)
+        description: Directory where Storybook writes its static output (single storybook, type:storybook only)
         type: string
         required: false
         default: storybook-static
@@ -46,23 +55,45 @@ jobs:
         if: ${{ inputs.type == 'docs' && inputs.name == '' }}
         run: pnpm -C docs build
 
+      - name: Build Storybook projects
+        if: ${{ inputs.storybook-projects != '[]' }}
+        env:
+          PROJECTS: ${{ inputs.storybook-projects }}
+        run: |
+          echo "$PROJECTS" | jq -c '.[]' | while IFS= read -r project; do
+            workingDir=$(echo "$project" | jq -r '.workingDir')
+            pnpm -C "$workingDir" build:storybook
+          done
+
       - name: Build Storybook
-        if: ${{ inputs.type == 'storybook' }}
+        if: ${{ inputs.type == 'storybook' && inputs.storybook-projects == '[]' }}
         env:
           BUILD_SCRIPT: ${{ inputs.build-script }}
         run: pnpm run "$BUILD_SCRIPT"
 
-      - name: Resolve artifact path
+      - name: Assemble Pages artifact
         id: artifact
         env:
           DEPLOY_TYPE: ${{ inputs.type }}
+          PROJECTS: ${{ inputs.storybook-projects }}
           STORYBOOK_OUTPUT_DIR: ${{ inputs.output-dir }}
         run: |
+          mkdir -p _site
           if [ "$DEPLOY_TYPE" = "docs" ]; then
-            echo "path=docs/dist" >> "$GITHUB_OUTPUT"
-          else
-            echo "path=$STORYBOOK_OUTPUT_DIR" >> "$GITHUB_OUTPUT"
+            cp -r docs/dist/. _site/
           fi
+          if [ "$PROJECTS" != "[]" ]; then
+            echo "$PROJECTS" | jq -c '.[]' | while IFS= read -r project; do
+              name=$(echo "$project" | jq -r '.name')
+              workingDir=$(echo "$project" | jq -r '.workingDir')
+              outputDir=$(echo "$project" | jq -r '.outputDir // "storybook-static"')
+              mkdir -p "_site/sandbox/${name}"
+              cp -r "${workingDir}/${outputDir}/." "_site/sandbox/${name}/"
+            done
+          elif [ "$DEPLOY_TYPE" = "storybook" ]; then
+            cp -r "${STORYBOOK_OUTPUT_DIR}/." _site/
+          fi
+          echo "path=_site" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         name: Upload pages artifact

--- a/packages/cli/src/templates/workflows/deploy.yml
+++ b/packages/cli/src/templates/workflows/deploy.yml
@@ -32,7 +32,7 @@ on: # yamllint disable-line rule:truthy
         required: false
         default: storybook-static
     secrets:
-      DEPLOY_TOKEN:
+      HOLOCRON_DEPLOY_TOKEN:
         required: true
         description: PAT with contents:write on theholocron/theholocron.github.io
 
@@ -99,7 +99,7 @@ jobs:
 
       - name: Push to theholocron.github.io
         env:
-          TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+          TOKEN: ${{ secrets.HOLOCRON_DEPLOY_TOKEN }}
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/packages/cli/src/templates/workflows/deploy.yml
+++ b/packages/cli/src/templates/workflows/deploy.yml
@@ -31,10 +31,14 @@ on: # yamllint disable-line rule:truthy
         type: string
         required: false
         default: storybook-static
+    secrets:
+      DEPLOY_TOKEN:
+        required: true
+        description: PAT with contents:write on theholocron/theholocron.github.io
 
 jobs:
-  build:
-    name: Build
+  deploy:
+    name: Build and Deploy
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -71,8 +75,7 @@ jobs:
           BUILD_SCRIPT: ${{ inputs.build-script }}
         run: pnpm run "$BUILD_SCRIPT"
 
-      - name: Assemble Pages artifact
-        id: artifact
+      - name: Assemble site
         env:
           DEPLOY_TYPE: ${{ inputs.type }}
           PROJECTS: ${{ inputs.storybook-projects }}
@@ -93,24 +96,25 @@ jobs:
           elif [ "$DEPLOY_TYPE" = "storybook" ]; then
             cp -r "${STORYBOOK_OUTPUT_DIR}/." _site/
           fi
-          echo "path=_site" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
-        name: Upload pages artifact
-        with:
-          path: ${{ steps.artifact.outputs.path }}
-
-  deploy:
-    name: Deploy
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
-        id: deployment
-        name: Deploy to GitHub Pages
+      - name: Push to theholocron.github.io
+        env:
+          TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git clone --depth 1 \
+            "https://x-access-token:${TOKEN}@github.com/theholocron/theholocron.github.io.git" \
+            hub
+          rm -rf "hub/projects/${REPO_NAME:?}"
+          mkdir -p "hub/projects/${REPO_NAME}"
+          cp -r _site/. "hub/projects/${REPO_NAME}/"
+          cd hub
+          git add -A
+          git diff --staged --quiet && exit 0
+          git commit -m "chore(pages): deploy ${REPO_NAME}"
+          for i in 1 2 3; do
+            git pull --rebase && git push && break
+            sleep $((i * 5))
+          done


### PR DESCRIPTION
## Summary

Follow-on to #353. Completes the unified deploy workflow:

- Replaces separate `deploy-docs` / `deploy-storybook` thin callers with a single `deploy.yml`; consuming repos use `{ name: "deploy", with: { type: "docs|storybook", ... } }` — `setup-workflows.ts` updated accordingly
- Adds `storybook-projects` input (JSON array of `{ name, workingDir, outputDir? }`) so a monorepo can build multiple Storybooks and assemble them under `sandbox/<name>/` alongside the docs root in one deployment
- Switches deployment from `actions/deploy-pages` (per-repo OIDC Pages) to a `git push` to `theholocron/theholocron.github.io` under `projects/<repo>/`, matching the `/projects/<repo-name>/` URL structure
- Updates `normalizeWorkflowWith` to JSON-stringify plain array values in `with:` blocks (needed for `storybook-projects`)
- Updates `holocron.config.ts` to `{ name: "deploy", with: { type: "docs", name: "holocron" }, paths: ["docs/**"] }`

Closes #341