### PR TITLE
feat(deploy): derive src/** and .storybook/** for root storybook path

### DIFF
--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
 	workflows: [
 		...workflows,
 		{ name: "release", with: { "sentry-project": "holocron-cli" } },
-		{ name: "deploy", with: { type: "docs", name: "holocron" }, paths: ["docs/**"] },
+		{ name: "deploy", with: { docs: true } },
 	],
 	providers: {
 		...providers,

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1327,7 +1327,7 @@ describe("runSetup", () => {
 		expect(deployWorkflow).toContain("- packages/ui/**");
 	});
 
-	it("skips path derivation for storybook root (path: '.')", async () => {
+	it("derives src/** and .storybook/** for root storybook (path: '.')", async () => {
 		const writtenFiles: Array<[string, string]> = [];
 		const loaded = loadedFrom({
 			name: "demo",
@@ -1358,7 +1358,8 @@ describe("runSetup", () => {
 		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
 		const [, deployContent] = writtenFiles.find(([n]) => n === "deploy.yml") ?? [];
 		expect(deployContent).toBeDefined();
-		expect(deployContent).not.toContain("paths:");
+		expect(deployContent).toContain("- src/**");
+		expect(deployContent).toContain("- .storybook/**");
 	});
 
 	it("explicit paths: overrides auto-derived deploy paths", async () => {

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1362,6 +1362,38 @@ describe("runSetup", () => {
 		expect(deployContent).toContain("- .storybook/**");
 	});
 
+	it("skips path derivation for storybook with empty path", async () => {
+		const writtenFiles: Array<[string, string]> = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [
+				{
+					name: "deploy",
+					with: { storybook: [{ name: "ui", path: "" }] },
+				},
+			],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (name: string, content: string) => {
+						writtenFiles.push([name, content]);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const [, deployContent] = writtenFiles.find(([n]) => n === "deploy.yml") ?? [];
+		expect(deployContent).toBeDefined();
+		expect(deployContent).not.toContain("paths:");
+	});
+
 	it("explicit paths: overrides auto-derived deploy paths", async () => {
 		const writtenFiles: Array<[string, string]> = [];
 		const loaded = loadedFrom({

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -595,8 +595,13 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		const storybookProjects = raw["storybook"];
 		if (Array.isArray(storybookProjects)) {
 			for (const s of storybookProjects as Array<{ path?: string }>) {
-				if (typeof s.path === "string" && s.path !== "." && s.path !== "") {
-					paths.push(`${s.path}/**`);
+				if (typeof s.path === "string" && s.path !== "") {
+					if (s.path === ".") {
+						paths.push("src/**");
+						paths.push(".storybook/**");
+					} else {
+						paths.push(`${s.path}/**`);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Root storybook entries (`path: "."`) now auto-derive `src/**` and `.storybook/**` instead of producing no paths filter
- Non-root storybooks are unchanged (`<path>/**` as before)
- `docs: { path: "." }` skip is unchanged

This means repos using `storybook: [{ name: "app", path: "." }]` no longer need explicit `paths:` in their deploy config.

## Test plan

- [x] `derives src/** and .storybook/** for root storybook (path: '.')` — 641/641 passing