### PR TITLE
fix(audit): correct lighthouse-config default to lighthouse.config.cjs

### DIFF
--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -205,6 +205,32 @@ describe("runSyncGithub", () => {
 		expect(releaseBlob?.body?.content).toContain("run-build: false");
 	});
 
+	it("applies per-workflow with: overrides when TS config has trailing commas", async () => {
+		const configTs = `export default defineConfig({
+	workflows: [
+		{
+			name: "audit",
+			with: { "run-performance": true, "lighthouse-config": "lighthouse.config.cjs" },
+		},
+	],
+})`;
+		const { fn, calls } = makeFetch({}, undefined, configTs);
+		await runSyncGithub({
+			token: "ghp_test",
+			repo: "theholocron/.github-private",
+			branch: "chore/sync",
+			dryRun: false,
+			print: () => {},
+			fetch: fn,
+		});
+		const blobs = calls.filter((c) => c.method === "POST" && c.url.includes("/git/blobs"));
+		const auditBlob = blobs.find(
+			(c) => typeof c.body?.content === "string" && (c.body.content as string).includes("name: Audit")
+		);
+		expect(auditBlob?.body?.content).toContain("run-performance: true");
+		expect(auditBlob?.body?.content).toContain("lighthouse-config: lighthouse.config.cjs");
+	});
+
 	it("skips unchanged files and omits them from the commit tree", async () => {
 		// Pre-populate the tree with the actual git blob SHA for release.yml
 		// so sync treats it as unchanged.

--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -231,6 +231,67 @@ describe("runSyncGithub", () => {
 		expect(auditBlob?.body?.content).toContain("lighthouse-config: lighthouse.config.cjs");
 	});
 
+	it("parses name-only object entry with trailing comma", async () => {
+		const configTs = `export default defineConfig({
+	workflows: [
+		{
+			name: "typecheck",
+		},
+	],
+})`;
+		const { fn, calls } = makeFetch({}, undefined, configTs);
+		await runSyncGithub({
+			token: "ghp_test",
+			repo: "theholocron/.github-private",
+			branch: "chore/sync",
+			dryRun: false,
+			print: () => {},
+			fetch: fn,
+		});
+		const blobs = calls.filter((c) => c.method === "POST" && c.url.includes("/git/blobs"));
+		const typecheckBlob = blobs.find(
+			(c) => typeof c.body?.content === "string" && (c.body.content as string).includes("name: Typecheck")
+		);
+		expect(typecheckBlob).toBeDefined();
+		// name-only entry — no with: block injected
+		expect(typecheckBlob?.body?.content).not.toContain("with:");
+	});
+
+	it("parses mixed entries — some with with:, some name-only — all with trailing commas", async () => {
+		const configTs = `export default defineConfig({
+	workflows: [
+		"typecheck",
+		{
+			name: "release",
+			with: { "run-build": true },
+		},
+		{
+			name: "audit",
+			with: { "run-performance": true, "lighthouse-config": "lighthouse.config.cjs" },
+		},
+	],
+})`;
+		const { fn, calls } = makeFetch({}, undefined, configTs);
+		await runSyncGithub({
+			token: "ghp_test",
+			repo: "theholocron/.github-private",
+			branch: "chore/sync",
+			dryRun: false,
+			print: () => {},
+			fetch: fn,
+		});
+		const blobs = calls.filter((c) => c.method === "POST" && c.url.includes("/git/blobs"));
+		const getContent = (name: string) =>
+			blobs.find(
+				(c) => typeof c.body?.content === "string" && (c.body.content as string).includes(`name: ${name}`)
+			)?.body?.content as string | undefined;
+
+		expect(getContent("Typecheck")).toBeDefined();
+		expect(getContent("Release")).toContain("run-build: true");
+		expect(getContent("Audit")).toContain("run-performance: true");
+		expect(getContent("Audit")).toContain("lighthouse-config: lighthouse.config.cjs");
+	});
+
 	it("skips unchanged files and omits them from the commit tree", async () => {
 		// Pre-populate the tree with the actual git blob SHA for release.yml
 		// so sync treats it as unchanged.

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -76,7 +76,8 @@ function parseWorkflowsFromTs(source: string): WorkflowEntry[] {
 	const objSpans: Array<[number, number]> = [];
 
 	// Pass 1: object entries — { name: "foo", with: { ... } }
-	const objRe = /\{\s*name\s*:\s*"([^"]+)"(?:\s*,\s*with\s*:\s*(\{[^}]*\}))?\s*\}/g;
+	// The trailing ,? handles TS trailing commas: with: { ... },  }
+	const objRe = /\{\s*name\s*:\s*"([^"]+)"(?:\s*,\s*with\s*:\s*(\{[^}]*\}))?\s*,?\s*\}/g;
 	let m: RegExpExecArray | null;
 	while ((m = objRe.exec(body)) !== null) {
 		objSpans.push([m.index, m.index + m[0].length]);

--- a/packages/cli/src/templates/workflows/audit.yml
+++ b/packages/cli/src/templates/workflows/audit.yml
@@ -21,10 +21,10 @@ on: # yamllint disable-line rule:truthy
       lighthouse-config:
         description: >
           Path to the Lighthouse CI config file passed as --config to lhci autorun.
-          Defaults to lighthouse.config.js (the org standard).
+          Defaults to lighthouse.config.cjs (the org standard).
         type: string
         required: false
-        default: lighthouse.config.js
+        default: lighthouse.config.cjs
       knip-script:
         description: Script that invokes Knip (must exit non-zero on findings)
         type: string


### PR DESCRIPTION
## Summary

The `lighthouse-config` input in the reusable `audit.yml` workflow defaulted to `lighthouse.config.js`, but all org repos use `lighthouse.config.cjs`. Any repo using `run-performance: true` without explicitly overriding `lighthouse-config` would silently fail to find the config file.

Repos that already pass `lighthouse-config: lighthouse.config.cjs` explicitly are unaffected — this just makes the default correct.

`sync-workflow-templates` will push the updated workflow to all consumer repos.

## Test plan

- [ ] Verify `audit / Audit the performance` picks up the correct config on a repo that relies on the default