### PR TITLE
feat(deploy): add docs: true shorthand with auto-derived paths

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1428,6 +1428,38 @@ describe("runSetup", () => {
 		expect(deployContent).not.toContain("- docs/**");
 	});
 
+	it("skips path derivation for docs: { path: '.' }", async () => {
+		const writtenFiles: Array<[string, string]> = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [
+				{
+					name: "deploy",
+					with: { docs: { path: "." } },
+				},
+			],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (name: string, content: string) => {
+						writtenFiles.push([name, content]);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const [, deployContent] = writtenFiles.find(([n]) => n === "deploy.yml") ?? [];
+		expect(deployContent).toBeDefined();
+		expect(deployContent).not.toContain("paths:");
+	});
+
 	it("dry-run skips workflow writes", async () => {
 		let writeCallCount = 0;
 		const loaded = loadedFrom({

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1177,7 +1177,7 @@ describe("runSetup", () => {
 		expect(testWorkflow).toContain("UI");
 	});
 
-	it("JSON-stringifies plain array values in workflow with: blocks (e.g. storybook-projects)", async () => {
+	it("translates deploy storybook: shorthand to storybook-projects and sets type: docs", async () => {
 		const written: string[] = [];
 		const loaded = loadedFrom({
 			name: "demo",
@@ -1185,14 +1185,122 @@ describe("runSetup", () => {
 				{
 					name: "deploy",
 					with: {
-						type: "docs",
-						name: "demo",
-						"storybook-projects": [
-							{ name: "web", workingDir: "apps/web" },
-							{ name: "ui", workingDir: "packages/ui" },
+						docs: true,
+						storybook: [
+							{ name: "web", path: "apps/web" },
+							{ name: "ui", path: "packages/ui" },
 						],
 					},
-					paths: ["docs/**"],
+				},
+			],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (_: string, content: string) => {
+						written.push(content);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const deployWorkflow = written.find((c) => c.includes("deploy"));
+		expect(deployWorkflow).toBeDefined();
+		expect(deployWorkflow).toContain("type: docs");
+		expect(deployWorkflow).toContain("storybook-projects: '[{");
+		expect(deployWorkflow).toContain('"workingDir":"apps/web"');
+		expect(deployWorkflow).toContain('"workingDir":"packages/ui"');
+	});
+
+	it("auto-derives paths for deploy docs + storybook shorthand", async () => {
+		const writtenFiles: Array<[string, string]> = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [
+				{
+					name: "deploy",
+					with: {
+						docs: true,
+						storybook: [
+							{ name: "web", path: "apps/web" },
+							{ name: "ui", path: "packages/ui" },
+						],
+					},
+				},
+			],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (name: string, content: string) => {
+						writtenFiles.push([name, content]);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const [, deployContent] = writtenFiles.find(([n]) => n === "deploy.yml") ?? [];
+		expect(deployContent).toBeDefined();
+		expect(deployContent).toContain("- docs/**");
+		expect(deployContent).toContain("- apps/web/**");
+		expect(deployContent).toContain("- packages/ui/**");
+	});
+
+	it("auto-derives paths for deploy docs-only shorthand", async () => {
+		const writtenFiles: Array<[string, string]> = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [
+				{
+					name: "deploy",
+					with: { docs: true },
+				},
+			],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (name: string, content: string) => {
+						writtenFiles.push([name, content]);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const [, deployContent] = writtenFiles.find(([n]) => n === "deploy.yml") ?? [];
+		expect(deployContent).toBeDefined();
+		expect(deployContent).toContain("- docs/**");
+		expect(deployContent).not.toContain("apps/");
+	});
+
+	it("sets type: storybook for storybook-only deploy shorthand", async () => {
+		const written: string[] = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [
+				{
+					name: "deploy",
+					with: {
+						storybook: [{ name: "ui", path: "packages/ui" }],
+					},
 				},
 			],
 			providers: { source: "github" },
@@ -1214,7 +1322,110 @@ describe("runSetup", () => {
 		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
 		const deployWorkflow = written.find((c) => c.includes("storybook-projects"));
 		expect(deployWorkflow).toBeDefined();
-		expect(deployWorkflow).toContain("storybook-projects: '[{");
+		expect(deployWorkflow).toContain("type: storybook");
+		expect(deployWorkflow).not.toContain("type: docs");
+		expect(deployWorkflow).toContain("- packages/ui/**");
+	});
+
+	it("skips path derivation for storybook root (path: '.')", async () => {
+		const writtenFiles: Array<[string, string]> = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [
+				{
+					name: "deploy",
+					with: {
+						storybook: [{ name: "ui", path: "." }],
+					},
+				},
+			],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (name: string, content: string) => {
+						writtenFiles.push([name, content]);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const [, deployContent] = writtenFiles.find(([n]) => n === "deploy.yml") ?? [];
+		expect(deployContent).toBeDefined();
+		expect(deployContent).not.toContain("paths:");
+	});
+
+	it("explicit paths: overrides auto-derived deploy paths", async () => {
+		const writtenFiles: Array<[string, string]> = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [
+				{
+					name: "deploy",
+					with: { docs: true },
+					paths: ["packages/my-docs/**"],
+				},
+			],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (name: string, content: string) => {
+						writtenFiles.push([name, content]);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const [, deployContent] = writtenFiles.find(([n]) => n === "deploy.yml") ?? [];
+		expect(deployContent).toBeDefined();
+		expect(deployContent).toContain("- packages/my-docs/**");
+		expect(deployContent).not.toContain("- docs/**");
+	});
+
+	it("derives paths from docs: { path } custom location", async () => {
+		const writtenFiles: Array<[string, string]> = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [
+				{
+					name: "deploy",
+					with: { docs: { path: "packages/site" } },
+				},
+			],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (name: string, content: string) => {
+						writtenFiles.push([name, content]);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const [, deployContent] = writtenFiles.find(([n]) => n === "deploy.yml") ?? [];
+		expect(deployContent).toBeDefined();
+		expect(deployContent).toContain("- packages/site/**");
+		expect(deployContent).not.toContain("- docs/**");
 	});
 
 	it("dry-run skips workflow writes", async () => {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -536,8 +536,31 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	//   → run-chromatic: true, chromatic-projects: JSON.stringify(projects)
 	// Within each project, arrays (e.g. untraced) are joined to newline-
 	// separated strings as expected by the chromaui/action input schema.
+	//
+	// Also handles the high-level deploy shorthand:
+	//   docs: "docs"  → type: "docs"
+	//   storybook: [{ name, path }]  → type: "storybook" (if no docs), storybook-projects: JSON
 	function normalizeWorkflowWith(raw: Record<string, unknown>): Record<string, unknown> {
 		const result = { ...raw };
+
+		// Deploy shorthand: docs + storybook → type + storybook-projects
+		const hasDocs = raw["docs"] === true || (raw["docs"] !== null && typeof raw["docs"] === "object");
+		const storybookProjects = raw["storybook"];
+		if (hasDocs) {
+			result["type"] = "docs";
+			delete result["docs"];
+		}
+		if (Array.isArray(storybookProjects)) {
+			if (!hasDocs) result["type"] = "storybook";
+			result["storybook-projects"] = JSON.stringify(
+				(storybookProjects as Array<{ name: string; path: string }>).map(({ name, path }) => ({
+					name,
+					workingDir: path,
+				}))
+			);
+			delete result["storybook"];
+		}
+
 		const runChromatic = raw["run-chromatic"];
 		if (runChromatic !== null && typeof runChromatic === "object" && "projects" in runChromatic) {
 			result["run-chromatic"] = true;
@@ -558,6 +581,28 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		return result;
 	}
 
+	// Derive on.push.paths entries from the deploy with: shorthand so the user
+	// never needs to write paths: manually for deploy entries.
+	function deriveDeployPaths(raw: Record<string, unknown>): string[] {
+		const paths: string[] = [];
+		const docs = raw["docs"];
+		if (docs === true) {
+			paths.push("docs/**");
+		} else if (docs !== null && typeof docs === "object" && "path" in docs) {
+			const p = (docs as { path: string }).path;
+			if (p && p !== ".") paths.push(`${p}/**`);
+		}
+		const storybookProjects = raw["storybook"];
+		if (Array.isArray(storybookProjects)) {
+			for (const s of storybookProjects as Array<{ path?: string }>) {
+				if (typeof s.path === "string" && s.path !== "." && s.path !== "") {
+					paths.push(`${s.path}/**`);
+				}
+			}
+		}
+		return paths;
+	}
+
 	const workflows = config.workflows;
 	if (loader.has("source") && workflows && workflows.length > 0) {
 		const source = loader.get("source") as Source;
@@ -566,7 +611,10 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			const name = typeof entry === "string" ? entry : entry.name;
 			const rawWith = typeof entry === "object" ? entry.with : undefined;
 			const withOverrides = rawWith ? normalizeWorkflowWith(rawWith) : undefined;
-			const additionalPaths = typeof entry === "object" ? entry.paths : undefined;
+			const explicitPaths = typeof entry === "object" ? entry.paths : undefined;
+			const additionalPaths =
+				explicitPaths ??
+				(name === "deploy" && rawWith ? deriveDeployPaths(rawWith as Record<string, unknown>) : undefined);
 
 			// Enforce that the test workflow has at least one test type enabled.
 			// This check lives here so it fails at setup time rather than silently

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -202,12 +202,35 @@ export interface ChromaticProjectConfig {
 }
 
 /**
- * Typed `with:` inputs for the `test` reusable workflow.
+ * A single Storybook app in a deploy workflow config.
+ * `name` becomes the sandbox sub-path (`_site/sandbox/<name>/`);
+ * `path` is the working directory relative to the repo root.
+ */
+export interface StorybookDeployProject {
+	name: string;
+	path: string;
+}
+
+/**
+ * Typed `with:` inputs for reusable workflows.
+ *
  * `run-chromatic` accepts either a plain boolean (single-project) or a
  * `ChromaticProjectConfig[]` object (multi-project monorepo).
+ *
+ * `docs` / `storybook` are high-level deploy shorthand that `holocron setup`
+ * translates to `type` / `storybook-projects` before writing the thin caller.
+ * They also drive automatic `paths:` derivation so you never need to write
+ * `paths:` manually for deploy entries.
  */
 export type WorkflowWithConfig = Record<string, unknown> & {
 	"run-chromatic"?: boolean | { projects: ChromaticProjectConfig[] };
+	/**
+	 * Docs deployment shorthand. `true` uses the org-standard `docs/` directory;
+	 * `{ path: "custom" }` uses a custom directory. Both derive a `paths:` entry automatically.
+	 */
+	docs?: true | { path: string };
+	/** Storybook apps to deploy alongside docs. Each entry's `path` is appended to `paths:`. */
+	storybook?: StorybookDeployProject[];
 };
 
 export interface HolocronConfig {
@@ -230,14 +253,35 @@ export interface HolocronConfig {
 	 *
 	 * Supported values: "lint" | "test" | "typecheck" | "codeql" | "review" |
 	 *   "release" | "stale" | "greetings" | "dependencies" | "bookkeeping" | "audit" |
-	 *   "deploy-docs"
+	 *   "deploy"
 	 *
 	 * `holocron setup` writes `.github/workflows/<name>.yml` for each entry,
-	 * calling the corresponding `ci-<name>.yml@main` reusable workflow.
+	 * calling the corresponding reusable workflow in `theholocron/.github`.
 	 * Files are overwritten on each run — they are generated artifacts.
 	 *
-	 * Use `paths` to append additional `on.push.paths` entries beyond the
-	 * template default (e.g. the repo-specific docs content package path).
+	 * ### deploy workflow
+	 * Use `docs` and/or `storybook` in `with:` — setup derives `paths:` automatically.
+	 * `docs: true` uses the org-standard `docs/` directory; `docs: { path: "custom" }` overrides it.
+	 *
+	 * ```ts
+	 * // Docs only (standard layout)
+	 * { name: "deploy", with: { docs: true } }
+	 *
+	 * // Docs + monorepo storybooks
+	 * {
+	 *   name: "deploy",
+	 *   with: {
+	 *     docs: true,
+	 *     storybook: [
+	 *       { name: "web", path: "apps/web" },
+	 *       { name: "ui", path: "packages/ui" },
+	 *     ],
+	 *   },
+	 * }
+	 *
+	 * // Non-standard docs location
+	 * { name: "deploy", with: { docs: { path: "packages/site" } } }
+	 * ```
 	 *
 	 * ### run-chromatic
 	 * For a single-project repo, use `"run-chromatic": true` with a
@@ -259,7 +303,7 @@ export interface HolocronConfig {
 	 *
 	 * @example
 	 * ["lint", { "name": "release", "with": { "run-build": false } }]
-	 * { "name": "deploy-docs", "with": { "name": "configs" }, "paths": ["packages/configs-docs/**"] }
+	 * { "name": "deploy", "with": { "docs": true } }
 	 */
 	workflows?: Array<string | { name: string; with?: WorkflowWithConfig; paths?: string[] }>;
 	providers: RawProvidersConfig;


### PR DESCRIPTION
## Summary

- Adds `docs: true` shorthand to `WorkflowWithConfig` — uses the org-standard `docs/` directory without spelling it out; `docs: { path: "custom" }` handles non-standard layouts
- Adds `storybook: [{ name, path }]` shorthand that translates to `storybook-projects` + `type`
- `normalizeWorkflowWith` translates both shorthands to the reusable workflow's existing `type`/`storybook-projects` inputs
- `deriveDeployPaths` computes `on.push.paths` automatically from `docs` and `storybook[].path` — no manual `paths:` needed on deploy entries
- Explicit `paths:` still wins when provided

Before:
```ts
{ name: "deploy", with: { type: "docs", name: "clients" }, paths: ["docs/**"] }
```

After:
```ts
{ name: "deploy", with: { docs: true } }
```

Monorepo with storybooks:
```ts
{
  name: "deploy",
  with: {
    docs: true,
    storybook: [
      { name: "web", path: "apps/web" },
      { name: "ui", path: "packages/ui" },
    ],
  },
}
// generates paths: [docs/**, apps/web/**, packages/ui/**] automatically
```

## Test plan

- [x] `translates deploy storybook: shorthand to storybook-projects and sets type: docs`
- [x] `auto-derives paths for deploy docs + storybook shorthand`
- [x] `auto-derives paths for deploy docs-only shorthand`
- [x] `sets type: storybook for storybook-only deploy shorthand`
- [x] `skips path derivation for storybook root (path: '.')`
- [x] `derives paths from docs: { path } custom location`
- [x] `explicit paths: overrides auto-derived deploy paths`
- [x] 640/640 tests passing