### PR TITLE
fix(npm-bump-versions): succeed when packages/ dir is absent (single-package repos)

### DIFF
--- a/packages/cli/src/__tests__/npm-bump-versions.test.ts
+++ b/packages/cli/src/__tests__/npm-bump-versions.test.ts
@@ -131,6 +131,27 @@ describe("runNpmBumpVersions", () => {
 		expect(JSON.parse(written[join(CWD, "package.json")]!).version).toBe("1.4.0");
 	});
 
+	it("returns dry-run status when packages/ does not exist and dryRun is true", async () => {
+		const { readFile, writeFile, isDir, written } = makeFs({
+			"package.json": { name: "root", version: "1.3.2" },
+		});
+		const report = await runNpmBumpVersions({
+			version: "1.4.0",
+			cwd: CWD,
+			dryRun: true,
+			print: () => {},
+			readFile,
+			writeFile,
+			listDir: () => {
+				throw new Error("ENOENT");
+			},
+			isDir,
+		});
+		expect(report.status).toBe("dry-run");
+		expect(report.bumped).toEqual(["root"]);
+		expect(Object.keys(written)).toHaveLength(0);
+	});
+
 	it("dry-run prints changes but does not write files", async () => {
 		const lines: string[] = [];
 		const { readFile, writeFile, listDir, isDir, written } = makeFs({

--- a/packages/cli/src/__tests__/npm-bump-versions.test.ts
+++ b/packages/cli/src/__tests__/npm-bump-versions.test.ts
@@ -111,12 +111,12 @@ describe("runNpmBumpVersions", () => {
 		expect(JSON.parse(written[join(CWD, "package.json")]!).version).toBe("4.2.0");
 	});
 
-	it("returns fail when packages/ directory does not exist", async () => {
-		const { readFile, writeFile, isDir } = makeFs({
-			"package.json": { name: "root", version: "0.0.0", private: true },
+	it("succeeds with only root when packages/ directory does not exist", async () => {
+		const { readFile, writeFile, isDir, written } = makeFs({
+			"package.json": { name: "root", version: "1.3.2" },
 		});
 		const report = await runNpmBumpVersions({
-			version: "4.2.0",
+			version: "1.4.0",
 			cwd: CWD,
 			print: () => {},
 			readFile,
@@ -126,8 +126,9 @@ describe("runNpmBumpVersions", () => {
 			},
 			isDir,
 		});
-		expect(report.status).toBe("fail");
-		expect(report.message).toContain("packages/ directory not found");
+		expect(report.status).toBe("ok");
+		expect(report.bumped).toEqual(["root"]);
+		expect(JSON.parse(written[join(CWD, "package.json")]!).version).toBe("1.4.0");
 	});
 
 	it("dry-run prints changes but does not write files", async () => {

--- a/packages/cli/src/commands/npm-bump-versions.ts
+++ b/packages/cli/src/commands/npm-bump-versions.ts
@@ -64,7 +64,8 @@ export async function runNpmBumpVersions(input: RunNpmBumpVersionsInput): Promis
 	try {
 		entries = listDir(packagesDir);
 	} catch {
-		return { status: "fail", bumped, skipped, message: `packages/ directory not found in ${cwd}` };
+		// No packages/ dir — single-package repo; root bump is sufficient.
+		return { status: dryRun ? "dry-run" : "ok", bumped, skipped };
 	}
 
 	for (const entry of entries) {


### PR DESCRIPTION
## Summary

- `holocron npm bump-versions` was designed for monorepos with a `packages/` directory. When called in a single-package repo (no `packages/`), it bumped root successfully but returned `status: "fail"` with "packages/ directory not found", causing the semantic-release `prepareCmd` to exit 1 and abort the release.
- Fix: treat a missing `packages/` as a single-package repo — return `status: "ok"` after bumping root rather than failing.
- Updated the existing test for this case to assert the new correct behaviour (root is bumped, status is `"ok"`).