### PR TITLE
fix(sync-github): handle extra properties (e.g. paths:) after with: in config entries

### DIFF
--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -231,6 +231,29 @@ describe("runSyncGithub", () => {
 		expect(auditBlob?.body?.content).toContain("lighthouse-config: lighthouse.config.cjs");
 	});
 
+	it("preserves with: overrides when entry also has a paths: property", async () => {
+		const configTs = `export default defineConfig({
+	workflows: [
+		{ name: "deploy", with: { type: "docs", name: "clients" }, paths: ["docs/**"] },
+	],
+})`;
+		const { fn, calls } = makeFetch({}, undefined, configTs);
+		await runSyncGithub({
+			token: "ghp_test",
+			repo: "theholocron/.github-private",
+			branch: "chore/sync",
+			dryRun: false,
+			print: () => {},
+			fetch: fn,
+		});
+		const blobs = calls.filter((c) => c.method === "POST" && c.url.includes("/git/blobs"));
+		const deployBlob = blobs.find(
+			(c) => typeof c.body?.content === "string" && (c.body.content as string).includes("name: Deploy")
+		);
+		expect(deployBlob?.body?.content).toContain("type: docs");
+		expect(deployBlob?.body?.content).toContain("name: clients");
+	});
+
 	it("parses unquoted TS keys in with: blocks (e.g. docs: true)", async () => {
 		const configTs = `export default defineConfig({
 	workflows: [

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -80,9 +80,11 @@ function parseWorkflowsFromTs(source: string): WorkflowEntry[] {
 	const entries: Array<{ pos: number; entry: WorkflowEntry }> = [];
 	const objSpans: Array<[number, number]> = [];
 
-	// Pass 1: object entries — { name: "foo", with: { ... } }
+	// Pass 1: object entries — { name: "foo", with: { ... }, paths: [...] }
+	// (?:\s*,[^}]*)? skips any additional properties (e.g. paths: [...]) whose
+	// values don't contain } — covers arrays and strings but not nested objects.
 	// The trailing ,? handles TS trailing commas: with: { ... },  }
-	const objRe = /\{\s*name\s*:\s*"([^"]+)"(?:\s*,\s*with\s*:\s*(\{[^}]*\}))?\s*,?\s*\}/g;
+	const objRe = /\{\s*name\s*:\s*"([^"]+)"(?:\s*,\s*with\s*:\s*(\{[^}]*\}))?(?:\s*,[^}]*)?\s*,?\s*\}/g;
 	let m: RegExpExecArray | null;
 	while ((m = objRe.exec(body)) !== null) {
 		objSpans.push([m.index, m.index + m[0].length]);


### PR DESCRIPTION
## Summary

`parseWorkflowsFromTs` used `\s*,?\s*\}` to match the end of a config entry object. This failed when the entry had any additional property after `with:` (like `paths: [...]`), causing the `with:` overrides to be silently dropped and the thin caller to be generated without them.

**Root cause for clients:** `{ name: "deploy", with: { type: "docs", name: "clients" }, paths: ["docs/**"] }` — the `paths:` property after `with:` caused the full object match to fail. The entry was treated as name-only, generating a bare `deploy.yml` with no `with:` block.

**Fix:** adds `(?:\s*,[^}]*)?` before the closing `}` to skip any additional properties whose values don't contain `}` (covers arrays and strings).

## Test plan

- [x] `preserves with: overrides when entry also has a paths: property`
- [x] 650/650 tests passing