### PR TITLE
fix(sync-github): normalise with: overrides and derive paths for deploy shorthand

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1177,6 +1177,84 @@ describe("runSetup", () => {
 		expect(testWorkflow).toContain("UI");
 	});
 
+	it("joins untraced array to newline-separated string in chromatic-projects", async () => {
+		const written: string[] = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [
+				{
+					name: "test",
+					with: {
+						"run-unit": false,
+						"run-storybook": true,
+						"run-chromatic": {
+							projects: [
+								{
+									tokenName: "UI",
+									workingDir: "packages/ui",
+									untraced: ["./packages/!(ui)/**", "./apps/**"],
+								},
+							],
+						},
+					},
+				},
+			],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (_: string, content: string) => {
+						written.push(content);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const testWorkflow = written.find((c) => c.includes("chromatic-projects"));
+		expect(testWorkflow).toBeDefined();
+		// untraced array should be joined with \n, not left as JSON array
+		expect(testWorkflow).toContain("packages/!(ui)");
+		expect(testWorkflow).not.toContain('["./packages');
+	});
+
+	it("JSON-stringifies unrecognised array values passed directly in with:", async () => {
+		const written: string[] = [];
+		const loaded = loadedFrom({
+			name: "demo",
+			workflows: [
+				{
+					name: "release",
+					with: { "run-build": true, "extra-tags": ["v1", "latest"] as unknown as boolean },
+				},
+			],
+			providers: { source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					writeWorkflowFile: async (_: string, content: string) => {
+						written.push(content);
+					},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+		const releaseWorkflow = written.find((c) => c.includes("run-build"));
+		expect(releaseWorkflow).toBeDefined();
+		expect(releaseWorkflow).toContain("extra-tags: '[\"v1\"");
+	});
+
 	it("translates deploy storybook: shorthand to storybook-projects and sets type: docs", async () => {
 		const written: string[] = [];
 		const loaded = loadedFrom({

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -1252,7 +1252,7 @@ describe("runSetup", () => {
 		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
 		const releaseWorkflow = written.find((c) => c.includes("run-build"));
 		expect(releaseWorkflow).toBeDefined();
-		expect(releaseWorkflow).toContain("extra-tags: '[\"v1\"");
+		expect(releaseWorkflow).toContain('extra-tags: \'["v1"');
 	});
 
 	it("translates deploy storybook: shorthand to storybook-projects and sets type: docs", async () => {

--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -231,6 +231,30 @@ describe("runSyncGithub", () => {
 		expect(auditBlob?.body?.content).toContain("lighthouse-config: lighthouse.config.cjs");
 	});
 
+	it("parses unquoted TS keys in with: blocks (e.g. docs: true)", async () => {
+		const configTs = `export default defineConfig({
+	workflows: [
+		{ name: "deploy", with: { docs: true } },
+	],
+})`;
+		const { fn, calls } = makeFetch({}, undefined, configTs);
+		await runSyncGithub({
+			token: "ghp_test",
+			repo: "theholocron/.github-private",
+			branch: "chore/sync",
+			dryRun: false,
+			print: () => {},
+			fetch: fn,
+		});
+		const blobs = calls.filter((c) => c.method === "POST" && c.url.includes("/git/blobs"));
+		const deployBlob = blobs.find(
+			(c) => typeof c.body?.content === "string" && (c.body.content as string).includes("name: Deploy")
+		);
+		// docs: true is normalised → type: docs and paths: - docs/**
+		expect(deployBlob?.body?.content).toContain("type: docs");
+		expect(deployBlob?.body?.content).toContain("- docs/**");
+	});
+
 	it("parses name-only object entry with trailing comma", async () => {
 		const configTs = `export default defineConfig({
 	workflows: [

--- a/packages/cli/src/commands/setup-workflows.ts
+++ b/packages/cli/src/commands/setup-workflows.ts
@@ -157,3 +157,75 @@ export function generateThinCallerContent(
 	}
 	return injected;
 }
+
+/**
+ * Expand structured with-values to flat GitHub Actions inputs before
+ * generating the thin caller. Handles:
+ *   - deploy shorthand: docs/storybook → type + storybook-projects
+ *   - run-chromatic object → run-chromatic: true + chromatic-projects
+ *   - plain arrays → JSON-stringified for YAML scalar quoting
+ *
+ * Used by both `holocron setup` and `sync-workflow-templates`.
+ */
+export function normalizeWorkflowWith(raw: Record<string, unknown>): Record<string, unknown> {
+	const result = { ...raw };
+
+	const hasDocs = raw["docs"] === true || (raw["docs"] !== null && typeof raw["docs"] === "object");
+	const storybookProjects = raw["storybook"];
+	if (hasDocs) {
+		result["type"] = "docs";
+		delete result["docs"];
+	}
+	if (Array.isArray(storybookProjects)) {
+		if (!hasDocs) result["type"] = "storybook";
+		result["storybook-projects"] = JSON.stringify(
+			(storybookProjects as Array<{ name: string; path?: string }>).map(({ name, path = "." }) => ({
+				name,
+				workingDir: path,
+			}))
+		);
+		delete result["storybook"];
+	}
+
+	const runChromatic = raw["run-chromatic"];
+	if (runChromatic !== null && typeof runChromatic === "object" && "projects" in runChromatic) {
+		result["run-chromatic"] = true;
+		const projects = (runChromatic as { projects: Record<string, unknown>[] }).projects.map((p) => ({
+			...p,
+			...(Array.isArray(p.untraced) ? { untraced: (p.untraced as string[]).join("\n") } : {}),
+		}));
+		result["chromatic-projects"] = JSON.stringify(projects);
+	}
+	for (const [k, v] of Object.entries(result)) {
+		if (Array.isArray(v)) result[k] = JSON.stringify(v);
+	}
+	return result;
+}
+
+/**
+ * Derive on.push.paths entries from the deploy with: shorthand.
+ * Used by both `holocron setup` and `sync-workflow-templates`.
+ */
+export function deriveDeployPaths(raw: Record<string, unknown>): string[] {
+	const paths: string[] = [];
+	const docs = raw["docs"];
+	if (docs === true) {
+		paths.push("docs/**");
+	} else if (docs !== null && typeof docs === "object" && "path" in docs) {
+		const p = (docs as { path: string }).path;
+		if (p && p !== ".") paths.push(`${p}/**`);
+	}
+	const storybookProjects = raw["storybook"];
+	if (Array.isArray(storybookProjects)) {
+		for (const s of storybookProjects as Array<{ path?: string }>) {
+			const p = s.path || ".";
+			if (p === ".") {
+				paths.push("src/**");
+				paths.push(".storybook/**");
+			} else {
+				paths.push(`${p}/**`);
+			}
+		}
+	}
+	return paths;
+}

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -35,8 +35,10 @@ import { withSpinner } from "../ui/progress.js";
 import { style } from "../ui/style.js";
 import {
 	DEPENDABOT_CONFIG,
+	deriveDeployPaths,
 	generateThinCallerContent,
 	KNOWN_WORKFLOWS,
+	normalizeWorkflowWith,
 	scaffoldHeader,
 	WORKFLOW_CHECK_CONTEXTS,
 	workflowHeader,
@@ -530,82 +532,8 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 	}
 
 	// ── source: workflow thin wrappers ──────────────────────────────────
-	// Expand structured with-values to flat GitHub Actions inputs before
-	// generating the thin caller. Currently handles:
-	//   run-chromatic: { projects: [...] }
-	//   → run-chromatic: true, chromatic-projects: JSON.stringify(projects)
-	// Within each project, arrays (e.g. untraced) are joined to newline-
-	// separated strings as expected by the chromaui/action input schema.
-	//
-	// Also handles the high-level deploy shorthand:
-	//   docs: "docs"  → type: "docs"
-	//   storybook: [{ name, path }]  → type: "storybook" (if no docs), storybook-projects: JSON
-	function normalizeWorkflowWith(raw: Record<string, unknown>): Record<string, unknown> {
-		const result = { ...raw };
-
-		// Deploy shorthand: docs + storybook → type + storybook-projects
-		const hasDocs = raw["docs"] === true || (raw["docs"] !== null && typeof raw["docs"] === "object");
-		const storybookProjects = raw["storybook"];
-		if (hasDocs) {
-			result["type"] = "docs";
-			delete result["docs"];
-		}
-		if (Array.isArray(storybookProjects)) {
-			if (!hasDocs) result["type"] = "storybook";
-			result["storybook-projects"] = JSON.stringify(
-				(storybookProjects as Array<{ name: string; path?: string }>).map(({ name, path = "." }) => ({
-					name,
-					workingDir: path,
-				}))
-			);
-			delete result["storybook"];
-		}
-
-		const runChromatic = raw["run-chromatic"];
-		if (runChromatic !== null && typeof runChromatic === "object" && "projects" in runChromatic) {
-			result["run-chromatic"] = true;
-			const projects = (runChromatic as { projects: Record<string, unknown>[] }).projects.map((p) => ({
-				...p,
-				// chromaui/action expects untraced as newline-separated string
-				...(Array.isArray(p.untraced) ? { untraced: p.untraced.join("\n") } : {}),
-			}));
-			result["chromatic-projects"] = JSON.stringify(projects);
-		}
-		// Stringify any plain array values (e.g. storybook-projects) so yamlScalar
-		// can single-quote them as JSON strings in the generated YAML with: block.
-		for (const [k, v] of Object.entries(result)) {
-			if (Array.isArray(v)) {
-				result[k] = JSON.stringify(v);
-			}
-		}
-		return result;
-	}
-
-	// Derive on.push.paths entries from the deploy with: shorthand so the user
-	// never needs to write paths: manually for deploy entries.
-	function deriveDeployPaths(raw: Record<string, unknown>): string[] {
-		const paths: string[] = [];
-		const docs = raw["docs"];
-		if (docs === true) {
-			paths.push("docs/**");
-		} else if (docs !== null && typeof docs === "object" && "path" in docs) {
-			const p = (docs as { path: string }).path;
-			if (p && p !== ".") paths.push(`${p}/**`);
-		}
-		const storybookProjects = raw["storybook"];
-		if (Array.isArray(storybookProjects)) {
-			for (const s of storybookProjects as Array<{ path?: string }>) {
-				const p = s.path || ".";
-				if (p === ".") {
-					paths.push("src/**");
-					paths.push(".storybook/**");
-				} else {
-					paths.push(`${p}/**`);
-				}
-			}
-		}
-		return paths;
-	}
+	// normalizeWorkflowWith and deriveDeployPaths are imported from setup-workflows.ts
+	// so they're shared with sync-github.ts.
 
 	const workflows = config.workflows;
 	if (loader.has("source") && workflows && workflows.length > 0) {

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -179,8 +179,7 @@ function buildBatch(
 			if (allowedWorkflows && !allowedWorkflows.has(name)) continue;
 			const rawWith = withOverrides?.get(name);
 			const normalizedWith = rawWith ? normalizeWorkflowWith(rawWith) : undefined;
-			const additionalPaths =
-				name === "deploy" && rawWith ? deriveDeployPaths(rawWith) : undefined;
+			const additionalPaths = name === "deploy" && rawWith ? deriveDeployPaths(rawWith) : undefined;
 			const content = generateThinCallerContent(name, normalizedWith, additionalPaths);
 			if (!content) continue;
 			files.push({

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -6,7 +6,12 @@ import { createGitHubClient } from "@theholocron/github-client";
 import { ProviderApiError } from "@theholocron/http-client";
 
 import { ACTIONS, REUSABLE_WORKFLOWS, WORKFLOW_TEMPLATE_PROPERTIES } from "../templates/index.js";
-import { generateThinCallerContent, WORKFLOW_TEMPLATES } from "./setup-workflows.js";
+import {
+	deriveDeployPaths,
+	generateThinCallerContent,
+	normalizeWorkflowWith,
+	WORKFLOW_TEMPLATES,
+} from "./setup-workflows.js";
 
 const DEFAULT_REPO = "theholocron/.github";
 
@@ -84,7 +89,10 @@ function parseWorkflowsFromTs(source: string): WorkflowEntry[] {
 		let withObj: Record<string, unknown> | undefined;
 		if (m[2]) {
 			try {
-				withObj = JSON.parse(m[2]);
+				// TS object literals use unquoted keys (docs: true); JSON requires quoted keys.
+				// Normalise before parsing so both forms work.
+				const jsonSafe = m[2].replace(/([{,]\s*)([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:/g, '$1"$2":');
+				withObj = JSON.parse(jsonSafe) as Record<string, unknown>;
 			} catch {
 				/* ignore malformed with: value */
 			}
@@ -169,7 +177,11 @@ function buildBatch(
 	} else {
 		for (const name of Object.keys(REUSABLE_WORKFLOWS)) {
 			if (allowedWorkflows && !allowedWorkflows.has(name)) continue;
-			const content = generateThinCallerContent(name, withOverrides?.get(name));
+			const rawWith = withOverrides?.get(name);
+			const normalizedWith = rawWith ? normalizeWorkflowWith(rawWith) : undefined;
+			const additionalPaths =
+				name === "deploy" && rawWith ? deriveDeployPaths(rawWith) : undefined;
+			const content = generateThinCallerContent(name, normalizedWith, additionalPaths);
 			if (!content) continue;
 			files.push({
 				path: `.github/workflows/${name}.yml`,


### PR DESCRIPTION
## Summary

Two bugs in `sync-workflow-templates` prevented `with:` overrides from being applied correctly:

**1. Unquoted TS keys fail `JSON.parse`**
TypeScript allows unquoted property names (`docs: true`), but `JSON.parse` requires quoted keys (`"docs": true`). When `parseWorkflowsFromTs` extracted `{ docs: true }` and called `JSON.parse`, it threw and silently dropped the override — the workflow was synced without any `with:` block. Fixed by normalising identifier keys before parsing.

**2. `normalizeWorkflowWith` / `deriveDeployPaths` weren't called in the sync path**
These functions translate the deploy shorthand (`docs: true` → `type: docs`, `paths: docs/**`) but only lived in `setup.ts`. The sync called `generateThinCallerContent` with raw config values, so `docs: true` would appear verbatim in the YAML rather than being translated.

Fixed by moving both functions to `setup-workflows.ts` (exported, shared) and calling them in `buildBatch` before generating each thin caller.

**Effect on clients:** the `deploy.yml` will now be generated with `type: docs` in the `with:` block and `paths: - docs/**`, matching what `holocron setup` would produce.

## Test plan

- [x] `parses unquoted TS keys in with: blocks (e.g. docs: true)` — 647/647 passing
- [x] All existing sync-github and setup tests still pass