### PR TITLE
feat(deploy): make storybook path optional, defaulting to repo root

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1362,7 +1362,41 @@ describe("runSetup", () => {
 		expect(deployContent).toContain("- .storybook/**");
 	});
 
-	it("skips path derivation for storybook with empty path", async () => {
+	it("defaults path to root when path is omitted from storybook entry", async () => {
+		const writtenFiles: Array<[string, string]> = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [
+				{
+					name: "deploy",
+					with: { storybook: [{ name: "app" }] },
+				},
+			],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (name: string, content: string) => {
+						writtenFiles.push([name, content]);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const [, deployContent] = writtenFiles.find(([n]) => n === "deploy.yml") ?? [];
+		expect(deployContent).toBeDefined();
+		expect(deployContent).toContain("- src/**");
+		expect(deployContent).toContain("- .storybook/**");
+		expect(deployContent).toContain('"workingDir":"."');
+	});
+
+	it("treats empty string path as root in storybook entry", async () => {
 		const writtenFiles: Array<[string, string]> = [];
 		const loaded = loadedFrom({
 			name: "demo",
@@ -1391,7 +1425,8 @@ describe("runSetup", () => {
 		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
 		const [, deployContent] = writtenFiles.find(([n]) => n === "deploy.yml") ?? [];
 		expect(deployContent).toBeDefined();
-		expect(deployContent).not.toContain("paths:");
+		expect(deployContent).toContain("- src/**");
+		expect(deployContent).toContain("- .storybook/**");
 	});
 
 	it("explicit paths: overrides auto-derived deploy paths", async () => {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -553,7 +553,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		if (Array.isArray(storybookProjects)) {
 			if (!hasDocs) result["type"] = "storybook";
 			result["storybook-projects"] = JSON.stringify(
-				(storybookProjects as Array<{ name: string; path: string }>).map(({ name, path }) => ({
+				(storybookProjects as Array<{ name: string; path?: string }>).map(({ name, path = "." }) => ({
 					name,
 					workingDir: path,
 				}))
@@ -595,13 +595,12 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 		const storybookProjects = raw["storybook"];
 		if (Array.isArray(storybookProjects)) {
 			for (const s of storybookProjects as Array<{ path?: string }>) {
-				if (typeof s.path === "string" && s.path !== "") {
-					if (s.path === ".") {
-						paths.push("src/**");
-						paths.push(".storybook/**");
-					} else {
-						paths.push(`${s.path}/**`);
-					}
+				const p = s.path || ".";
+				if (p === ".") {
+					paths.push("src/**");
+					paths.push(".storybook/**");
+				} else {
+					paths.push(`${p}/**`);
 				}
 			}
 		}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -203,12 +203,12 @@ export interface ChromaticProjectConfig {
 
 /**
  * A single Storybook app in a deploy workflow config.
- * `name` becomes the sandbox sub-path (`_site/sandbox/<name>/`);
- * `path` is the working directory relative to the repo root.
+ * `name` becomes the sandbox sub-path (`_site/sandbox/<name>/`).
+ * `path` is the working directory relative to the repo root; defaults to `"."` (repo root) when omitted.
  */
 export interface StorybookDeployProject {
 	name: string;
-	path: string;
+	path?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `path` in `StorybookDeployProject` is now optional — omitting it defaults to `"."` (repo root)
- Both `undefined` and `""` are treated as root, deriving `src/**` and `.storybook/**` automatically
- `normalizeWorkflowWith` defaults `workingDir` to `"."` when path is missing
- Monorepo entries with explicit paths are unchanged

Before: `storybook: [{ name: "app", path: "." }]`
After: `storybook: [{ name: "app" }]`

## Test plan

- [x] `defaults path to root when path is omitted from storybook entry`
- [x] `treats empty string path as root in storybook entry`
- [x] 643/643 tests passing