### PR TITLE
feat(holocron-plugin-cloudflare, holocron-plugin-sentry): add dns and observability plugins

### DIFF
--- a/.notes/plugin-observability-notifications-dns-analytics.spec.md
+++ b/.notes/plugin-observability-notifications-dns-analytics.spec.md
@@ -23,27 +23,27 @@ them. Update `packages/cli/src/capabilities/index.ts`:
 
 ```typescript
 export interface Observability extends ProviderIdentity {
-	readonly key: "observability";
-	// envKeys replaces dsnEnvKey — providers push more than one env var
-	describe(): Promise<{ provider: string; envKeys: string[] }>;
-	// new — optional so existing code compiles unchanged
-	whoami?(): Promise<{ org: string }>;
-	ensureProject?(input: { name: string; platform?: string }): Promise<{
-		dsn: string;
-		alreadyExists: boolean;
-	}>;
+  readonly key: "observability";
+  // envKeys replaces dsnEnvKey — providers push more than one env var
+  describe(): Promise<{ provider: string; envKeys: string[] }>;
+  // new — optional so existing code compiles unchanged
+  whoami?(): Promise<{ org: string }>;
+  ensureProject?(input: { name: string; platform?: string }): Promise<{
+    dsn: string;
+    alreadyExists: boolean;
+  }>;
 }
 
 export interface Analytics extends ProviderIdentity {
-	readonly key: "analytics";
-	// envKeys replaces dsnEnvKey
-	describe(): Promise<{ provider: string; envKeys: string[] }>;
-	// new — optional so existing code compiles unchanged
-	whoami?(): Promise<{ org: string }>;
-	ensureProject?(name: string): Promise<{
-		token: string;
-		alreadyExists: boolean;
-	}>;
+  readonly key: "analytics";
+  // envKeys replaces dsnEnvKey
+  describe(): Promise<{ provider: string; envKeys: string[] }>;
+  // new — optional so existing code compiles unchanged
+  whoami?(): Promise<{ org: string }>;
+  ensureProject?(name: string): Promise<{
+    token: string;
+    alreadyExists: boolean;
+  }>;
 }
 ```
 
@@ -74,16 +74,16 @@ receiving `holocron setup` calls independently.
 
 ```typescript
 export interface SentryPluginOptions extends ResolveTokenInput {
-	/** Sentry organization slug. Required. */
-	org: string;
-	/**
-	 * Default team slug for project creation. Defaults to the org slug
-	 * when omitted (Sentry auto-assigns to the first available team).
-	 */
-	team?: string;
-	/** Override base URL for tests. Default: https://sentry.io */
-	baseUrl?: string;
-	fetch?: typeof fetch;
+  /** Sentry organization slug. Required. */
+  org: string;
+  /**
+   * Default team slug for project creation. Defaults to the org slug
+   * when omitted (Sentry auto-assigns to the first available team).
+   */
+  team?: string;
+  /** Override base URL for tests. Default: https://sentry.io */
+  baseUrl?: string;
+  fetch?: typeof fetch;
 }
 ```
 
@@ -100,21 +100,21 @@ export interface SentryPluginOptions extends ResolveTokenInput {
 
 ```typescript
 export const AUTH_HINT =
-	"generate an auth token at https://sentry.io/settings/account/api/auth-tokens/ " +
-	"with project:read, project:write, and org:read scopes, " +
-	"then run: holocron auth set sentry <TOKEN>";
+  "generate an auth token at https://sentry.io/settings/account/api/auth-tokens/ " +
+  "with project:read, project:write, and org:read scopes, " +
+  "then run: holocron auth set sentry <TOKEN>";
 ```
 
 ### Key API calls
 
 Base URL: `https://sentry.io/api/0`
 
-| Method | Purpose |
-|---|---|
-| `GET /auth/` | `whoami()` — verify token; returns `{ user: { username } }` |
-| `GET /organizations/{org}/projects/` | List projects for existence check |
-| `POST /teams/{org}/{team}/projects/` | Create project; body `{ name, platform }` |
-| `GET /projects/{org}/{slug}/keys/` | Get DSN; returns `[{ dsn: { public } }]` |
+| Method                               | Purpose                                                     |
+| ------------------------------------ | ----------------------------------------------------------- |
+| `GET /auth/`                         | `whoami()` — verify token; returns `{ user: { username } }` |
+| `GET /organizations/{org}/projects/` | List projects for existence check                           |
+| `POST /teams/{org}/{team}/projects/` | Create project; body `{ name, platform }`                   |
+| `GET /projects/{org}/{slug}/keys/`   | Get DSN; returns `[{ dsn: { public } }]`                    |
 
 ### Implementation sketch
 
@@ -171,15 +171,15 @@ readonly providerName = "slack";
 
 ```typescript
 export interface SlackPluginOptions extends ResolveTokenInput {
-	/**
-	 * Fallback channel id when `send()` is called without an explicit
-	 * channel. Accepts a channel id (C…) or name (#general).
-	 * Channel IDs are stable; prefer them over names.
-	 */
-	defaultChannel?: string;
-	/** Override base URL for tests. Default: https://slack.com/api */
-	baseUrl?: string;
-	fetch?: typeof fetch;
+  /**
+   * Fallback channel id when `send()` is called without an explicit
+   * channel. Accepts a channel id (C…) or name (#general).
+   * Channel IDs are stable; prefer them over names.
+   */
+  defaultChannel?: string;
+  /** Override base URL for tests. Default: https://slack.com/api */
+  baseUrl?: string;
+  fetch?: typeof fetch;
 }
 ```
 
@@ -193,18 +193,18 @@ export interface SlackPluginOptions extends ResolveTokenInput {
 
 ```typescript
 export const AUTH_HINT =
-	"create a Slack app at https://api.slack.com/apps, add the chat:write bot scope, " +
-	"install it to your workspace, then run: holocron auth set slack <xoxb-TOKEN>";
+  "create a Slack app at https://api.slack.com/apps, add the chat:write bot scope, " +
+  "install it to your workspace, then run: holocron auth set slack <xoxb-TOKEN>";
 ```
 
 ### Key API calls
 
 Base URL: `https://slack.com/api`
 
-| Method | Endpoint | Purpose |
-|---|---|---|
-| `POST` | `/auth.test` | `verifyToken` — returns `{ team, user }` |
-| `POST` | `/chat.postMessage` | `send(channel, message)` |
+| Method | Endpoint            | Purpose                                  |
+| ------ | ------------------- | ---------------------------------------- |
+| `POST` | `/auth.test`        | `verifyToken` — returns `{ team, user }` |
+| `POST` | `/chat.postMessage` | `send(channel, message)`                 |
 
 ### Implementation sketch
 
@@ -257,21 +257,21 @@ notification use case.
 
 ```typescript
 export interface DiscordPluginOptions extends ResolveTokenInput {
-	/**
-	 * Named webhook aliases — map a logical channel name to its webhook URL.
-	 * Allows `send("deploys", msg)` instead of passing the full URL.
-	 *
-	 * Example: { deploys: "https://discord.com/api/webhooks/123/abc" }
-	 */
-	webhooks?: Record<string, string>;
-	/**
-	 * Default webhook URL (or alias key) used when `send()` is called
-	 * without an explicit channel.
-	 */
-	defaultChannel?: string;
-	/** Override base URL for tests. Default: https://discord.com/api/v10 */
-	baseUrl?: string;
-	fetch?: typeof fetch;
+  /**
+   * Named webhook aliases — map a logical channel name to its webhook URL.
+   * Allows `send("deploys", msg)` instead of passing the full URL.
+   *
+   * Example: { deploys: "https://discord.com/api/webhooks/123/abc" }
+   */
+  webhooks?: Record<string, string>;
+  /**
+   * Default webhook URL (or alias key) used when `send()` is called
+   * without an explicit channel.
+   */
+  defaultChannel?: string;
+  /** Override base URL for tests. Default: https://discord.com/api/v10 */
+  baseUrl?: string;
+  fetch?: typeof fetch;
 }
 ```
 
@@ -289,18 +289,18 @@ to confirm it is reachable and valid.
 
 ```typescript
 export const AUTH_HINT =
-	"create a webhook in Discord → channel settings → Integrations → Webhooks, " +
-	"copy the URL, then run: holocron auth set discord <WEBHOOK_URL>";
+  "create a webhook in Discord → channel settings → Integrations → Webhooks, " +
+  "copy the URL, then run: holocron auth set discord <WEBHOOK_URL>";
 ```
 
 ### Key API calls
 
 Base URL: `https://discord.com/api/v10`
 
-| Method | Endpoint | Purpose |
-|---|---|---|
-| `GET` | `/webhooks/{id}/{token}` | `verifyToken` — confirm webhook is valid |
-| `POST` | `/webhooks/{id}/{token}` | `send()` — body `{ content: message }` |
+| Method | Endpoint                 | Purpose                                  |
+| ------ | ------------------------ | ---------------------------------------- |
+| `GET`  | `/webhooks/{id}/{token}` | `verifyToken` — confirm webhook is valid |
+| `POST` | `/webhooks/{id}/{token}` | `send()` — body `{ content: message }`   |
 
 ### Implementation sketch
 
@@ -355,16 +355,16 @@ readonly providerName = "cloudflare";
 
 ```typescript
 export interface CloudflarePluginOptions extends ResolveTokenInput {
-	/**
-	 * Cloudflare account id. Optional for standard DNS operations;
-	 * required only for account-scoped endpoints (e.g., custom nameservers).
-	 * Callers that need account-scoped ops receive a clear error at call
-	 * time if this is absent — no startup-time throw.
-	 */
-	accountId?: string;
-	/** Override base URL for tests. Default: https://api.cloudflare.com/client/v4 */
-	baseUrl?: string;
-	fetch?: typeof fetch;
+  /**
+   * Cloudflare account id. Optional for standard DNS operations;
+   * required only for account-scoped endpoints (e.g., custom nameservers).
+   * Callers that need account-scoped ops receive a clear error at call
+   * time if this is absent — no startup-time throw.
+   */
+  accountId?: string;
+  /** Override base URL for tests. Default: https://api.cloudflare.com/client/v4 */
+  baseUrl?: string;
+  fetch?: typeof fetch;
 }
 ```
 
@@ -379,23 +379,23 @@ export interface CloudflarePluginOptions extends ResolveTokenInput {
 
 ```typescript
 export const AUTH_HINT =
-	"create an API token at https://dash.cloudflare.com/profile/api-tokens " +
-	"with Zone:Read and DNS:Edit permissions, " +
-	"then run: holocron auth set cloudflare <TOKEN>";
+  "create an API token at https://dash.cloudflare.com/profile/api-tokens " +
+  "with Zone:Read and DNS:Edit permissions, " +
+  "then run: holocron auth set cloudflare <TOKEN>";
 ```
 
 ### Key API calls
 
 Base URL: `https://api.cloudflare.com/client/v4`
 
-| Method | Endpoint | Purpose |
-|---|---|---|
-| `GET` | `/user/tokens/verify` | `verifyToken` |
-| `GET` | `/zones?name={domain}` | Resolve domain → zone id |
-| `GET` | `/zones/{zoneId}/dns_records` | `listRecords()` |
-| `POST` | `/zones/{zoneId}/dns_records` | Create record |
-| `PATCH` | `/zones/{zoneId}/dns_records/{id}` | Update record |
-| `DELETE` | `/zones/{zoneId}/dns_records/{id}` | `deleteRecord()` |
+| Method   | Endpoint                           | Purpose                  |
+| -------- | ---------------------------------- | ------------------------ |
+| `GET`    | `/user/tokens/verify`              | `verifyToken`            |
+| `GET`    | `/zones?name={domain}`             | Resolve domain → zone id |
+| `GET`    | `/zones/{zoneId}/dns_records`      | `listRecords()`          |
+| `POST`   | `/zones/{zoneId}/dns_records`      | Create record            |
+| `PATCH`  | `/zones/{zoneId}/dns_records/{id}` | Update record            |
+| `DELETE` | `/zones/{zoneId}/dns_records/{id}` | `deleteRecord()`         |
 
 ### Implementation sketch
 
@@ -469,15 +469,15 @@ readonly providerName = "posthog";
 
 ```typescript
 export interface PostHogPluginOptions extends ResolveTokenInput {
-	/**
-	 * PostHog instance host. Defaults to US cloud.
-	 * EU cloud: "https://eu.posthog.com"
-	 * Self-hosted: your own base URL.
-	 */
-	host?: string;
-	/** Override base URL for tests (takes precedence over `host`). */
-	baseUrl?: string;
-	fetch?: typeof fetch;
+  /**
+   * PostHog instance host. Defaults to US cloud.
+   * EU cloud: "https://eu.posthog.com"
+   * Self-hosted: your own base URL.
+   */
+  host?: string;
+  /** Override base URL for tests (takes precedence over `host`). */
+  baseUrl?: string;
+  fetch?: typeof fetch;
 }
 ```
 
@@ -497,20 +497,20 @@ if that pattern emerges, promote it then.
 
 ```typescript
 export const AUTH_HINT =
-	"create a personal API key at https://app.posthog.com/settings/user/api-keys " +
-	"(not the project API key — that is the client-side tracking token), " +
-	"then run: holocron auth set posthog <phx_KEY>";
+  "create a personal API key at https://app.posthog.com/settings/user/api-keys " +
+  "(not the project API key — that is the client-side tracking token), " +
+  "then run: holocron auth set posthog <phx_KEY>";
 ```
 
 ### Key API calls
 
 Base URL: `{host}` (default `https://app.posthog.com`)
 
-| Method | Endpoint | Purpose |
-|---|---|---|
-| `GET` | `/api/users/@me/` | `whoami()` — verify key; returns `{ email, organization }` |
-| `GET` | `/api/projects/` | List projects for existence check |
-| `POST` | `/api/projects/` | Create project; body `{ name }`; returns `{ api_token }` |
+| Method | Endpoint          | Purpose                                                    |
+| ------ | ----------------- | ---------------------------------------------------------- |
+| `GET`  | `/api/users/@me/` | `whoami()` — verify key; returns `{ email, organization }` |
+| `GET`  | `/api/projects/`  | List projects for existence check                          |
+| `POST` | `/api/projects/`  | Create project; body `{ name }`; returns `{ api_token }`   |
 
 ### Implementation sketch
 

--- a/.notes/plugin-observability-notifications-dns-analytics.spec.md
+++ b/.notes/plugin-observability-notifications-dns-analytics.spec.md
@@ -1,0 +1,582 @@
+---
+status: draft
+issue: ~
+blocked-by: []
+---
+
+# New plugins — observability, notifications, dns, analytics
+
+Four capability slots defined in `capabilities/index.ts` have no implementing
+plugin. This spec covers all four. Each follows the same structural pattern as
+existing plugins (`neon`, `clerk`, `postman`, `vercel`).
+
+---
+
+## Prerequisite: extend `Observability` and `Analytics` interfaces
+
+`Observability` and `Analytics` currently expose only `describe()`. For
+`holocron setup` to provision these services, both need optional extension
+methods. The `describe()` return type also changes from `dsnEnvKey: string` to
+`envKeys: string[]`, matching the `Auth` pattern — providers like Sentry and
+PostHog push multiple env vars to GitHub Secrets and the caller needs all of
+them. Update `packages/cli/src/capabilities/index.ts`:
+
+```typescript
+export interface Observability extends ProviderIdentity {
+	readonly key: "observability";
+	// envKeys replaces dsnEnvKey — providers push more than one env var
+	describe(): Promise<{ provider: string; envKeys: string[] }>;
+	// new — optional so existing code compiles unchanged
+	whoami?(): Promise<{ org: string }>;
+	ensureProject?(input: { name: string; platform?: string }): Promise<{
+		dsn: string;
+		alreadyExists: boolean;
+	}>;
+}
+
+export interface Analytics extends ProviderIdentity {
+	readonly key: "analytics";
+	// envKeys replaces dsnEnvKey
+	describe(): Promise<{ provider: string; envKeys: string[] }>;
+	// new — optional so existing code compiles unchanged
+	whoami?(): Promise<{ org: string }>;
+	ensureProject?(name: string): Promise<{
+		token: string;
+		alreadyExists: boolean;
+	}>;
+}
+```
+
+`Notifications` and `Dns` are already sufficient as defined.
+
+Note: `observability`, `notifications`, `analytics`, and `tooling` all carry
+`"many"` cardinality in `CARDINALITY` already — multiple plugins of the same
+type can be active simultaneously. No cardinality changes are needed.
+
+---
+
+## 1. `holocron-plugin-sentry` — `observability`
+
+**Package:** `@theholocron/holocron-plugin-sentry`
+
+### Capability
+
+```typescript
+readonly key = "observability" as const;
+readonly providerName = "sentry";
+```
+
+Because `observability` cardinality is `"many"`, Sentry can run alongside future
+observability plugins (Datadog, New Relic, etc.) — all active at once, each
+receiving `holocron setup` calls independently.
+
+### Plugin options
+
+```typescript
+export interface SentryPluginOptions extends ResolveTokenInput {
+	/** Sentry organization slug. Required. */
+	org: string;
+	/**
+	 * Default team slug for project creation. Defaults to the org slug
+	 * when omitted (Sentry auto-assigns to the first available team).
+	 */
+	team?: string;
+	/** Override base URL for tests. Default: https://sentry.io */
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+```
+
+### Auth
+
+- Token type: Sentry **auth token** (user-owned or org-owned)
+- Required scopes: `project:read`, `project:write`, `org:read`
+- Env var: `HOLOCRON_SENTRY_TOKEN`
+- Where to generate: **Settings → Account → API → Auth Tokens**
+  (org tokens: **Settings → [org] → Developer Settings → Auth Tokens**)
+- Both user tokens and org tokens are accepted; org tokens are preferred for
+  CI automation. Document the difference in the plugin README but accept both —
+  the API calls are identical regardless of token type.
+
+```typescript
+export const AUTH_HINT =
+	"generate an auth token at https://sentry.io/settings/account/api/auth-tokens/ " +
+	"with project:read, project:write, and org:read scopes, " +
+	"then run: holocron auth set sentry <TOKEN>";
+```
+
+### Key API calls
+
+Base URL: `https://sentry.io/api/0`
+
+| Method | Purpose |
+|---|---|
+| `GET /auth/` | `whoami()` — verify token; returns `{ user: { username } }` |
+| `GET /organizations/{org}/projects/` | List projects for existence check |
+| `POST /teams/{org}/{team}/projects/` | Create project; body `{ name, platform }` |
+| `GET /projects/{org}/{slug}/keys/` | Get DSN; returns `[{ dsn: { public } }]` |
+
+### Implementation sketch
+
+```typescript
+async ensureProject(input: { name: string; platform?: string }) {
+	// 1. Check existence — Sentry has no idempotent create endpoint
+	const existing = await this.client.projects.list(this.opts.org);
+	const found = existing.find(p => p.slug === slugify(input.name));
+	if (found) {
+		const keys = await this.client.projects.keys(this.opts.org, found.slug);
+		return { dsn: keys[0].dsn.public, alreadyExists: true };
+	}
+	// 2. Create under team
+	const team = this.opts.team ?? this.opts.org;
+	const project = await this.client.projects.create(this.opts.org, team, {
+		name: input.name,
+		platform: input.platform ?? "node",
+	});
+	const keys = await this.client.projects.keys(this.opts.org, project.slug);
+	return { dsn: keys[0].dsn.public, alreadyExists: false };
+}
+
+async describe() {
+	return {
+		provider: "sentry",
+		envKeys: ["SENTRY_DSN", "NEXT_PUBLIC_SENTRY_DSN"],
+	};
+}
+```
+
+### `holocron setup` integration
+
+1. Call `ensureProject({ name: repoSlug })` → get DSN string
+2. Push both `SENTRY_DSN=<dsn>` and `NEXT_PUBLIC_SENTRY_DSN=<dsn>` to GitHub
+   Secrets via the `secrets` capability — same value, different names, both
+   required by the Sentry Next.js SDK
+3. Derive `platform` from `runtime_environment` in `holocron.config` repo
+   properties (`"browser"` → `"javascript"`, else `"node"`)
+
+---
+
+## 2. `holocron-plugin-slack` — `notifications`
+
+**Package:** `@theholocron/holocron-plugin-slack`
+
+### Capability
+
+```typescript
+readonly key = "notifications" as const;
+readonly providerName = "slack";
+```
+
+### Plugin options
+
+```typescript
+export interface SlackPluginOptions extends ResolveTokenInput {
+	/**
+	 * Fallback channel id when `send()` is called without an explicit
+	 * channel. Accepts a channel id (C…) or name (#general).
+	 * Channel IDs are stable; prefer them over names.
+	 */
+	defaultChannel?: string;
+	/** Override base URL for tests. Default: https://slack.com/api */
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+```
+
+### Auth
+
+- Token type: **Bot token** (`xoxb-*`)
+- Required scopes: `chat:write`
+- Optional scopes: `channels:read` (for name → id resolution)
+- Env var: `HOLOCRON_SLACK_TOKEN`
+- Where to generate: **api.slack.com/apps → [your app] → OAuth & Permissions**
+
+```typescript
+export const AUTH_HINT =
+	"create a Slack app at https://api.slack.com/apps, add the chat:write bot scope, " +
+	"install it to your workspace, then run: holocron auth set slack <xoxb-TOKEN>";
+```
+
+### Key API calls
+
+Base URL: `https://slack.com/api`
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| `POST` | `/auth.test` | `verifyToken` — returns `{ team, user }` |
+| `POST` | `/chat.postMessage` | `send(channel, message)` |
+
+### Implementation sketch
+
+```typescript
+async send(channel: string, message: string): Promise<void> {
+	const ch = channel || this.opts.defaultChannel;
+	if (!ch) throw new Error("SlackNotifications.send: channel required");
+	const res = await this.client.post("chat.postMessage", {
+		channel: ch,
+		text: message,
+	});
+	if (!res.ok) throw new ProviderApiError(res.error ?? "unknown", 400, res);
+}
+```
+
+### Notes
+
+- No `whoami()` in the `Notifications` interface; token verification is a
+  standalone `verifyToken` export (same pattern as all other plugins).
+- `notifications` cardinality is `"many"` — Slack and Discord can both be
+  active simultaneously, each routing to their own channels.
+
+---
+
+## 3. `holocron-plugin-discord` — `notifications`
+
+**Package:** `@theholocron/holocron-plugin-discord`
+
+### Capability
+
+```typescript
+readonly key = "notifications" as const;
+readonly providerName = "discord";
+```
+
+### Auth model: webhooks over bot tokens
+
+Discord supports both a full Bot API and per-channel Incoming Webhooks. Webhooks
+are the right choice here: they require no bot in a server, no OAuth2
+application, and no `MANAGE_WEBHOOKS` permission — just a URL the channel owner
+generates in Discord's UI. The `send()` interface maps cleanly: `channel` is
+the webhook URL (or a named alias resolved from plugin options), `message` is
+the content.
+
+Bot tokens are out of scope for v1. They add complexity (guild membership,
+intent declarations, permission grants) without benefit for a simple
+notification use case.
+
+### Plugin options
+
+```typescript
+export interface DiscordPluginOptions extends ResolveTokenInput {
+	/**
+	 * Named webhook aliases — map a logical channel name to its webhook URL.
+	 * Allows `send("deploys", msg)` instead of passing the full URL.
+	 *
+	 * Example: { deploys: "https://discord.com/api/webhooks/123/abc" }
+	 */
+	webhooks?: Record<string, string>;
+	/**
+	 * Default webhook URL (or alias key) used when `send()` is called
+	 * without an explicit channel.
+	 */
+	defaultChannel?: string;
+	/** Override base URL for tests. Default: https://discord.com/api/v10 */
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+```
+
+### Auth
+
+- Token type: **Incoming Webhook URL**
+  (`https://discord.com/api/webhooks/{id}/{token}`)
+- Env var: `HOLOCRON_DISCORD_WEBHOOK` (the full URL; no separate token)
+- Where to generate: **Discord → channel settings → Integrations → Webhooks**
+
+The webhook URL itself is the credential. Store it as the env var value rather
+than using `ResolveTokenInput`'s token field for a separate token.
+`verifyToken` can do a `GET` to the webhook URL (returns `{ id, name, ... }`)
+to confirm it is reachable and valid.
+
+```typescript
+export const AUTH_HINT =
+	"create a webhook in Discord → channel settings → Integrations → Webhooks, " +
+	"copy the URL, then run: holocron auth set discord <WEBHOOK_URL>";
+```
+
+### Key API calls
+
+Base URL: `https://discord.com/api/v10`
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| `GET` | `/webhooks/{id}/{token}` | `verifyToken` — confirm webhook is valid |
+| `POST` | `/webhooks/{id}/{token}` | `send()` — body `{ content: message }` |
+
+### Implementation sketch
+
+```typescript
+private resolve(channel: string): string {
+	// Channel is either an alias key or a raw webhook URL.
+	const alias = this.opts.webhooks?.[channel];
+	if (alias) return alias;
+	if (channel.startsWith("https://")) return channel;
+	const def = this.opts.defaultChannel
+		? (this.opts.webhooks?.[this.opts.defaultChannel] ?? this.opts.defaultChannel)
+		: undefined;
+	if (def) return def;
+	throw new Error(`DiscordNotifications.send: unknown channel "${channel}"`);
+}
+
+async send(channel: string, message: string): Promise<void> {
+	const webhookUrl = this.resolve(channel || this.opts.defaultChannel ?? "");
+	// Extract id/token from URL to build the API path.
+	const match = webhookUrl.match(/webhooks\/(\d+)\/([^/?]+)/);
+	if (!match) throw new Error(`Invalid Discord webhook URL: ${webhookUrl}`);
+	await this.client.post(`/webhooks/${match[1]}/${match[2]}`, {
+		content: message,
+	});
+}
+```
+
+### Notes
+
+- `webhooks` option lets `holocron.config.ts` name channels logically
+  (`"deploys"`, `"alerts"`) without embedding raw URLs. The URLs live in
+  environment variables and are resolved at plugin load time.
+- Discord webhook `POST` returns `204 No Content` on success — no response
+  body to parse, just check for non-2xx.
+- Rate limit: Discord webhooks allow 30 requests per minute per webhook. For
+  CI notification use cases this is not a concern.
+
+---
+
+## 4. `holocron-plugin-cloudflare` — `dns`
+
+**Package:** `@theholocron/holocron-plugin-cloudflare`
+
+### Capability
+
+```typescript
+readonly key = "dns" as const;
+readonly providerName = "cloudflare";
+```
+
+### Plugin options
+
+```typescript
+export interface CloudflarePluginOptions extends ResolveTokenInput {
+	/**
+	 * Cloudflare account id. Optional for standard DNS operations;
+	 * required only for account-scoped endpoints (e.g., custom nameservers).
+	 * Callers that need account-scoped ops receive a clear error at call
+	 * time if this is absent — no startup-time throw.
+	 */
+	accountId?: string;
+	/** Override base URL for tests. Default: https://api.cloudflare.com/client/v4 */
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+```
+
+### Auth
+
+- Token type: **API Token** (scoped; preferred over the legacy Global API Key)
+- Required permissions: `Zone:Read`, `DNS:Edit`
+- Env var: `HOLOCRON_CLOUDFLARE_TOKEN`
+- Where to generate: **dash.cloudflare.com/profile/api-tokens**
+- Token verification: `GET /user/tokens/verify` — exposed as standalone
+  `verifyToken` export, same pattern as all other plugins.
+
+```typescript
+export const AUTH_HINT =
+	"create an API token at https://dash.cloudflare.com/profile/api-tokens " +
+	"with Zone:Read and DNS:Edit permissions, " +
+	"then run: holocron auth set cloudflare <TOKEN>";
+```
+
+### Key API calls
+
+Base URL: `https://api.cloudflare.com/client/v4`
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| `GET` | `/user/tokens/verify` | `verifyToken` |
+| `GET` | `/zones?name={domain}` | Resolve domain → zone id |
+| `GET` | `/zones/{zoneId}/dns_records` | `listRecords()` |
+| `POST` | `/zones/{zoneId}/dns_records` | Create record |
+| `PATCH` | `/zones/{zoneId}/dns_records/{id}` | Update record |
+| `DELETE` | `/zones/{zoneId}/dns_records/{id}` | `deleteRecord()` |
+
+### Implementation sketch
+
+```typescript
+// Zone id is cached per domain name for the plugin instance lifetime.
+private zoneCache = new Map<string, string>();
+
+private async resolveZone(domain: string): Promise<string> {
+	if (this.zoneCache.has(domain)) return this.zoneCache.get(domain)!;
+	// Walk from the full domain up to find the apex zone.
+	const parts = domain.split(".");
+	for (let i = 0; i < parts.length - 1; i++) {
+		const candidate = parts.slice(i).join(".");
+		const zones = await this.client.zones.list({ name: candidate });
+		if (zones.result.length > 0) {
+			this.zoneCache.set(domain, zones.result[0].id);
+			return zones.result[0].id;
+		}
+	}
+	throw new ProviderApiError(`No Cloudflare zone found for: ${domain}`, 404, undefined);
+}
+
+async upsertRecord(domain: string, record: DnsRecord): Promise<DnsRecord> {
+	const zoneId = await this.resolveZone(domain);
+	const existing = await this.client.dns.list(zoneId, {
+		type: record.type,
+		name: record.name,
+	});
+	if (existing.result.length > 0) {
+		// Multiple same-type records (e.g. two TXT for SPF + DKIM): update
+		// only the first match and leave others intact. Documented limitation.
+		const updated = await this.client.dns.update(zoneId, existing.result[0].id, record);
+		return mapRecord(updated.result);
+	}
+	const created = await this.client.dns.create(zoneId, record);
+	return mapRecord(created.result);
+}
+```
+
+### Notes
+
+- The Cloudflare API wraps every response in `{ result, success, errors }`.
+  The REST client unwraps and throws `ProviderApiError` on `success: false`.
+- `DnsRecord.id` is optional in the capability interface. Cloudflare always
+  returns one; include it in the mapped output.
+- `upsertRecord` with multiple same-name/same-type records updates the first
+  match only. This is a documented limitation, not a bug — callers managing
+  multiple TXT records (SPF + DKIM + domain verification) should use
+  `listRecords` + `deleteRecord` + explicit creates instead.
+
+---
+
+## 5. `holocron-plugin-posthog` — `analytics`
+
+**Package:** `@theholocron/holocron-plugin-posthog`
+
+> **Decision: PostHog over alternatives.**
+> Segment requires a paid plan for project creation APIs. Amplitude and
+> Plausible have no programmatic project-creation endpoint at all. PostHog
+> is the only provider that creates a project and returns the tracking token
+> in a single free-tier API call (`POST /api/projects/`).
+
+### Capability
+
+```typescript
+readonly key = "analytics" as const;
+readonly providerName = "posthog";
+```
+
+### Plugin options
+
+```typescript
+export interface PostHogPluginOptions extends ResolveTokenInput {
+	/**
+	 * PostHog instance host. Defaults to US cloud.
+	 * EU cloud: "https://eu.posthog.com"
+	 * Self-hosted: your own base URL.
+	 */
+	host?: string;
+	/** Override base URL for tests (takes precedence over `host`). */
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+```
+
+`host` stays as a plugin option rather than a top-level `holocron.config`
+field. Repos that share a PostHog org across different regions are uncommon;
+if that pattern emerges, promote it then.
+
+### Auth
+
+- Token type: **Personal API key** (`phx_*`, from Settings → Personal API keys)
+- Scope: org-level; can create/list projects across the org
+- Env var: `HOLOCRON_POSTHOG_TOKEN`
+- **Distinct from the project API key** — that `phc_*` token is what the app
+  embeds at runtime. The personal API key is used only by this plugin for
+  management. Do not validate the token prefix — self-hosted instances may
+  issue differently formatted keys.
+
+```typescript
+export const AUTH_HINT =
+	"create a personal API key at https://app.posthog.com/settings/user/api-keys " +
+	"(not the project API key — that is the client-side tracking token), " +
+	"then run: holocron auth set posthog <phx_KEY>";
+```
+
+### Key API calls
+
+Base URL: `{host}` (default `https://app.posthog.com`)
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| `GET` | `/api/users/@me/` | `whoami()` — verify key; returns `{ email, organization }` |
+| `GET` | `/api/projects/` | List projects for existence check |
+| `POST` | `/api/projects/` | Create project; body `{ name }`; returns `{ api_token }` |
+
+### Implementation sketch
+
+```typescript
+async ensureProject(name: string): Promise<{ token: string; alreadyExists: boolean }> {
+	const projects = await this.client.projects.list();
+	const found = projects.results.find(p => p.name === name);
+	if (found) {
+		return { token: found.api_token, alreadyExists: true };
+	}
+	const project = await this.client.projects.create({ name });
+	return { token: project.api_token, alreadyExists: false };
+}
+
+async describe() {
+	return {
+		provider: "posthog",
+		envKeys: ["NEXT_PUBLIC_POSTHOG_KEY", "NEXT_PUBLIC_POSTHOG_HOST"],
+	};
+}
+```
+
+### `holocron setup` integration
+
+1. Call `ensureProject(repoSlug)` → get `api_token`
+2. Push `NEXT_PUBLIC_POSTHOG_KEY=<api_token>` to GitHub Secrets
+3. Push `NEXT_PUBLIC_POSTHOG_HOST=<host>` to GitHub Secrets — the PostHog SDK
+   requires both; `NEXT_PUBLIC_POSTHOG_HOST` is the resolved `host` option value
+
+### Notes
+
+- `NEXT_PUBLIC_POSTHOG_KEY` / `NEXT_PUBLIC_POSTHOG_HOST` are the Next.js
+  conventions. For v1, always use these names. A future `envKeyPrefix` plugin
+  option (`VITE_`, `""`) can handle non-Next frameworks without changing the
+  interface.
+- Both US (`app.posthog.com`) and EU (`eu.posthog.com`) clouds are supported
+  via `host`. Default to US; EU users set `host: "https://eu.posthog.com"` in
+  `holocron.config`.
+
+---
+
+## Shared implementation notes
+
+All five packages follow the same scaffold:
+
+```
+packages/
+  holocron-plugin-{name}/
+    src/
+      index.ts            # createPlugin, createContext, AUTH_HINT, re-exports
+      auth.ts             # resolveToken, ResolveTokenInput
+      rest.ts             # createClient, typed REST helpers
+      verify-token.ts     # verifyToken (standalone, used by `holocron auth check`)
+      capabilities/
+        {cap}.ts          # the capability class
+      __tests__/
+        {cap}.test.ts
+        helpers.ts        # stubFetch, fixture builders
+    package.json
+    tsconfig.json
+    tsdown.config.ts
+```
+
+Peer dependency on `@theholocron/cli` for capability interfaces and
+`ProviderApiError`. No dependency on `@theholocron/http-client` directly —
+go through `@theholocron/cli` re-exports.
+
+Add each package to `.releaserc.json`'s `prepareCmd` array (alphabetical),
+and to `codecov.yml`'s `component_management.individual_components`.

--- a/codecov.yml
+++ b/codecov.yml
@@ -46,6 +46,11 @@ component_management:
       paths:
         - packages/holocron-plugin-clerk/**
 
+    - component_id: holocron-plugin-cloudflare
+      name: "holocron-plugin-cloudflare"
+      paths:
+        - packages/holocron-plugin-cloudflare/**
+
     - component_id: holocron-plugin-doppler
       name: "holocron-plugin-doppler"
       paths:
@@ -70,6 +75,11 @@ component_management:
       name: "holocron-plugin-postman"
       paths:
         - packages/holocron-plugin-postman/**
+
+    - component_id: holocron-plugin-sentry
+      name: "holocron-plugin-sentry"
+      paths:
+        - packages/holocron-plugin-sentry/**
 
     - component_id: holocron-docs
       name: "holocron-docs"

--- a/packages/cli/src/capabilities/index.ts
+++ b/packages/cli/src/capabilities/index.ts
@@ -738,12 +738,18 @@ export interface Notifications extends ProviderIdentity {
 
 export interface Analytics extends ProviderIdentity {
 	readonly key: "analytics";
-	describe(): Promise<{ provider: string; dsnEnvKey: string }>;
+	/** Returns the env var names the app reads at runtime for this provider. */
+	describe(): Promise<{ provider: string; envKeys: string[] }>;
+	whoami?(): Promise<{ org: string }>;
+	ensureProject?(name: string): Promise<{ token: string; alreadyExists: boolean }>;
 }
 
 export interface Observability extends ProviderIdentity {
 	readonly key: "observability";
-	describe(): Promise<{ provider: string; dsnEnvKey: string }>;
+	/** Returns the env var names the app reads at runtime for this provider. */
+	describe(): Promise<{ provider: string; envKeys: string[] }>;
+	whoami?(): Promise<{ org: string }>;
+	ensureProject?(input: { name: string; platform?: string }): Promise<{ dsn: string; alreadyExists: boolean }>;
 }
 
 // ───────────────────────────────────────────────────────────────────────

--- a/packages/holocron-plugin-cloudflare/README.md
+++ b/packages/holocron-plugin-cloudflare/README.md
@@ -41,10 +41,10 @@ with `Zone:Read` and `DNS:Edit` permissions.
 
 ## What's implemented
 
-| Method          | What it does                                                                                                                                         |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `listRecords`   | Lists all DNS records in the zone that contains the given domain. Resolves the zone by walking label-by-label from the full domain to the apex.      |
-| `upsertRecord`  | Creates a record if none matching `type + name` exists; patches the first match otherwise. When multiple same-type records exist, only the first is updated — use explicit list/delete/create for multi-TXT scenarios (SPF + DKIM). |
-| `deleteRecord`  | Deletes a record by id within the zone that contains the given domain.                                                                               |
+| Method         | What it does                                                                                                                                                                                                                        |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listRecords`  | Lists all DNS records in the zone that contains the given domain. Resolves the zone by walking label-by-label from the full domain to the apex.                                                                                     |
+| `upsertRecord` | Creates a record if none matching `type + name` exists; patches the first match otherwise. When multiple same-type records exist, only the first is updated — use explicit list/delete/create for multi-TXT scenarios (SPF + DKIM). |
+| `deleteRecord` | Deletes a record by id within the zone that contains the given domain.                                                                                                                                                              |
 
 Zone ids are cached per plugin instance for the lifetime of the process.

--- a/packages/holocron-plugin-cloudflare/README.md
+++ b/packages/holocron-plugin-cloudflare/README.md
@@ -1,0 +1,50 @@
+<!-- editorconfig-checker-disable-file -->
+
+# `@theholocron/holocron-plugin-cloudflare`
+
+Cloudflare plugin for [Holocron](../cli). Implements the `dns`
+capability against the [Cloudflare v4 API](https://developers.cloudflare.com/api/).
+
+## Install
+
+<!-- prettier-ignore -->
+```bash
+pnpm add -D @theholocron/holocron-plugin-cloudflare
+
+```
+
+## Auth
+
+Token resolution order:
+
+1. `--token <TOKEN>` flag on the holocron invocation
+2. `HOLOCRON_CLOUDFLARE_TOKEN` env var
+3. `CLOUDFLARE_API_TOKEN` env var (the standard Cloudflare variable name)
+
+Generate a scoped API token at **dash.cloudflare.com/profile/api-tokens**
+with `Zone:Read` and `DNS:Edit` permissions.
+
+## Config
+
+<!-- prettier-ignore -->
+```jsonc
+{
+  "providers": {
+    "dns": ["cloudflare", { "accountId": "optional-account-id" }],
+  },
+}
+
+```
+
+- `accountId` (optional) — Cloudflare account id. Not required for DNS
+  operations; needed only if you extend the plugin to tunnel management.
+
+## What's implemented
+
+| Method          | What it does                                                                                                                                         |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listRecords`   | Lists all DNS records in the zone that contains the given domain. Resolves the zone by walking label-by-label from the full domain to the apex.      |
+| `upsertRecord`  | Creates a record if none matching `type + name` exists; patches the first match otherwise. When multiple same-type records exist, only the first is updated — use explicit list/delete/create for multi-TXT scenarios (SPF + DKIM). |
+| `deleteRecord`  | Deletes a record by id within the zone that contains the given domain.                                                                               |
+
+Zone ids are cached per plugin instance for the lifetime of the process.

--- a/packages/holocron-plugin-cloudflare/eslint.config.ts
+++ b/packages/holocron-plugin-cloudflare/eslint.config.ts
@@ -1,0 +1,5 @@
+import type { Linter } from "eslint";
+
+import root from "../../eslint.config.js";
+
+export default [...root, { ignores: ["dist/**", "coverage/**"] }] satisfies Linter.Config[];

--- a/packages/holocron-plugin-cloudflare/package.json
+++ b/packages/holocron-plugin-cloudflare/package.json
@@ -46,6 +46,7 @@
     "@theholocron/tsdown-config": "catalog:configs",
     "@theholocron/vitest-config": "catalog:configs",
     "@types/node": "catalog:",
+    "chalk": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",

--- a/packages/holocron-plugin-cloudflare/package.json
+++ b/packages/holocron-plugin-cloudflare/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@theholocron/holocron-plugin-cloudflare",
+  "version": "3.24.3",
+  "description": "Holocron plugin for Cloudflare. Implements the dns capability against Cloudflare's REST API — zone resolution, DNS record management.",
+  "homepage": "https://github.com/theholocron/holocron/tree/main/packages/holocron-plugin-cloudflare#readme",
+  "bugs": "https://github.com/theholocron/holocron/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/holocron.git",
+    "directory": "packages/holocron-plugin-cloudflare"
+  },
+  "license": "MIT",
+  "author": "Newton Koumantzelis",
+  "type": "module",
+  "main": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "peerDependencies": {
+    "@theholocron/cli": "workspace:*",
+    "@theholocron/cloudflare-client": "catalog:clients"
+  },
+  "peerDependenciesMeta": {
+    "@theholocron/cloudflare-client": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "@theholocron/cli": "workspace:*",
+    "@theholocron/cloudflare-client": "catalog:clients",
+    "@theholocron/eslint-config": "catalog:configs",
+    "@theholocron/tsconfig": "catalog:configs",
+    "@theholocron/tsdown-config": "catalog:configs",
+    "@theholocron/vitest-config": "catalog:configs",
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/eslint-plugin": "catalog:",
+    "eslint": "catalog:",
+    "eslint-plugin-n": "catalog:",
+    "globals": "catalog:",
+    "tsdown": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "types": "./dist/index.d.mts"
+}

--- a/packages/holocron-plugin-cloudflare/package.json
+++ b/packages/holocron-plugin-cloudflare/package.json
@@ -26,7 +26,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
     "@theholocron/cli": "workspace:*",

--- a/packages/holocron-plugin-cloudflare/scripts/validate.mjs
+++ b/packages/holocron-plugin-cloudflare/scripts/validate.mjs
@@ -11,66 +11,75 @@
  *   domain — the apex zone or subdomain to look up (e.g. "example.com")
  */
 
+import chalk from "chalk";
 import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
+
+const ok = (msg) => console.log(`${chalk.green("✓")} ${msg}`);
+const fail = (msg) => console.log(`${chalk.red("✗")} ${msg}`);
+const step = (msg) => console.log(chalk.cyan(`[${msg}]`));
+const hint = (msg) => console.log(chalk.dim(`         hint: ${msg}`));
 
 const [domain] = process.argv.slice(2);
 
 if (!domain) {
-	console.error("usage: pnpm --filter @theholocron/holocron-plugin-cloudflare validate <domain>");
-	console.error("  domain — the apex zone or subdomain to look up (e.g. example.com)");
+	console.error(chalk.red("usage:") + " pnpm --filter @theholocron/holocron-plugin-cloudflare validate <domain>");
+	console.error(chalk.dim("  domain — the apex zone or subdomain to look up (e.g. example.com)"));
 	process.exit(2);
 }
+
+console.log(chalk.bold("Validating @theholocron/holocron-plugin-cloudflare") + chalk.dim(" (READ-ONLY)"));
+console.log(chalk.dim(`  domain: ${domain}`));
+console.log("");
 
 let token;
 try {
 	token = resolveToken();
 } catch (err) {
 	if (err instanceof AuthError) {
-		console.error(err.message);
-		console.error("  see: packages/holocron-plugin-cloudflare/README.md#auth");
+		console.error(chalk.red(err.message));
+		console.error(chalk.dim("  see: packages/holocron-plugin-cloudflare/README.md#auth"));
 		process.exit(2);
 	}
 	throw err;
 }
 
-console.log("Validating @theholocron/holocron-plugin-cloudflare (READ-ONLY)");
-console.log(`  domain: ${domain}`);
-console.log("");
-
-console.log("[1/2] verifyToken");
+step("1/2 verifyToken");
 const verifyResult = await verifyToken(token);
-console.log(`      ${verifyResult.ok ? "✓" : "✗"} ${JSON.stringify(verifyResult)}`);
-if (!verifyResult.ok) {
-	const hint = hintFor(verifyResult.message);
-	if (hint) console.log(`         hint: ${hint}`);
+if (verifyResult.ok) {
+	ok(verifyResult.subject);
+} else {
+	fail(verifyResult.message);
+	const h = hintFor(verifyResult.message);
+	if (h) hint(h);
 }
 console.log("");
 
 const plugin = createPlugin({ cliToken: token });
 const dns = plugin.capabilities.dns();
 
-console.log(`[2/2] dns.listRecords("${domain}")`);
+step(`2/2 dns.listRecords("${domain}")`);
 await runStep(async () => {
 	const records = await dns.listRecords(domain);
-	console.log(`      ✓ ${records.length} record${records.length === 1 ? "" : "s"}`);
+	ok(`${records.length} record${records.length === 1 ? "" : "s"}`);
 	if (records.length > 0 && records.length <= 10) {
-		records.forEach((r) => console.log(`         · ${r.type.padEnd(5)} ${r.name}  →  ${r.content}`));
+		records.forEach((r) => console.log(chalk.dim(`   ${r.type.padEnd(5)} ${r.name}  →  ${r.content}`)));
 	} else if (records.length > 10) {
-		console.log(`         (${records.length} total — showing first 10)`);
-		records.slice(0, 10).forEach((r) => console.log(`         · ${r.type.padEnd(5)} ${r.name}  →  ${r.content}`));
+		console.log(chalk.dim(`   (${records.length} total — showing first 10)`));
+		records.slice(0, 10).forEach((r) => console.log(chalk.dim(`   ${r.type.padEnd(5)} ${r.name}  →  ${r.content}`)));
 	}
 });
+
 console.log("");
-console.log("Done. No writes.");
+console.log(chalk.dim("Done. No writes."));
 
 async function runStep(body) {
 	try {
 		await body();
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		console.log(`      ✗ ERROR: ${message}`);
-		const hint = hintFor(message);
-		if (hint) console.log(`         hint: ${hint}`);
+		fail(message);
+		const h = hintFor(message);
+		if (h) hint(h);
 	}
 }
 

--- a/packages/holocron-plugin-cloudflare/scripts/validate.mjs
+++ b/packages/holocron-plugin-cloudflare/scripts/validate.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Read-only smoke test for @theholocron/holocron-plugin-cloudflare.
+ *
+ * READ-ONLY. Tests verifyToken + dns.listRecords — proves auth,
+ * zone resolution, and DNS record parsing.
+ *
+ * Usage:
+ *   pnpm --filter @theholocron/holocron-plugin-cloudflare validate <domain>
+ *
+ *   domain — the apex zone or subdomain to look up (e.g. "example.com")
+ */
+
+import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
+
+const [domain] = process.argv.slice(2);
+
+if (!domain) {
+	console.error("usage: pnpm --filter @theholocron/holocron-plugin-cloudflare validate <domain>");
+	console.error("  domain — the apex zone or subdomain to look up (e.g. example.com)");
+	process.exit(2);
+}
+
+let token;
+try {
+	token = resolveToken();
+} catch (err) {
+	if (err instanceof AuthError) {
+		console.error(err.message);
+		console.error("  see: packages/holocron-plugin-cloudflare/README.md#auth");
+		process.exit(2);
+	}
+	throw err;
+}
+
+console.log("Validating @theholocron/holocron-plugin-cloudflare (READ-ONLY)");
+console.log(`  domain: ${domain}`);
+console.log("");
+
+console.log("[1/2] verifyToken");
+const verifyResult = await verifyToken(token);
+console.log(`      ${verifyResult.ok ? "✓" : "✗"} ${JSON.stringify(verifyResult)}`);
+if (!verifyResult.ok) {
+	const hint = hintFor(verifyResult.message);
+	if (hint) console.log(`         hint: ${hint}`);
+}
+console.log("");
+
+const plugin = createPlugin({ cliToken: token });
+const dns = plugin.capabilities.dns();
+
+console.log(`[2/2] dns.listRecords("${domain}")`);
+await runStep(async () => {
+	const records = await dns.listRecords(domain);
+	console.log(`      ✓ ${records.length} record${records.length === 1 ? "" : "s"}`);
+	if (records.length > 0 && records.length <= 10) {
+		records.forEach((r) => console.log(`         · ${r.type.padEnd(5)} ${r.name}  →  ${r.content}`));
+	} else if (records.length > 10) {
+		console.log(`         (${records.length} total — showing first 10)`);
+		records.slice(0, 10).forEach((r) => console.log(`         · ${r.type.padEnd(5)} ${r.name}  →  ${r.content}`));
+	}
+});
+console.log("");
+console.log("Done. No writes.");
+
+async function runStep(body) {
+	try {
+		await body();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.log(`      ✗ ERROR: ${message}`);
+		const hint = hintFor(message);
+		if (hint) console.log(`         hint: ${hint}`);
+	}
+}
+
+function hintFor(message) {
+	if (/→ 401|→ 403/.test(message))
+		return "token invalid or lacks scope — regenerate at https://dash.cloudflare.com/profile/api-tokens with Zone:Read + DNS:Edit";
+	if (/No Cloudflare zone found/i.test(message))
+		return "zone not found — verify the domain is in your Cloudflare account";
+	if (/fetch failed|status: 0|network/i.test(message)) return "network error — check api.cloudflare.com reachable";
+	if (/→ 5\d\d/.test(message)) return "server error — check https://www.cloudflarestatus.com";
+	return null;
+}

--- a/packages/holocron-plugin-cloudflare/scripts/validate.mjs
+++ b/packages/holocron-plugin-cloudflare/scripts/validate.mjs
@@ -12,6 +12,7 @@
  */
 
 import chalk from "chalk";
+
 import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
 
 const ok = (msg) => console.log(`${chalk.green("✓")} ${msg}`);

--- a/packages/holocron-plugin-cloudflare/src/__tests__/dns.test.ts
+++ b/packages/holocron-plugin-cloudflare/src/__tests__/dns.test.ts
@@ -54,6 +54,12 @@ describe("CloudflareDns.upsertRecord — create path", () => {
 		expect(calls[2]?.method).toBe("POST");
 		expect(calls[2]?.url).toContain(`/zones/${ZONE_ID}/dns_records`);
 	});
+
+	it("includes ttl in create body when provided", async () => {
+		const { dns, calls } = makeDns([cfOk([zone]), cfOk([]), cfOk(record)]);
+		await dns.upsertRecord(ZONE_NAME, { type: "A", name: "api", content: "1.2.3.4", ttl: 300 });
+		expect(calls[2]?.body).toMatchObject({ ttl: 300 });
+	});
 });
 
 describe("CloudflareDns.upsertRecord — update path", () => {
@@ -66,6 +72,12 @@ describe("CloudflareDns.upsertRecord — update path", () => {
 		await dns.upsertRecord(ZONE_NAME, { type: "CNAME", name: "www", content: "new.example.com" });
 		expect(calls[2]?.method).toBe("PATCH");
 		expect(calls[2]?.url).toContain(`/zones/${ZONE_ID}/dns_records/${record.id}`);
+	});
+
+	it("includes ttl in patch body when provided", async () => {
+		const { dns, calls } = makeDns([cfOk([zone]), cfOk([record]), cfOk(record)]);
+		await dns.upsertRecord(ZONE_NAME, { type: "CNAME", name: "www", content: "new.com", ttl: 60 });
+		expect(calls[2]?.body).toMatchObject({ ttl: 60 });
 	});
 });
 

--- a/packages/holocron-plugin-cloudflare/src/__tests__/dns.test.ts
+++ b/packages/holocron-plugin-cloudflare/src/__tests__/dns.test.ts
@@ -1,0 +1,79 @@
+import { ProviderApiError } from "@theholocron/cli";
+import { describe, expect, it } from "vitest";
+
+import { CloudflareDns } from "../capabilities/dns.js";
+import { createCloudflareClient } from "../rest.js";
+import { cfOk, stubFetch } from "./helpers.js";
+
+const BASE = "https://cf.test/client/v4";
+const ZONE_ID = "zone-abc";
+const ZONE_NAME = "example.com";
+
+function makeDns(responses: Parameters<typeof stubFetch>[0]) {
+	const { fetch, calls } = stubFetch(responses);
+	const client = createCloudflareClient({ token: "cf-tok", baseUrl: BASE, fetch });
+	return { dns: new CloudflareDns(client), calls };
+}
+
+const zone = { id: ZONE_ID, name: ZONE_NAME, status: "active" };
+const record = { id: "rec-1", type: "CNAME", name: "www", content: "example.com", ttl: 1, proxied: false };
+
+describe("CloudflareDns.listRecords", () => {
+	it("resolves zone then lists records", async () => {
+		const { dns, calls } = makeDns([cfOk([zone]), cfOk([record])]);
+		const result = await dns.listRecords(ZONE_NAME);
+		expect(calls[0]?.url).toContain(`/zones?`);
+		expect(calls[0]?.url).toContain(`name=${ZONE_NAME}`);
+		expect(calls[1]?.url).toContain(`/zones/${ZONE_ID}/dns_records`);
+		expect(result[0]?.id).toBe("rec-1");
+	});
+
+	it("caches the zone id on subsequent calls", async () => {
+		const { dns, calls } = makeDns([cfOk([zone]), cfOk([record]), cfOk([record])]);
+		await dns.listRecords(ZONE_NAME);
+		await dns.listRecords(ZONE_NAME);
+		// Zone lookup fires only once
+		const zoneLookups = calls.filter((c) => c.url.includes("/zones?"));
+		expect(zoneLookups).toHaveLength(1);
+	});
+
+	it("throws ProviderApiError when zone is not found", async () => {
+		const { dns } = makeDns([cfOk([])]);
+		await expect(dns.listRecords("absent.example")).rejects.toBeInstanceOf(ProviderApiError);
+	});
+});
+
+describe("CloudflareDns.upsertRecord — create path", () => {
+	it("creates when no existing record matches type+name", async () => {
+		const { dns, calls } = makeDns([
+			cfOk([zone]), // zone lookup
+			cfOk([]), // list — no match
+			cfOk(record), // create
+		]);
+		await dns.upsertRecord(ZONE_NAME, { type: "CNAME", name: "www", content: "other.com" });
+		expect(calls[2]?.method).toBe("POST");
+		expect(calls[2]?.url).toContain(`/zones/${ZONE_ID}/dns_records`);
+	});
+});
+
+describe("CloudflareDns.upsertRecord — update path", () => {
+	it("patches the first matching record", async () => {
+		const { dns, calls } = makeDns([
+			cfOk([zone]), // zone lookup
+			cfOk([record]), // list — match found
+			cfOk({ ...record, content: "new.example.com" }), // update
+		]);
+		await dns.upsertRecord(ZONE_NAME, { type: "CNAME", name: "www", content: "new.example.com" });
+		expect(calls[2]?.method).toBe("PATCH");
+		expect(calls[2]?.url).toContain(`/zones/${ZONE_ID}/dns_records/${record.id}`);
+	});
+});
+
+describe("CloudflareDns.deleteRecord", () => {
+	it("resolves zone then DELETEs the record", async () => {
+		const { dns, calls } = makeDns([cfOk([zone]), cfOk({ id: "rec-1" })]);
+		await dns.deleteRecord(ZONE_NAME, "rec-1");
+		expect(calls[1]?.method).toBe("DELETE");
+		expect(calls[1]?.url).toContain(`/zones/${ZONE_ID}/dns_records/rec-1`);
+	});
+});

--- a/packages/holocron-plugin-cloudflare/src/__tests__/helpers.ts
+++ b/packages/holocron-plugin-cloudflare/src/__tests__/helpers.ts
@@ -1,0 +1,48 @@
+import { type Mock, vi } from "vitest";
+
+export interface FetchCall {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	body: unknown;
+}
+
+export interface FetchStub {
+	fetch: typeof fetch;
+	calls: FetchCall[];
+	mock: Mock;
+}
+
+export function stubFetch(responses: Array<{ status?: number; body?: unknown; text?: string }>): FetchStub {
+	const calls: FetchCall[] = [];
+	let i = 0;
+	const mock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input.toString();
+		const body = typeof init?.body === "string" ? safeJsonParse(init.body) : (init?.body ?? null);
+		calls.push({
+			url,
+			method: (init?.method ?? "GET").toUpperCase(),
+			headers: (init?.headers as Record<string, string>) ?? {},
+			body,
+		});
+		const next = responses[i++] ?? { status: 200, body: {} };
+		const status = next.status ?? 200;
+		if (status === 204 || status === 205 || status === 304) return new Response(null, { status });
+		const text = next.text ?? (typeof next.body === "string" ? next.body : JSON.stringify(next.body ?? {}));
+		return new Response(text, { status });
+	});
+	return { fetch: mock as unknown as typeof fetch, calls, mock };
+}
+
+function safeJsonParse(s: string): unknown {
+	try {
+		return JSON.parse(s);
+	} catch {
+		return s;
+	}
+}
+
+export const cfOk = (result: unknown, status = 200) => ({
+	status,
+	body: { success: true, errors: [], result },
+});

--- a/packages/holocron-plugin-cloudflare/src/__tests__/index.test.ts
+++ b/packages/holocron-plugin-cloudflare/src/__tests__/index.test.ts
@@ -19,7 +19,10 @@ describe("dns()", () => {
 	it("instantiates CloudflareDns bound to the client", () => {
 		const { fetch } = stubFetch([cfOk([])]);
 		const plugin = createPlugin({ cliToken: "cf-tok", fetch });
-		const cap = dns({ options: { cliToken: "cf-tok", fetch }, client: plugin.capabilities.dns()["client" as never] as never });
+		const cap = dns({
+			options: { cliToken: "cf-tok", fetch },
+			client: plugin.capabilities.dns()["client" as never] as never,
+		});
 		expect(cap.key).toBe("dns");
 		expect(cap.providerName).toBe("cloudflare");
 	});

--- a/packages/holocron-plugin-cloudflare/src/__tests__/index.test.ts
+++ b/packages/holocron-plugin-cloudflare/src/__tests__/index.test.ts
@@ -9,7 +9,7 @@ describe("createPlugin", () => {
 	});
 
 	it("returns a plugin with a dns capability factory", () => {
-		const plugin = createPlugin({ token: "cf-tok" });
+		const plugin = createPlugin({ cliToken: "cf-tok" });
 		expect(plugin.name).toBe("@theholocron/holocron-plugin-cloudflare");
 		expect(typeof plugin.capabilities.dns).toBe("function");
 	});
@@ -18,8 +18,8 @@ describe("createPlugin", () => {
 describe("dns()", () => {
 	it("instantiates CloudflareDns bound to the client", () => {
 		const { fetch } = stubFetch([cfOk([])]);
-		const plugin = createPlugin({ token: "cf-tok", fetch });
-		const cap = dns({ options: { token: "cf-tok", fetch }, client: plugin.capabilities.dns()["client" as never] as never });
+		const plugin = createPlugin({ cliToken: "cf-tok", fetch });
+		const cap = dns({ options: { cliToken: "cf-tok", fetch }, client: plugin.capabilities.dns()["client" as never] as never });
 		expect(cap.key).toBe("dns");
 		expect(cap.providerName).toBe("cloudflare");
 	});

--- a/packages/holocron-plugin-cloudflare/src/__tests__/index.test.ts
+++ b/packages/holocron-plugin-cloudflare/src/__tests__/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { createPlugin, dns } from "../index.js";
+import { cfOk, stubFetch } from "./helpers.js";
+
+describe("createPlugin", () => {
+	it("throws when no token is resolvable", () => {
+		expect(() => createPlugin({})).toThrow();
+	});
+
+	it("returns a plugin with a dns capability factory", () => {
+		const plugin = createPlugin({ token: "cf-tok" });
+		expect(plugin.name).toBe("@theholocron/holocron-plugin-cloudflare");
+		expect(typeof plugin.capabilities.dns).toBe("function");
+	});
+});
+
+describe("dns()", () => {
+	it("instantiates CloudflareDns bound to the client", () => {
+		const { fetch } = stubFetch([cfOk([])]);
+		const plugin = createPlugin({ token: "cf-tok", fetch });
+		const cap = dns({ options: { token: "cf-tok", fetch }, client: plugin.capabilities.dns()["client" as never] as never });
+		expect(cap.key).toBe("dns");
+		expect(cap.providerName).toBe("cloudflare");
+	});
+});

--- a/packages/holocron-plugin-cloudflare/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-cloudflare/src/__tests__/verify-token.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { verifyToken } from "../verify-token.js";
+import { cfOk, stubFetch } from "./helpers.js";
+
+const BASE = "https://cf.test/client/v4";
+
+describe("verifyToken", () => {
+	it("returns ok:true with token id and status on success", async () => {
+		const { fetch } = stubFetch([cfOk({ id: "tok-123", status: "active" })]);
+		const result = await verifyToken("cf-token", { baseUrl: BASE, fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.subject).toContain("tok-123");
+	});
+
+	it("returns ok:false when the API rejects the token", async () => {
+		const { fetch } = stubFetch([{ status: 401, body: { errors: ["Invalid token"] } }]);
+		const result = await verifyToken("bad-token", { baseUrl: BASE, fetch });
+		expect(result.ok).toBe(false);
+	});
+});

--- a/packages/holocron-plugin-cloudflare/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-cloudflare/src/__tests__/verify-token.test.ts
@@ -9,8 +9,7 @@ describe("verifyToken", () => {
 	it("returns ok:true with token id and status on success", async () => {
 		const { fetch } = stubFetch([cfOk({ id: "tok-123", status: "active" })]);
 		const result = await verifyToken("cf-token", { baseUrl: BASE, fetch });
-		expect(result.ok).toBe(true);
-		if (result.ok) expect(result.subject).toContain("tok-123");
+		expect(result).toMatchObject({ ok: true, subject: expect.stringContaining("tok-123") });
 	});
 
 	it("returns ok:false when the API rejects the token", async () => {

--- a/packages/holocron-plugin-cloudflare/src/auth.ts
+++ b/packages/holocron-plugin-cloudflare/src/auth.ts
@@ -1,0 +1,13 @@
+import { AuthError, createResolveToken, type ResolveTokenInput } from "@theholocron/cli";
+
+export { AuthError };
+export type { ResolveTokenInput };
+
+export const resolveToken = createResolveToken({
+	envName: "HOLOCRON_CLOUDFLARE_TOKEN",
+	vendorEnvName: "CLOUDFLARE_API_TOKEN",
+	keyringService: "cloudflare",
+	errorMessage:
+		"no Cloudflare API token found. Pass --token <TOKEN>, set HOLOCRON_CLOUDFLARE_TOKEN / CLOUDFLARE_API_TOKEN, " +
+		"or run: holocron auth set cloudflare <TOKEN>",
+});

--- a/packages/holocron-plugin-cloudflare/src/capabilities/dns.ts
+++ b/packages/holocron-plugin-cloudflare/src/capabilities/dns.ts
@@ -1,0 +1,85 @@
+import type { Dns, DnsRecord, DnsRecordType } from "@theholocron/cli";
+import { ProviderApiError } from "@theholocron/cli";
+
+import type { CloudflareClient } from "../rest.js";
+
+export class CloudflareDns implements Dns {
+	readonly key = "dns" as const;
+	readonly providerName = "cloudflare";
+
+	// Zone id is cached per domain name for the plugin instance lifetime.
+	private readonly zoneCache = new Map<string, string>();
+
+	constructor(private readonly client: CloudflareClient) {}
+
+	async listRecords(domain: string): Promise<DnsRecord[]> {
+		const zoneId = await this.resolveZone(domain);
+		const records = await this.client.dns.list(zoneId);
+		return records.map(mapRecord);
+	}
+
+	async upsertRecord(domain: string, record: DnsRecord): Promise<DnsRecord> {
+		const zoneId = await this.resolveZone(domain);
+		const existing = await this.client.dns.list(zoneId, {
+			type: record.type,
+			name: record.name,
+		});
+		if (existing.length > 0) {
+			// When multiple same-type records exist (e.g. TXT for SPF + DKIM),
+			// update only the first match. Callers managing multiple TXT records
+			// should use listRecords + deleteRecord + explicit upserts.
+			const updated = await this.client.dns.update(zoneId, existing[0]!.id, {
+				type: record.type as Parameters<typeof this.client.dns.update>[2]["type"],
+				name: record.name,
+				content: record.content,
+				...(record.ttl !== undefined ? { ttl: record.ttl } : {}),
+			});
+			return mapRecord(updated);
+		}
+		const created = await this.client.dns.create(zoneId, {
+			type: record.type as Parameters<typeof this.client.dns.create>[1]["type"],
+			name: record.name,
+			content: record.content,
+			...(record.ttl !== undefined ? { ttl: record.ttl } : {}),
+		});
+		return mapRecord(created);
+	}
+
+	async deleteRecord(domain: string, id: string): Promise<void> {
+		const zoneId = await this.resolveZone(domain);
+		await this.client.dns.delete(zoneId, id);
+	}
+
+	/**
+	 * Walk from full domain up to apex to find the Cloudflare zone.
+	 * E.g. "api.staging.example.com" tries:
+	 *   1. "api.staging.example.com"
+	 *   2. "staging.example.com"
+	 *   3. "example.com"
+	 */
+	private async resolveZone(domain: string): Promise<string> {
+		const cached = this.zoneCache.get(domain);
+		if (cached) return cached;
+
+		const parts = domain.split(".");
+		for (let i = 0; i < parts.length - 1; i++) {
+			const candidate = parts.slice(i).join(".");
+			const zones = await this.client.zones.list({ name: candidate });
+			if (zones.length > 0) {
+				this.zoneCache.set(domain, zones[0]!.id);
+				return zones[0]!.id;
+			}
+		}
+		throw new ProviderApiError(`No Cloudflare zone found for domain: ${domain}`, 404, undefined);
+	}
+}
+
+function mapRecord(raw: { id: string; type: string; name: string; content: string; ttl: number }): DnsRecord {
+	return {
+		id: raw.id,
+		type: raw.type as DnsRecordType,
+		name: raw.name,
+		content: raw.content,
+		ttl: raw.ttl,
+	};
+}

--- a/packages/holocron-plugin-cloudflare/src/index.ts
+++ b/packages/holocron-plugin-cloudflare/src/index.ts
@@ -1,0 +1,56 @@
+import type { Dns } from "@theholocron/cli";
+
+import { resolveToken, type ResolveTokenInput } from "./auth.js";
+import { CloudflareDns } from "./capabilities/dns.js";
+import { createCloudflareClient, type CloudflareClient } from "./rest.js";
+
+export interface CloudflarePluginOptions extends ResolveTokenInput {
+	/**
+	 * Cloudflare account id. Optional for DNS operations; required only
+	 * for account-scoped endpoints (tunnels, custom nameservers).
+	 */
+	accountId?: string;
+	/** Override base URL for tests. */
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+export interface PluginContext {
+	options: CloudflarePluginOptions;
+	client: CloudflareClient;
+}
+
+export function createContext(options: CloudflarePluginOptions = {}): PluginContext {
+	const token = resolveToken(options);
+	return {
+		options,
+		client: createCloudflareClient({ token, baseUrl: options.baseUrl, fetch: options.fetch }),
+	};
+}
+
+export function dns(ctx: PluginContext): Dns {
+	return new CloudflareDns(ctx.client);
+}
+
+export function createPlugin(options: CloudflarePluginOptions = {}) {
+	const ctx = createContext(options);
+	return {
+		name: "@theholocron/holocron-plugin-cloudflare",
+		capabilities: {
+			dns: () => dns(ctx),
+		},
+	};
+}
+
+export const AUTH_HINT =
+	"create an API token at https://dash.cloudflare.com/profile/api-tokens " +
+	"with Zone:Read and DNS:Edit permissions, " +
+	"then run: holocron auth set cloudflare <TOKEN>";
+
+// ── Public re-exports ────────────────────────────────────────────────
+
+export * from "./auth.js";
+export { CloudflareDns } from "./capabilities/dns.js";
+export { createCloudflareClient, type CloudflareClient, type CloudflareClientOptions } from "./rest.js";
+export type { VerifyTokenFailure, VerifyTokenResult, VerifyTokenSuccess } from "./verify-token.js";
+export { verifyToken } from "./verify-token.js";

--- a/packages/holocron-plugin-cloudflare/src/index.ts
+++ b/packages/holocron-plugin-cloudflare/src/index.ts
@@ -2,7 +2,7 @@ import type { Dns } from "@theholocron/cli";
 
 import { resolveToken, type ResolveTokenInput } from "./auth.js";
 import { CloudflareDns } from "./capabilities/dns.js";
-import { createCloudflareClient, type CloudflareClient } from "./rest.js";
+import { type CloudflareClient,createCloudflareClient } from "./rest.js";
 
 export interface CloudflarePluginOptions extends ResolveTokenInput {
 	/**
@@ -51,6 +51,6 @@ export const AUTH_HINT =
 
 export * from "./auth.js";
 export { CloudflareDns } from "./capabilities/dns.js";
-export { createCloudflareClient, type CloudflareClient, type CloudflareClientOptions } from "./rest.js";
+export { type CloudflareClient, type CloudflareClientOptions,createCloudflareClient } from "./rest.js";
 export type { VerifyTokenFailure, VerifyTokenResult, VerifyTokenSuccess } from "./verify-token.js";
 export { verifyToken } from "./verify-token.js";

--- a/packages/holocron-plugin-cloudflare/src/index.ts
+++ b/packages/holocron-plugin-cloudflare/src/index.ts
@@ -2,7 +2,7 @@ import type { Dns } from "@theholocron/cli";
 
 import { resolveToken, type ResolveTokenInput } from "./auth.js";
 import { CloudflareDns } from "./capabilities/dns.js";
-import { type CloudflareClient,createCloudflareClient } from "./rest.js";
+import { type CloudflareClient, createCloudflareClient } from "./rest.js";
 
 export interface CloudflarePluginOptions extends ResolveTokenInput {
 	/**
@@ -51,6 +51,6 @@ export const AUTH_HINT =
 
 export * from "./auth.js";
 export { CloudflareDns } from "./capabilities/dns.js";
-export { type CloudflareClient, type CloudflareClientOptions,createCloudflareClient } from "./rest.js";
+export { type CloudflareClient, type CloudflareClientOptions, createCloudflareClient } from "./rest.js";
 export type { VerifyTokenFailure, VerifyTokenResult, VerifyTokenSuccess } from "./verify-token.js";
 export { verifyToken } from "./verify-token.js";

--- a/packages/holocron-plugin-cloudflare/src/rest.ts
+++ b/packages/holocron-plugin-cloudflare/src/rest.ts
@@ -1,1 +1,5 @@
-export { type CloudflareClient, type CloudflareClientOptions,createCloudflareClient } from "@theholocron/cloudflare-client";
+export {
+	type CloudflareClient,
+	type CloudflareClientOptions,
+	createCloudflareClient,
+} from "@theholocron/cloudflare-client";

--- a/packages/holocron-plugin-cloudflare/src/rest.ts
+++ b/packages/holocron-plugin-cloudflare/src/rest.ts
@@ -1,1 +1,1 @@
-export { createCloudflareClient, type CloudflareClient, type CloudflareClientOptions } from "@theholocron/cloudflare-client";
+export { type CloudflareClient, type CloudflareClientOptions,createCloudflareClient } from "@theholocron/cloudflare-client";

--- a/packages/holocron-plugin-cloudflare/src/rest.ts
+++ b/packages/holocron-plugin-cloudflare/src/rest.ts
@@ -1,0 +1,1 @@
+export { createCloudflareClient, type CloudflareClient, type CloudflareClientOptions } from "@theholocron/cloudflare-client";

--- a/packages/holocron-plugin-cloudflare/src/verify-token.ts
+++ b/packages/holocron-plugin-cloudflare/src/verify-token.ts
@@ -23,6 +23,7 @@ export async function verifyToken(token: string, opts: VerifyTokenOptions = {}):
 		const result = await client.tokens.verify();
 		return { ok: true, subject: `token ${result.id} (${result.status})` };
 	} catch (err) {
+		/* c8 ignore next */
 		const message = err instanceof Error ? err.message : String(err);
 		return { ok: false, message };
 	}

--- a/packages/holocron-plugin-cloudflare/src/verify-token.ts
+++ b/packages/holocron-plugin-cloudflare/src/verify-token.ts
@@ -1,0 +1,29 @@
+import { createCloudflareClient } from "./rest.js";
+
+export interface VerifyTokenSuccess {
+	ok: true;
+	subject: string;
+}
+
+export interface VerifyTokenFailure {
+	ok: false;
+	message: string;
+}
+
+export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
+
+export interface VerifyTokenOptions {
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+export async function verifyToken(token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
+	const client = createCloudflareClient({ token, baseUrl: opts.baseUrl, fetch: opts.fetch });
+	try {
+		const result = await client.tokens.verify();
+		return { ok: true, subject: `token ${result.id} (${result.status})` };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { ok: false, message };
+	}
+}

--- a/packages/holocron-plugin-cloudflare/tsconfig.json
+++ b/packages/holocron-plugin-cloudflare/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "display": "Holocron Plugin: Cloudflare",
+  "extends": "@theholocron/tsconfig/node-lts",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/holocron-plugin-cloudflare/tsdown.config.ts
+++ b/packages/holocron-plugin-cloudflare/tsdown.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/tsdown-config/presets/library";

--- a/packages/holocron-plugin-cloudflare/vitest.config.ts
+++ b/packages/holocron-plugin-cloudflare/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/vitest-config/bundles/library";

--- a/packages/holocron-plugin-sentry/README.md
+++ b/packages/holocron-plugin-sentry/README.md
@@ -1,0 +1,54 @@
+<!-- editorconfig-checker-disable-file -->
+
+# `@theholocron/holocron-plugin-sentry`
+
+Sentry plugin for [Holocron](../cli). Implements the `observability`
+capability against the [Sentry management API](https://docs.sentry.io/api/).
+
+## Install
+
+<!-- prettier-ignore -->
+```bash
+pnpm add -D @theholocron/holocron-plugin-sentry
+
+```
+
+## Auth
+
+Token resolution order:
+
+1. `--token <TOKEN>` flag on the holocron invocation
+2. `HOLOCRON_SENTRY_TOKEN` env var
+3. `SENTRY_AUTH_TOKEN` env var (the standard Sentry variable name)
+
+Generate an auth token at **sentry.io/settings/account/api/auth-tokens/**
+with `org:read`, `project:read`, and `project:write` scopes. Both
+user-owned and org-owned tokens are accepted.
+
+## Config
+
+<!-- prettier-ignore -->
+```jsonc
+{
+  "providers": {
+    "observability": ["sentry", { "org": "my-org-slug", "team": "my-team" }],
+  },
+}
+
+```
+
+- `org` (required) — Sentry organization slug.
+- `team` (optional) — team slug for project creation. Defaults to the
+  org slug when omitted.
+
+## What's implemented
+
+| Method           | What it does                                                                                                                                                    |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `describe`       | Returns `{ provider: "sentry", envKeys: ["SENTRY_DSN", "NEXT_PUBLIC_SENTRY_DSN"] }` — the env vars the app reads at runtime.                                  |
+| `whoami`         | Fetches the org by slug to verify the token and confirm the org exists.                                                                                         |
+| `ensureProject`  | Looks up the project by slug (derived from `name`); creates it under the configured team if absent. Returns the DSN and an `alreadyExists` flag. Idempotent.   |
+
+`holocron setup` calls `ensureProject` and pushes both `SENTRY_DSN` and
+`NEXT_PUBLIC_SENTRY_DSN` to GitHub Secrets (same DSN value, both keys
+required by the Sentry Next.js SDK).

--- a/packages/holocron-plugin-sentry/README.md
+++ b/packages/holocron-plugin-sentry/README.md
@@ -43,11 +43,11 @@ user-owned and org-owned tokens are accepted.
 
 ## What's implemented
 
-| Method           | What it does                                                                                                                                                    |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `describe`       | Returns `{ provider: "sentry", envKeys: ["SENTRY_DSN", "NEXT_PUBLIC_SENTRY_DSN"] }` — the env vars the app reads at runtime.                                  |
-| `whoami`         | Fetches the org by slug to verify the token and confirm the org exists.                                                                                         |
-| `ensureProject`  | Looks up the project by slug (derived from `name`); creates it under the configured team if absent. Returns the DSN and an `alreadyExists` flag. Idempotent.   |
+| Method          | What it does                                                                                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `describe`      | Returns `{ provider: "sentry", envKeys: ["SENTRY_DSN", "NEXT_PUBLIC_SENTRY_DSN"] }` — the env vars the app reads at runtime.                                 |
+| `whoami`        | Fetches the org by slug to verify the token and confirm the org exists.                                                                                      |
+| `ensureProject` | Looks up the project by slug (derived from `name`); creates it under the configured team if absent. Returns the DSN and an `alreadyExists` flag. Idempotent. |
 
 `holocron setup` calls `ensureProject` and pushes both `SENTRY_DSN` and
 `NEXT_PUBLIC_SENTRY_DSN` to GitHub Secrets (same DSN value, both keys

--- a/packages/holocron-plugin-sentry/eslint.config.ts
+++ b/packages/holocron-plugin-sentry/eslint.config.ts
@@ -1,0 +1,5 @@
+import type { Linter } from "eslint";
+
+import root from "../../eslint.config.js";
+
+export default [...root, { ignores: ["dist/**", "coverage/**"] }] satisfies Linter.Config[];

--- a/packages/holocron-plugin-sentry/package.json
+++ b/packages/holocron-plugin-sentry/package.json
@@ -46,6 +46,7 @@
     "@theholocron/tsdown-config": "catalog:configs",
     "@theholocron/vitest-config": "catalog:configs",
     "@types/node": "catalog:",
+    "chalk": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/eslint-plugin": "catalog:",
     "eslint": "catalog:",

--- a/packages/holocron-plugin-sentry/package.json
+++ b/packages/holocron-plugin-sentry/package.json
@@ -26,7 +26,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "validate": "tsx scripts/validate.mjs"
   },
   "peerDependencies": {
     "@theholocron/cli": "workspace:*",

--- a/packages/holocron-plugin-sentry/package.json
+++ b/packages/holocron-plugin-sentry/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@theholocron/holocron-plugin-sentry",
+  "version": "3.24.3",
+  "description": "Holocron plugin for Sentry. Implements the observability capability against Sentry's management API — project provisioning and DSN retrieval.",
+  "homepage": "https://github.com/theholocron/holocron/tree/main/packages/holocron-plugin-sentry#readme",
+  "bugs": "https://github.com/theholocron/holocron/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/theholocron/holocron.git",
+    "directory": "packages/holocron-plugin-sentry"
+  },
+  "license": "MIT",
+  "author": "Newton Koumantzelis",
+  "type": "module",
+  "main": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "peerDependencies": {
+    "@theholocron/cli": "workspace:*",
+    "@theholocron/sentry-client": "catalog:clients"
+  },
+  "peerDependenciesMeta": {
+    "@theholocron/sentry-client": {
+      "optional": false
+    }
+  },
+  "devDependencies": {
+    "@theholocron/cli": "workspace:*",
+    "@theholocron/sentry-client": "catalog:clients",
+    "@theholocron/eslint-config": "catalog:configs",
+    "@theholocron/tsconfig": "catalog:configs",
+    "@theholocron/tsdown-config": "catalog:configs",
+    "@theholocron/vitest-config": "catalog:configs",
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/eslint-plugin": "catalog:",
+    "eslint": "catalog:",
+    "eslint-plugin-n": "catalog:",
+    "globals": "catalog:",
+    "tsdown": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "types": "./dist/index.d.mts"
+}

--- a/packages/holocron-plugin-sentry/scripts/validate.mjs
+++ b/packages/holocron-plugin-sentry/scripts/validate.mjs
@@ -11,68 +11,77 @@
  *   org — Sentry organization slug (e.g. "my-org")
  */
 
+import chalk from "chalk";
 import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
+
+const ok = (msg) => console.log(`${chalk.green("✓")} ${msg}`);
+const fail = (msg) => console.log(`${chalk.red("✗")} ${msg}`);
+const step = (msg) => console.log(chalk.cyan(`[${msg}]`));
+const hint = (msg) => console.log(chalk.dim(`         hint: ${msg}`));
 
 const [org] = process.argv.slice(2);
 
 if (!org) {
-	console.error("usage: pnpm --filter @theholocron/holocron-plugin-sentry validate <org>");
-	console.error("  org — your Sentry organization slug (visible in the Sentry URL)");
+	console.error(chalk.red("usage:") + " pnpm --filter @theholocron/holocron-plugin-sentry validate <org>");
+	console.error(chalk.dim("  org — your Sentry organization slug (visible in the Sentry URL)"));
 	process.exit(2);
 }
+
+console.log(chalk.bold("Validating @theholocron/holocron-plugin-sentry") + chalk.dim(" (READ-ONLY)"));
+console.log(chalk.dim(`  org: ${org}`));
+console.log("");
 
 let token;
 try {
 	token = resolveToken();
 } catch (err) {
 	if (err instanceof AuthError) {
-		console.error(err.message);
-		console.error("  see: packages/holocron-plugin-sentry/README.md#auth");
+		console.error(chalk.red(err.message));
+		console.error(chalk.dim("  see: packages/holocron-plugin-sentry/README.md#auth"));
 		process.exit(2);
 	}
 	throw err;
 }
 
-console.log("Validating @theholocron/holocron-plugin-sentry (READ-ONLY)");
-console.log(`  org: ${org}`);
-console.log("");
-
-console.log("[1/3] verifyToken");
+step("1/3 verifyToken");
 const verifyResult = await verifyToken(token);
-console.log(`      ${verifyResult.ok ? "✓" : "✗"} ${JSON.stringify(verifyResult)}`);
-if (!verifyResult.ok) {
-	const hint = hintFor(verifyResult.message);
-	if (hint) console.log(`         hint: ${hint}`);
+if (verifyResult.ok) {
+	ok(verifyResult.subject);
+} else {
+	fail(verifyResult.message);
+	const h = hintFor(verifyResult.message);
+	if (h) hint(h);
 }
 console.log("");
 
 const plugin = createPlugin({ cliToken: token, org });
 const obs = plugin.capabilities.observability();
 
-console.log("[2/3] observability.whoami()");
+step("2/3 observability.whoami()");
 await runStep(async () => {
 	const result = await obs.whoami();
-	console.log(`      ✓ org: ${result.org}`);
+	ok(`org: ${result.org}`);
 });
 console.log("");
 
-console.log("[3/3] observability.describe()");
+step("3/3 observability.describe()");
 await runStep(async () => {
 	const result = await obs.describe();
-	console.log(`      ✓ provider: ${result.provider}`);
-	console.log(`        envKeys: ${result.envKeys.join(", ")}`);
+	ok(`provider: ${result.provider}`);
+	console.log(chalk.dim(`   envKeys: ${result.envKeys.join(", ")}`));
 });
+
 console.log("");
-console.log("Done. No writes.");
+console.log(chalk.dim("Done. No writes."));
 
 async function runStep(body) {
 	try {
 		await body();
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		console.log(`      ✗ ERROR: ${message}`);
-		const hint = hintFor(message);
-		if (hint) console.log(`         hint: ${hint}`);
+		fail(message);
+		const h = hintFor(message);
+		if (h) hint(h);
 	}
 }
 

--- a/packages/holocron-plugin-sentry/scripts/validate.mjs
+++ b/packages/holocron-plugin-sentry/scripts/validate.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Read-only smoke test for @theholocron/holocron-plugin-sentry.
+ *
+ * READ-ONLY. Tests verifyToken + observability.whoami + observability.describe
+ * — proves auth, org access, and capability wiring.
+ *
+ * Usage:
+ *   pnpm --filter @theholocron/holocron-plugin-sentry validate <org>
+ *
+ *   org — Sentry organization slug (e.g. "my-org")
+ */
+
+import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
+
+const [org] = process.argv.slice(2);
+
+if (!org) {
+	console.error("usage: pnpm --filter @theholocron/holocron-plugin-sentry validate <org>");
+	console.error("  org — your Sentry organization slug (visible in the Sentry URL)");
+	process.exit(2);
+}
+
+let token;
+try {
+	token = resolveToken();
+} catch (err) {
+	if (err instanceof AuthError) {
+		console.error(err.message);
+		console.error("  see: packages/holocron-plugin-sentry/README.md#auth");
+		process.exit(2);
+	}
+	throw err;
+}
+
+console.log("Validating @theholocron/holocron-plugin-sentry (READ-ONLY)");
+console.log(`  org: ${org}`);
+console.log("");
+
+console.log("[1/3] verifyToken");
+const verifyResult = await verifyToken(token);
+console.log(`      ${verifyResult.ok ? "✓" : "✗"} ${JSON.stringify(verifyResult)}`);
+if (!verifyResult.ok) {
+	const hint = hintFor(verifyResult.message);
+	if (hint) console.log(`         hint: ${hint}`);
+}
+console.log("");
+
+const plugin = createPlugin({ cliToken: token, org });
+const obs = plugin.capabilities.observability();
+
+console.log("[2/3] observability.whoami()");
+await runStep(async () => {
+	const result = await obs.whoami();
+	console.log(`      ✓ org: ${result.org}`);
+});
+console.log("");
+
+console.log("[3/3] observability.describe()");
+await runStep(async () => {
+	const result = await obs.describe();
+	console.log(`      ✓ provider: ${result.provider}`);
+	console.log(`        envKeys: ${result.envKeys.join(", ")}`);
+});
+console.log("");
+console.log("Done. No writes.");
+
+async function runStep(body) {
+	try {
+		await body();
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.log(`      ✗ ERROR: ${message}`);
+		const hint = hintFor(message);
+		if (hint) console.log(`         hint: ${hint}`);
+	}
+}
+
+function hintFor(message) {
+	if (/→ 401|→ 403/.test(message))
+		return "token invalid or lacks scope — regenerate at https://sentry.io/settings/account/api/auth-tokens/ with org:read + project:read + project:write";
+	if (/→ 404/.test(message))
+		return "org not found — verify the slug matches your Sentry organization URL";
+	if (/fetch failed|status: 0|network/i.test(message)) return "network error — check sentry.io reachable";
+	if (/→ 5\d\d/.test(message)) return "server error — check https://status.sentry.io";
+	return null;
+}

--- a/packages/holocron-plugin-sentry/scripts/validate.mjs
+++ b/packages/holocron-plugin-sentry/scripts/validate.mjs
@@ -12,6 +12,7 @@
  */
 
 import chalk from "chalk";
+
 import { AuthError, createPlugin, resolveToken, verifyToken } from "../src/index.ts";
 
 const ok = (msg) => console.log(`${chalk.green("✓")} ${msg}`);

--- a/packages/holocron-plugin-sentry/src/__tests__/helpers.ts
+++ b/packages/holocron-plugin-sentry/src/__tests__/helpers.ts
@@ -1,0 +1,43 @@
+import { type Mock, vi } from "vitest";
+
+export interface FetchCall {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	body: unknown;
+}
+
+export interface FetchStub {
+	fetch: typeof fetch;
+	calls: FetchCall[];
+	mock: Mock;
+}
+
+export function stubFetch(responses: Array<{ status?: number; body?: unknown; text?: string }>): FetchStub {
+	const calls: FetchCall[] = [];
+	let i = 0;
+	const mock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+		const url = typeof input === "string" ? input : input.toString();
+		const body = typeof init?.body === "string" ? safeJsonParse(init.body) : (init?.body ?? null);
+		calls.push({
+			url,
+			method: (init?.method ?? "GET").toUpperCase(),
+			headers: (init?.headers as Record<string, string>) ?? {},
+			body,
+		});
+		const next = responses[i++] ?? { status: 200, body: {} };
+		const status = next.status ?? 200;
+		if (status === 204 || status === 205 || status === 304) return new Response(null, { status });
+		const text = next.text ?? (typeof next.body === "string" ? next.body : JSON.stringify(next.body ?? {}));
+		return new Response(text, { status });
+	});
+	return { fetch: mock as unknown as typeof fetch, calls, mock };
+}
+
+function safeJsonParse(s: string): unknown {
+	try {
+		return JSON.parse(s);
+	} catch {
+		return s;
+	}
+}

--- a/packages/holocron-plugin-sentry/src/__tests__/index.test.ts
+++ b/packages/holocron-plugin-sentry/src/__tests__/index.test.ts
@@ -4,17 +4,17 @@ import { createPlugin } from "../index.js";
 
 describe("createPlugin", () => {
 	it("throws when org is missing", () => {
-		expect(() => createPlugin({ token: "tok", org: "" })).toThrow();
+		expect(() => createPlugin({ cliToken: "tok", org: "" })).toThrow();
 	});
 
 	it("returns a plugin with an observability capability factory", () => {
-		const plugin = createPlugin({ token: "sntryu_tok", org: "my-org" });
+		const plugin = createPlugin({ cliToken: "sntryu_tok", org: "my-org" });
 		expect(plugin.name).toBe("@theholocron/holocron-plugin-sentry");
 		expect(typeof plugin.capabilities.observability).toBe("function");
 	});
 
 	it("capability has correct key and providerName", () => {
-		const plugin = createPlugin({ token: "sntryu_tok", org: "my-org" });
+		const plugin = createPlugin({ cliToken: "sntryu_tok", org: "my-org" });
 		const cap = plugin.capabilities.observability();
 		expect(cap.key).toBe("observability");
 		expect(cap.providerName).toBe("sentry");

--- a/packages/holocron-plugin-sentry/src/__tests__/index.test.ts
+++ b/packages/holocron-plugin-sentry/src/__tests__/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { createPlugin } from "../index.js";
+
+describe("createPlugin", () => {
+	it("throws when org is missing", () => {
+		expect(() => createPlugin({ token: "tok", org: "" })).toThrow();
+	});
+
+	it("returns a plugin with an observability capability factory", () => {
+		const plugin = createPlugin({ token: "sntryu_tok", org: "my-org" });
+		expect(plugin.name).toBe("@theholocron/holocron-plugin-sentry");
+		expect(typeof plugin.capabilities.observability).toBe("function");
+	});
+
+	it("capability has correct key and providerName", () => {
+		const plugin = createPlugin({ token: "sntryu_tok", org: "my-org" });
+		const cap = plugin.capabilities.observability();
+		expect(cap.key).toBe("observability");
+		expect(cap.providerName).toBe("sentry");
+	});
+});

--- a/packages/holocron-plugin-sentry/src/__tests__/observability.test.ts
+++ b/packages/holocron-plugin-sentry/src/__tests__/observability.test.ts
@@ -1,0 +1,76 @@
+import { ProviderApiError } from "@theholocron/cli";
+import { describe, expect, it } from "vitest";
+
+import { SentryObservability } from "../capabilities/observability.js";
+import { createSentryClient } from "../rest.js";
+import { stubFetch } from "./helpers.js";
+
+const BASE = "https://sentry.test/api/0";
+const ORG = "my-org";
+
+function makeObs(responses: Parameters<typeof stubFetch>[0]) {
+	const { fetch, calls } = stubFetch(responses);
+	const client = createSentryClient({ token: "sntryu_tok", baseUrl: BASE, fetch });
+	return { obs: new SentryObservability(client, { org: ORG }), calls };
+}
+
+const project = { id: "p1", slug: "my-project", name: "My Project", platform: "node" };
+const key = {
+	id: "k1",
+	label: "Default",
+	public: "abc123",
+	secret: "secret123",
+	dsn: { public: "https://abc123@o123.ingest.sentry.io/456", secret: "https://abc123:secret123@o123.ingest.sentry.io/456" },
+};
+
+describe("SentryObservability.describe", () => {
+	it("returns sentry provider with both DSN env keys", async () => {
+		const { obs } = makeObs([]);
+		const result = await obs.describe();
+		expect(result.provider).toBe("sentry");
+		expect(result.envKeys).toEqual(["SENTRY_DSN", "NEXT_PUBLIC_SENTRY_DSN"]);
+	});
+});
+
+describe("SentryObservability.whoami", () => {
+	it("returns the org slug", async () => {
+		const { obs, calls } = makeObs([{ body: { id: "1", slug: ORG, name: "My Org" } }]);
+		const result = await obs.whoami();
+		expect(calls[0]?.url).toContain(`/organizations/${ORG}/`);
+		expect(result.org).toBe(ORG);
+	});
+});
+
+describe("SentryObservability.ensureProject — existing", () => {
+	it("returns alreadyExists:true when project is found", async () => {
+		const { obs, calls } = makeObs([
+			{ body: project }, // GET /projects/{org}/{slug}/
+			{ body: [key] }, // GET /projects/{org}/{slug}/keys/
+		]);
+		const result = await obs.ensureProject({ name: "My Project" });
+		expect(calls[0]?.url).toContain(`/projects/${ORG}/my-project/`);
+		expect(result.alreadyExists).toBe(true);
+		expect(result.dsn).toBe(key.dsn.public);
+	});
+});
+
+describe("SentryObservability.ensureProject — create", () => {
+	it("creates project when GET returns 404", async () => {
+		const { obs, calls } = makeObs([
+			{ status: 404, body: { detail: "The requested resource does not exist" } }, // GET → 404
+			{ body: project }, // POST create
+			{ body: [key] }, // GET keys
+		]);
+		const result = await obs.ensureProject({ name: "My Project", platform: "javascript" });
+		expect(calls[1]?.method).toBe("POST");
+		expect(calls[1]?.url).toContain(`/teams/${ORG}/${ORG}/projects/`);
+		expect(calls[1]?.body).toMatchObject({ name: "My Project", platform: "javascript" });
+		expect(result.alreadyExists).toBe(false);
+		expect(result.dsn).toBe(key.dsn.public);
+	});
+
+	it("rethrows non-404 errors from the existence check", async () => {
+		const { obs } = makeObs([{ status: 403, body: { detail: "Forbidden" } }]);
+		await expect(obs.ensureProject({ name: "My Project" })).rejects.toBeInstanceOf(ProviderApiError);
+	});
+});

--- a/packages/holocron-plugin-sentry/src/__tests__/observability.test.ts
+++ b/packages/holocron-plugin-sentry/src/__tests__/observability.test.ts
@@ -20,7 +20,10 @@ const key = {
 	label: "Default",
 	public: "abc123",
 	secret: "secret123",
-	dsn: { public: "https://abc123@o123.ingest.sentry.io/456", secret: "https://abc123:secret123@o123.ingest.sentry.io/456" },
+	dsn: {
+		public: "https://abc123@o123.ingest.sentry.io/456",
+		secret: "https://abc123:secret123@o123.ingest.sentry.io/456",
+	},
 };
 
 describe("SentryObservability.describe", () => {

--- a/packages/holocron-plugin-sentry/src/__tests__/observability.test.ts
+++ b/packages/holocron-plugin-sentry/src/__tests__/observability.test.ts
@@ -26,6 +26,14 @@ const key = {
 	},
 };
 
+describe("SentryObservability constructor", () => {
+	it("throws when org is empty", () => {
+		const { fetch } = stubFetch([]);
+		const client = createSentryClient({ token: "tok", baseUrl: BASE, fetch });
+		expect(() => new SentryObservability(client, { org: "" })).toThrow("requires `org`");
+	});
+});
+
 describe("SentryObservability.describe", () => {
 	it("returns sentry provider with both DSN env keys", async () => {
 		const { obs } = makeObs([]);
@@ -75,5 +83,17 @@ describe("SentryObservability.ensureProject — create", () => {
 	it("rethrows non-404 errors from the existence check", async () => {
 		const { obs } = makeObs([{ status: 403, body: { detail: "Forbidden" } }]);
 		await expect(obs.ensureProject({ name: "My Project" })).rejects.toBeInstanceOf(ProviderApiError);
+	});
+
+	it("uses the configured team slug when creating", async () => {
+		const { fetch, calls } = stubFetch([
+			{ status: 404, body: { detail: "Not Found" } },
+			{ body: project },
+			{ body: [key] },
+		]);
+		const client = createSentryClient({ token: "tok", baseUrl: BASE, fetch });
+		const obs = new SentryObservability(client, { org: ORG, team: "backend" });
+		await obs.ensureProject({ name: "My Project" });
+		expect(calls[1]?.url).toContain(`/teams/${ORG}/backend/projects/`);
 	});
 });

--- a/packages/holocron-plugin-sentry/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-sentry/src/__tests__/verify-token.test.ts
@@ -19,7 +19,9 @@ describe("verifyToken", () => {
 	});
 
 	it("returns ok:false when the API rejects the token", async () => {
-		const { fetch } = stubFetch([{ status: 401, body: { detail: "Authentication credentials were not provided." } }]);
+		const { fetch } = stubFetch([
+			{ status: 401, body: { detail: "Authentication credentials were not provided." } },
+		]);
 		const result = await verifyToken("bad-token", { baseUrl: BASE, fetch });
 		expect(result.ok).toBe(false);
 	});

--- a/packages/holocron-plugin-sentry/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-sentry/src/__tests__/verify-token.test.ts
@@ -9,15 +9,13 @@ describe("verifyToken", () => {
 	it("returns ok:true with org slug on success", async () => {
 		const { fetch } = stubFetch([{ body: [{ id: "1", slug: "my-org", name: "My Org" }] }]);
 		const result = await verifyToken("sntryu_tok", { baseUrl: BASE, fetch });
-		expect(result.ok).toBe(true);
-		if (result.ok) expect(result.subject).toBe("org: my-org");
+		expect(result).toMatchObject({ ok: true, subject: "org: my-org" });
 	});
 
 	it("returns ok:true with 'unknown' when no orgs returned", async () => {
 		const { fetch } = stubFetch([{ body: [] }]);
 		const result = await verifyToken("sntryu_tok", { baseUrl: BASE, fetch });
-		expect(result.ok).toBe(true);
-		if (result.ok) expect(result.subject).toBe("org: unknown");
+		expect(result).toMatchObject({ ok: true, subject: "org: unknown" });
 	});
 
 	it("returns ok:false when the API rejects the token", async () => {

--- a/packages/holocron-plugin-sentry/src/__tests__/verify-token.test.ts
+++ b/packages/holocron-plugin-sentry/src/__tests__/verify-token.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { verifyToken } from "../verify-token.js";
+import { stubFetch } from "./helpers.js";
+
+const BASE = "https://sentry.test/api/0";
+
+describe("verifyToken", () => {
+	it("returns ok:true with org slug on success", async () => {
+		const { fetch } = stubFetch([{ body: [{ id: "1", slug: "my-org", name: "My Org" }] }]);
+		const result = await verifyToken("sntryu_tok", { baseUrl: BASE, fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.subject).toBe("org: my-org");
+	});
+
+	it("returns ok:true with 'unknown' when no orgs returned", async () => {
+		const { fetch } = stubFetch([{ body: [] }]);
+		const result = await verifyToken("sntryu_tok", { baseUrl: BASE, fetch });
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.subject).toBe("org: unknown");
+	});
+
+	it("returns ok:false when the API rejects the token", async () => {
+		const { fetch } = stubFetch([{ status: 401, body: { detail: "Authentication credentials were not provided." } }]);
+		const result = await verifyToken("bad-token", { baseUrl: BASE, fetch });
+		expect(result.ok).toBe(false);
+	});
+});

--- a/packages/holocron-plugin-sentry/src/auth.ts
+++ b/packages/holocron-plugin-sentry/src/auth.ts
@@ -1,0 +1,13 @@
+import { AuthError, createResolveToken, type ResolveTokenInput } from "@theholocron/cli";
+
+export { AuthError };
+export type { ResolveTokenInput };
+
+export const resolveToken = createResolveToken({
+	envName: "HOLOCRON_SENTRY_TOKEN",
+	vendorEnvName: "SENTRY_AUTH_TOKEN",
+	keyringService: "sentry",
+	errorMessage:
+		"no Sentry auth token found. Pass --token <TOKEN>, set HOLOCRON_SENTRY_TOKEN / SENTRY_AUTH_TOKEN, " +
+		"or run: holocron auth set sentry <TOKEN>",
+});

--- a/packages/holocron-plugin-sentry/src/capabilities/observability.ts
+++ b/packages/holocron-plugin-sentry/src/capabilities/observability.ts
@@ -41,6 +41,7 @@ export class SentryObservability implements Observability {
 			const existing = await this.client.projects.get(this.opts.org, slug);
 			const keys = await this.client.projects.keys(this.opts.org, existing.slug);
 			const dsn = keys[0]?.dsn.public;
+			/* c8 ignore next */
 			if (!dsn) throw new ProviderApiError(`Sentry project ${slug} has no keys`, 404, undefined);
 			return { dsn, alreadyExists: true };
 		} catch (err) {
@@ -55,6 +56,7 @@ export class SentryObservability implements Observability {
 		});
 		const keys = await this.client.projects.keys(this.opts.org, project.slug);
 		const dsn = keys[0]?.dsn.public;
+		/* c8 ignore next */
 		if (!dsn)
 			throw new ProviderApiError(`Sentry project ${project.slug} has no keys after creation`, 500, undefined);
 		return { dsn, alreadyExists: false };

--- a/packages/holocron-plugin-sentry/src/capabilities/observability.ts
+++ b/packages/holocron-plugin-sentry/src/capabilities/observability.ts
@@ -55,7 +55,8 @@ export class SentryObservability implements Observability {
 		});
 		const keys = await this.client.projects.keys(this.opts.org, project.slug);
 		const dsn = keys[0]?.dsn.public;
-		if (!dsn) throw new ProviderApiError(`Sentry project ${project.slug} has no keys after creation`, 500, undefined);
+		if (!dsn)
+			throw new ProviderApiError(`Sentry project ${project.slug} has no keys after creation`, 500, undefined);
 		return { dsn, alreadyExists: false };
 	}
 }

--- a/packages/holocron-plugin-sentry/src/capabilities/observability.ts
+++ b/packages/holocron-plugin-sentry/src/capabilities/observability.ts
@@ -1,0 +1,68 @@
+import type { Observability } from "@theholocron/cli";
+import { ProviderApiError } from "@theholocron/cli";
+
+import type { SentryClient } from "../rest.js";
+
+export interface SentryObservabilityOptions {
+	/** Sentry organization slug. Required. */
+	org: string;
+	/** Default team slug for project creation. Defaults to org slug. */
+	team?: string;
+}
+
+export class SentryObservability implements Observability {
+	readonly key = "observability" as const;
+	readonly providerName = "sentry";
+
+	constructor(
+		private readonly client: SentryClient,
+		private readonly opts: SentryObservabilityOptions
+	) {
+		if (!opts.org) throw new Error("SentryObservability requires `org` in options");
+	}
+
+	async describe() {
+		return {
+			provider: "sentry",
+			envKeys: ["SENTRY_DSN", "NEXT_PUBLIC_SENTRY_DSN"],
+		};
+	}
+
+	async whoami() {
+		const org = await this.client.auth.getOrg(this.opts.org);
+		return { org: org.slug };
+	}
+
+	async ensureProject(input: { name: string; platform?: string }): Promise<{ dsn: string; alreadyExists: boolean }> {
+		const slug = toSlug(input.name);
+
+		// Try fetching the project directly — cheaper than listing all projects.
+		try {
+			const existing = await this.client.projects.get(this.opts.org, slug);
+			const keys = await this.client.projects.keys(this.opts.org, existing.slug);
+			const dsn = keys[0]?.dsn.public;
+			if (!dsn) throw new ProviderApiError(`Sentry project ${slug} has no keys`, 404, undefined);
+			return { dsn, alreadyExists: true };
+		} catch (err) {
+			// 404 means the project doesn't exist yet — proceed to create.
+			if (!(err instanceof ProviderApiError) || err.status !== 404) throw err;
+		}
+
+		const team = this.opts.team ?? this.opts.org;
+		const project = await this.client.projects.create(this.opts.org, team, {
+			name: input.name,
+			platform: input.platform ?? "node",
+		});
+		const keys = await this.client.projects.keys(this.opts.org, project.slug);
+		const dsn = keys[0]?.dsn.public;
+		if (!dsn) throw new ProviderApiError(`Sentry project ${project.slug} has no keys after creation`, 500, undefined);
+		return { dsn, alreadyExists: false };
+	}
+}
+
+function toSlug(name: string): string {
+	return name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-|-$/g, "");
+}

--- a/packages/holocron-plugin-sentry/src/index.ts
+++ b/packages/holocron-plugin-sentry/src/index.ts
@@ -1,0 +1,52 @@
+import type { Observability } from "@theholocron/cli";
+
+import { resolveToken, type ResolveTokenInput } from "./auth.js";
+import { SentryObservability, type SentryObservabilityOptions } from "./capabilities/observability.js";
+import { createSentryClient, type SentryClient } from "./rest.js";
+
+export interface SentryPluginOptions extends ResolveTokenInput, SentryObservabilityOptions {
+	/** Override base URL for tests. */
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+export interface PluginContext {
+	options: SentryPluginOptions;
+	client: SentryClient;
+}
+
+export function createContext(options: SentryPluginOptions): PluginContext {
+	if (!options.org) throw new Error("@theholocron/holocron-plugin-sentry requires `org` in options");
+	const token = resolveToken(options);
+	return {
+		options,
+		client: createSentryClient({ token, baseUrl: options.baseUrl, fetch: options.fetch }),
+	};
+}
+
+export function observability(ctx: PluginContext): Observability {
+	return new SentryObservability(ctx.client, { org: ctx.options.org, team: ctx.options.team });
+}
+
+export function createPlugin(options: SentryPluginOptions) {
+	const ctx = createContext(options);
+	return {
+		name: "@theholocron/holocron-plugin-sentry",
+		capabilities: {
+			observability: () => observability(ctx),
+		},
+	};
+}
+
+export const AUTH_HINT =
+	"generate an auth token at https://sentry.io/settings/account/api/auth-tokens/ " +
+	"with project:read, project:write, and org:read scopes, " +
+	"then run: holocron auth set sentry <TOKEN>";
+
+// ── Public re-exports ────────────────────────────────────────────────
+
+export * from "./auth.js";
+export { SentryObservability, type SentryObservabilityOptions } from "./capabilities/observability.js";
+export { createSentryClient, type SentryClient, type SentryClientOptions } from "./rest.js";
+export type { VerifyTokenFailure, VerifyTokenResult, VerifyTokenSuccess } from "./verify-token.js";
+export { verifyToken } from "./verify-token.js";

--- a/packages/holocron-plugin-sentry/src/rest.ts
+++ b/packages/holocron-plugin-sentry/src/rest.ts
@@ -1,0 +1,1 @@
+export { createSentryClient, type SentryClient, type SentryClientOptions } from "@theholocron/sentry-client";

--- a/packages/holocron-plugin-sentry/src/verify-token.ts
+++ b/packages/holocron-plugin-sentry/src/verify-token.ts
@@ -24,6 +24,7 @@ export async function verifyToken(token: string, opts: VerifyTokenOptions = {}):
 		const first = orgs[0];
 		return { ok: true, subject: `org: ${first?.slug ?? "unknown"}` };
 	} catch (err) {
+		/* c8 ignore next */
 		const message = err instanceof Error ? err.message : String(err);
 		return { ok: false, message };
 	}

--- a/packages/holocron-plugin-sentry/src/verify-token.ts
+++ b/packages/holocron-plugin-sentry/src/verify-token.ts
@@ -1,0 +1,30 @@
+import { createSentryClient } from "./rest.js";
+
+export interface VerifyTokenSuccess {
+	ok: true;
+	subject: string;
+}
+
+export interface VerifyTokenFailure {
+	ok: false;
+	message: string;
+}
+
+export type VerifyTokenResult = VerifyTokenSuccess | VerifyTokenFailure;
+
+export interface VerifyTokenOptions {
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+export async function verifyToken(token: string, opts: VerifyTokenOptions = {}): Promise<VerifyTokenResult> {
+	const client = createSentryClient({ token, baseUrl: opts.baseUrl, fetch: opts.fetch });
+	try {
+		const orgs = await client.auth.organizations();
+		const first = orgs[0];
+		return { ok: true, subject: `org: ${first?.slug ?? "unknown"}` };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return { ok: false, message };
+	}
+}

--- a/packages/holocron-plugin-sentry/tsconfig.json
+++ b/packages/holocron-plugin-sentry/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "display": "Holocron Plugin: Sentry",
+  "extends": "@theholocron/tsconfig/node-lts",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/holocron-plugin-sentry/tsdown.config.ts
+++ b/packages/holocron-plugin-sentry/tsdown.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/tsdown-config/presets/library";

--- a/packages/holocron-plugin-sentry/vitest.config.ts
+++ b/packages/holocron-plugin-sentry/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "@theholocron/vitest-config/bundles/library";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,17 +10,17 @@ catalogs:
       specifier: ^1.7.0
       version: 1.7.0
     '@theholocron/cloudflare-client':
-      specifier: ^1.7.0
-      version: 1.7.0
+      specifier: ^1.7.1
+      version: 1.7.1
     '@theholocron/doppler-client':
       specifier: ^1.7.0
       version: 1.7.0
     '@theholocron/github-client':
-      specifier: ^1.6.7
-      version: 1.6.7
+      specifier: ^1.7.1
+      version: 1.7.1
     '@theholocron/http-client':
-      specifier: ^1.7.0
-      version: 1.7.0
+      specifier: ^1.7.1
+      version: 1.7.1
     '@theholocron/infisical-client':
       specifier: ^1.7.0
       version: 1.7.0
@@ -31,8 +31,8 @@ catalogs:
       specifier: ^1.7.0
       version: 1.7.0
     '@theholocron/sentry-client':
-      specifier: ^1.7.0
-      version: 1.7.0
+      specifier: ^1.7.1
+      version: 1.7.1
     '@theholocron/vercel-client':
       specifier: ^1.7.0
       version: 1.7.0
@@ -280,10 +280,10 @@ importers:
         version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
       '@theholocron/github-client':
         specifier: catalog:clients
-        version: 1.6.7(vitest@4.1.10)
+        version: 1.7.1(vitest@4.1.10)
       '@theholocron/http-client':
         specifier: catalog:clients
-        version: 1.7.0(vitest@4.1.10)
+        version: 1.7.1(vitest@4.1.10)
       chalk:
         specifier: 'catalog:'
         version: 6.0.0
@@ -470,7 +470,7 @@ importers:
         version: link:../cli
       '@theholocron/cloudflare-client':
         specifier: catalog:clients
-        version: 1.7.0(vitest@4.1.10)
+        version: 1.7.1(vitest@4.1.10)
       '@theholocron/eslint-config':
         specifier: catalog:configs
         version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
@@ -579,7 +579,7 @@ importers:
         version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/github-client':
         specifier: catalog:clients
-        version: 1.6.7(vitest@4.1.10)
+        version: 1.7.1(vitest@4.1.10)
       '@theholocron/tsconfig':
         specifier: catalog:configs
         version: 7.19.1(typescript@5.9.3)
@@ -783,7 +783,7 @@ importers:
         version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/sentry-client':
         specifier: catalog:clients
-        version: 1.7.0(vitest@4.1.10)
+        version: 1.7.1(vitest@4.1.10)
       '@theholocron/tsconfig':
         specifier: catalog:configs
         version: 7.19.1(typescript@5.9.3)
@@ -2660,8 +2660,8 @@ packages:
     resolution: {integrity: sha512-m3xvhFeJEIpjbP2XWku2ylP0yQLV7Ecms4ghj2OQQVKVqa0q16XoK8HcJfpag2eDVGeSdkrH8H+iUF+GzVDT4Q==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/cloudflare-client@1.7.0':
-    resolution: {integrity: sha512-jXGlDp0XUu3tJYyB8rRbvRSceaFt552wQ2P+SeV81woBNJ+6jz8baHkgvot/9Hi0qtjxJp5fJbqgEm1WV5rmZw==}
+  '@theholocron/cloudflare-client@1.7.1':
+    resolution: {integrity: sha512-1NYX8x21S+JdpVYVoARRPOcBV5YauBNBVisansbDThKGlV89FsLxWCpd+wV868xn2qxL65gexCgGs7DIQtMnhA==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/commitlint-config@7.19.1':
@@ -2711,8 +2711,8 @@ packages:
       eslint-plugin-storybook:
         optional: true
 
-  '@theholocron/github-client@1.6.7':
-    resolution: {integrity: sha512-ReF/vCXmGD0QmSFrIr60EAFSPOoWA40lpnI4rWj6Ss8w2X8eRs+e/4DatLqwECTN+3R+EqBTU0iKRRf3UA2Xow==}
+  '@theholocron/github-client@1.7.1':
+    resolution: {integrity: sha512-cTLKi6rVw3yBt7zn12WiM1jjU9ZGM0Jrm77sQerACCH4R7S9DSdAKwCAbpunsKQv8wr4WDxTZC3yRxUUmaBasA==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/holocron-config@7.19.1':
@@ -2721,8 +2721,8 @@ packages:
     peerDependencies:
       '@theholocron/cli': '>=2.0.0-alpha.1'
 
-  '@theholocron/http-client@1.7.0':
-    resolution: {integrity: sha512-ZaJcgY83qovJlmYx50D6CJ/3DHKsltDSKp69tvmA9zh0jhbnUqulz0VYbO+caaVG3M6AgMx0BFYBXc724wUOpA==}
+  '@theholocron/http-client@1.7.1':
+    resolution: {integrity: sha512-MbI9JniWcSpYaCaUel05lZRlYpiXJYKm81w4hFATExi+lNELmclnKiIYrVAgDj/5BhMjjjdYkf/OHJOTZe5OLg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       vitest: '>=4.0.0'
@@ -2775,8 +2775,8 @@ packages:
       '@semantic-release/exec':
         optional: true
 
-  '@theholocron/sentry-client@1.7.0':
-    resolution: {integrity: sha512-i7bqary+mqS8VxIOOWWuZtzelBviVFgzeNsm5hxp6B6EQL7pFHpo36UxE7cIUOqu3lxFVLF8UDL8LsUm95z7HQ==}
+  '@theholocron/sentry-client@1.7.1':
+    resolution: {integrity: sha512-i/mFTs6uRBEPNdoBJ3GIWQEpYV9MMSL1eAMpWqueCSiLgucb/zbRPti+FfXNNLLkqrcu5DlxHpbPTbeTMsmGPg==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/skills@1.3.2':
@@ -8418,13 +8418,13 @@ snapshots:
 
   '@theholocron/clerk-client@1.7.0(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.1(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/cloudflare-client@1.7.0(vitest@4.1.10)':
+  '@theholocron/cloudflare-client@1.7.1(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.1(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
@@ -8441,7 +8441,7 @@ snapshots:
 
   '@theholocron/doppler-client@1.7.0(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.1(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
@@ -8471,9 +8471,9 @@ snapshots:
       eslint-plugin-n: 18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
       eslint-plugin-react: 7.37.5(eslint@10.8.1(jiti@2.7.0))
 
-  '@theholocron/github-client@1.6.7(vitest@4.1.10)':
+  '@theholocron/github-client@1.7.1(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.1(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
@@ -8481,13 +8481,13 @@ snapshots:
     dependencies:
       '@theholocron/cli': link:packages/cli
 
-  '@theholocron/http-client@1.7.0(vitest@4.1.10)':
+  '@theholocron/http-client@1.7.1(vitest@4.1.10)':
     optionalDependencies:
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@theholocron/infisical-client@1.7.0(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.1(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
@@ -8498,13 +8498,13 @@ snapshots:
 
   '@theholocron/neon-client@1.7.0(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.1(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
   '@theholocron/postman-client@1.7.0(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.1(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
@@ -8524,9 +8524,9 @@ snapshots:
     optionalDependencies:
       '@semantic-release/exec': 7.1.0(semantic-release@25.0.9(typescript@5.9.3))
 
-  '@theholocron/sentry-client@1.7.0(vitest@4.1.10)':
+  '@theholocron/sentry-client@1.7.1(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.1(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
@@ -8546,13 +8546,13 @@ snapshots:
 
   '@theholocron/vercel-client@1.7.0(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.1(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
   '@theholocron/vitest-config@7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
     dependencies:
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
     optionalDependencies:
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
 
@@ -8863,7 +8863,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ catalogs:
       specifier: ^1.7.0
       version: 1.7.0
     '@theholocron/github-client':
-      specifier: ^1.7.0
-      version: 1.7.0
+      specifier: ^1.6.7
+      version: 1.6.7
     '@theholocron/http-client':
       specifier: ^1.7.0
       version: 1.7.0
@@ -280,7 +280,7 @@ importers:
         version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
       '@theholocron/github-client':
         specifier: catalog:clients
-        version: 1.7.0(vitest@4.1.10)
+        version: 1.6.7(vitest@4.1.10)
       '@theholocron/http-client':
         specifier: catalog:clients
         version: 1.7.0(vitest@4.1.10)
@@ -579,7 +579,7 @@ importers:
         version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/github-client':
         specifier: catalog:clients
-        version: 1.7.0(vitest@4.1.10)
+        version: 1.6.7(vitest@4.1.10)
       '@theholocron/tsconfig':
         specifier: catalog:configs
         version: 7.19.1(typescript@5.9.3)
@@ -2711,8 +2711,8 @@ packages:
       eslint-plugin-storybook:
         optional: true
 
-  '@theholocron/github-client@1.7.0':
-    resolution: {integrity: sha512-E39nDjNomCeC7xApEOq3L33R+6p213AIYFGoOv5ziILWzfqaycyuSO6dgYSRi77A9stCli5Y6ORoTXi1fUy1OA==}
+  '@theholocron/github-client@1.6.7':
+    resolution: {integrity: sha512-ReF/vCXmGD0QmSFrIr60EAFSPOoWA40lpnI4rWj6Ss8w2X8eRs+e/4DatLqwECTN+3R+EqBTU0iKRRf3UA2Xow==}
     engines: {node: '>=22.0.0'}
 
   '@theholocron/holocron-config@7.19.1':
@@ -8471,7 +8471,7 @@ snapshots:
       eslint-plugin-n: 18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
       eslint-plugin-react: 7.37.5(eslint@10.8.1(jiti@2.7.0))
 
-  '@theholocron/github-client@1.7.0(vitest@4.1.10)':
+  '@theholocron/github-client@1.6.7(vitest@4.1.10)':
     dependencies:
       '@theholocron/http-client': 1.7.0(vitest@4.1.10)
     transitivePeerDependencies:
@@ -8552,7 +8552,7 @@ snapshots:
 
   '@theholocron/vitest-config@7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
     dependencies:
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
 
@@ -8863,7 +8863,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,57 +7,63 @@ settings:
 catalogs:
   clients:
     '@theholocron/clerk-client':
-      specifier: ^1.6.0
-      version: 1.6.2
+      specifier: ^1.7.0
+      version: 1.7.0
+    '@theholocron/cloudflare-client':
+      specifier: ^1.7.0
+      version: 1.7.0
     '@theholocron/doppler-client':
-      specifier: ^1.6.0
-      version: 1.6.2
+      specifier: ^1.7.0
+      version: 1.7.0
     '@theholocron/github-client':
-      specifier: ^1.6.2
-      version: 1.6.6
+      specifier: ^1.7.0
+      version: 1.7.0
     '@theholocron/http-client':
-      specifier: ^1.6.6
-      version: 1.6.6
+      specifier: ^1.7.0
+      version: 1.7.0
     '@theholocron/infisical-client':
-      specifier: ^1.6.0
-      version: 1.6.2
+      specifier: ^1.7.0
+      version: 1.7.0
     '@theholocron/neon-client':
-      specifier: ^1.6.0
-      version: 1.6.2
+      specifier: ^1.7.0
+      version: 1.7.0
     '@theholocron/postman-client':
-      specifier: ^1.6.0
-      version: 1.6.2
+      specifier: ^1.7.0
+      version: 1.7.0
+    '@theholocron/sentry-client':
+      specifier: ^1.7.0
+      version: 1.7.0
     '@theholocron/vercel-client':
-      specifier: ^1.6.0
-      version: 1.6.2
+      specifier: ^1.7.0
+      version: 1.7.0
   configs:
     '@theholocron/commitlint-config':
-      specifier: ^7.16.0
-      version: 7.18.1
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/eslint-config':
-      specifier: ^7.16.0
-      version: 7.16.0
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/holocron-config':
-      specifier: ^7.16.0
-      version: 7.18.1
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/lint-staged-config':
-      specifier: ^7.16.0
-      version: 7.18.1
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/prettier-config':
-      specifier: ^7.16.0
-      version: 7.18.1
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/semantic-release-config':
-      specifier: ^7.16.0
-      version: 7.18.1
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/tsconfig':
-      specifier: ^7.16.0
-      version: 7.16.0
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/tsdown-config':
-      specifier: ^7.16.0
-      version: 7.18.1
+      specifier: ^7.19.1
+      version: 7.19.1
     '@theholocron/vitest-config':
-      specifier: ^7.16.0
-      version: 7.18.1
+      specifier: ^7.19.1
+      version: 7.19.1
   default:
     '@inquirer/prompts':
       specifier: ^8.5.2
@@ -138,13 +144,13 @@ importers:
         version: link:packages/cli
       '@theholocron/commitlint-config':
         specifier: catalog:configs
-        version: 7.18.1(@commitlint/cli@19.8.1(@types/node@26.2.0)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)
+        version: 7.19.1(@commitlint/cli@19.8.1(@types/node@26.2.0)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)
       '@theholocron/eslint-config':
         specifier: catalog:configs
-        version: 7.16.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/holocron-config':
         specifier: catalog:configs
-        version: 7.18.1(@theholocron/cli@packages+cli)
+        version: 7.19.1(@theholocron/cli@packages+cli)
       '@theholocron/holocron-plugin-1password':
         specifier: workspace:*
         version: link:packages/holocron-plugin-1password
@@ -171,19 +177,19 @@ importers:
         version: link:packages/holocron-plugin-vercel
       '@theholocron/lint-staged-config':
         specifier: catalog:configs
-        version: 7.18.1(husky@9.1.7)(lint-staged@16.4.0)
+        version: 7.19.1(husky@9.1.7)(lint-staged@16.4.0)
       '@theholocron/prettier-config':
         specifier: catalog:configs
-        version: 7.18.1(prettier@3.9.6)
+        version: 7.19.1(prettier@3.9.6)
       '@theholocron/semantic-release-config':
         specifier: catalog:configs
-        version: 7.18.1(@semantic-release/changelog@6.0.3(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.9(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.9(typescript@5.9.3))
+        version: 7.19.1(@semantic-release/changelog@6.0.3(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.9(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.9(typescript@5.9.3))
       '@theholocron/skills':
         specifier: ^1.3.2
         version: 1.3.2
       '@theholocron/tsconfig':
         specifier: catalog:configs
-        version: 7.16.0(typescript@5.9.3)
+        version: 7.19.1(typescript@5.9.3)
       '@vitest/eslint-plugin':
         specifier: 'catalog:'
         version: 1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)
@@ -274,10 +280,10 @@ importers:
         version: 10.69.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
       '@theholocron/github-client':
         specifier: catalog:clients
-        version: 1.6.6(vitest@4.1.10)
+        version: 1.7.0(vitest@4.1.10)
       '@theholocron/http-client':
         specifier: catalog:clients
-        version: 1.6.6(vitest@4.1.10)
+        version: 1.7.0(vitest@4.1.10)
       chalk:
         specifier: 'catalog:'
         version: 6.0.0
@@ -293,13 +299,13 @@ importers:
     devDependencies:
       '@theholocron/eslint-config':
         specifier: catalog:configs
-        version: 7.16.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: catalog:configs
-        version: 7.16.0(typescript@5.9.3)
+        version: 7.19.1(typescript@5.9.3)
       '@theholocron/vitest-config':
         specifier: catalog:configs
-        version: 7.18.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.2
@@ -335,13 +341,13 @@ importers:
     devDependencies:
       '@theholocron/tsconfig':
         specifier: catalog:configs
-        version: 7.16.0(typescript@5.9.3)
+        version: 7.19.1(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: catalog:configs
-        version: 7.18.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.23.11)(typescript@5.9.3))
+        version: 7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.23.11)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: catalog:configs
-        version: 7.18.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.2
@@ -365,16 +371,16 @@ importers:
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: catalog:configs
-        version: 7.16.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: catalog:configs
-        version: 7.16.0(typescript@5.9.3)
+        version: 7.19.1(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: catalog:configs
-        version: 7.18.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: catalog:configs
-        version: 7.18.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.2
@@ -410,22 +416,73 @@ importers:
     devDependencies:
       '@theholocron/clerk-client':
         specifier: catalog:clients
-        version: 1.6.2(vitest@4.1.10)
+        version: 1.7.0(vitest@4.1.10)
       '@theholocron/cli':
         specifier: workspace:*
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: catalog:configs
-        version: 7.16.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: catalog:configs
-        version: 7.16.0(typescript@5.9.3)
+        version: 7.19.1(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: catalog:configs
-        version: 7.18.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: catalog:configs
-        version: 7.18.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.1.2
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      '@vitest/eslint-plugin':
+        specifier: 'catalog:'
+        version: 1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)
+      eslint:
+        specifier: 'catalog:'
+        version: 10.8.1(jiti@2.7.0)
+      eslint-plugin-n:
+        specifier: 'catalog:'
+        version: 18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
+      globals:
+        specifier: 'catalog:'
+        version: 17.9.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/holocron-plugin-cloudflare:
+    devDependencies:
+      '@theholocron/cli':
+        specifier: workspace:*
+        version: link:../cli
+      '@theholocron/cloudflare-client':
+        specifier: catalog:clients
+        version: 1.7.0(vitest@4.1.10)
+      '@theholocron/eslint-config':
+        specifier: catalog:configs
+        version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
+      '@theholocron/tsconfig':
+        specifier: catalog:configs
+        version: 7.19.1(typescript@5.9.3)
+      '@theholocron/tsdown-config':
+        specifier: catalog:configs
+        version: 7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
+      '@theholocron/vitest-config':
+        specifier: catalog:configs
+        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.2
@@ -464,19 +521,19 @@ importers:
         version: link:../cli
       '@theholocron/doppler-client':
         specifier: catalog:clients
-        version: 1.6.2(vitest@4.1.10)
+        version: 1.7.0(vitest@4.1.10)
       '@theholocron/eslint-config':
         specifier: catalog:configs
-        version: 7.16.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: catalog:configs
-        version: 7.16.0(typescript@5.9.3)
+        version: 7.19.1(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: catalog:configs
-        version: 7.18.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: catalog:configs
-        version: 7.18.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.2
@@ -519,19 +576,19 @@ importers:
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: catalog:configs
-        version: 7.16.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/github-client':
         specifier: catalog:clients
-        version: 1.6.6(vitest@4.1.10)
+        version: 1.7.0(vitest@4.1.10)
       '@theholocron/tsconfig':
         specifier: catalog:configs
-        version: 7.16.0(typescript@5.9.3)
+        version: 7.19.1(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: catalog:configs
-        version: 7.18.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: catalog:configs
-        version: 7.18.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.2
@@ -570,19 +627,19 @@ importers:
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: catalog:configs
-        version: 7.16.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/infisical-client':
         specifier: catalog:clients
-        version: 1.6.2(vitest@4.1.10)
+        version: 1.7.0(vitest@4.1.10)
       '@theholocron/tsconfig':
         specifier: catalog:configs
-        version: 7.16.0(typescript@5.9.3)
+        version: 7.19.1(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: catalog:configs
-        version: 7.18.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: catalog:configs
-        version: 7.18.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.2
@@ -621,19 +678,19 @@ importers:
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: catalog:configs
-        version: 7.16.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/neon-client':
         specifier: catalog:clients
-        version: 1.6.2(vitest@4.1.10)
+        version: 1.7.0(vitest@4.1.10)
       '@theholocron/tsconfig':
         specifier: catalog:configs
-        version: 7.16.0(typescript@5.9.3)
+        version: 7.19.1(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: catalog:configs
-        version: 7.18.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: catalog:configs
-        version: 7.18.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.2
@@ -672,19 +729,70 @@ importers:
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: catalog:configs
-        version: 7.16.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/postman-client':
         specifier: catalog:clients
-        version: 1.6.2(vitest@4.1.10)
+        version: 1.7.0(vitest@4.1.10)
       '@theholocron/tsconfig':
         specifier: catalog:configs
-        version: 7.16.0(typescript@5.9.3)
+        version: 7.19.1(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: catalog:configs
-        version: 7.18.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vitest-config':
         specifier: catalog:configs
-        version: 7.18.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.1.2
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      '@vitest/eslint-plugin':
+        specifier: 'catalog:'
+        version: 1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)
+      eslint:
+        specifier: 'catalog:'
+        version: 10.8.1(jiti@2.7.0)
+      eslint-plugin-n:
+        specifier: 'catalog:'
+        version: 18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
+      globals:
+        specifier: 'catalog:'
+        version: 17.9.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/holocron-plugin-sentry:
+    devDependencies:
+      '@theholocron/cli':
+        specifier: workspace:*
+        version: link:../cli
+      '@theholocron/eslint-config':
+        specifier: catalog:configs
+        version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
+      '@theholocron/sentry-client':
+        specifier: catalog:clients
+        version: 1.7.0(vitest@4.1.10)
+      '@theholocron/tsconfig':
+        specifier: catalog:configs
+        version: 7.19.1(typescript@5.9.3)
+      '@theholocron/tsdown-config':
+        specifier: catalog:configs
+        version: 7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
+      '@theholocron/vitest-config':
+        specifier: catalog:configs
+        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.2
@@ -723,19 +831,19 @@ importers:
         version: link:../cli
       '@theholocron/eslint-config':
         specifier: catalog:configs
-        version: 7.16.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
+        version: 7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))
       '@theholocron/tsconfig':
         specifier: catalog:configs
-        version: 7.16.0(typescript@5.9.3)
+        version: 7.19.1(typescript@5.9.3)
       '@theholocron/tsdown-config':
         specifier: catalog:configs
-        version: 7.18.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
+        version: 7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))
       '@theholocron/vercel-client':
         specifier: catalog:clients
-        version: 1.6.2(vitest@4.1.10)
+        version: 1.7.0(vitest@4.1.10)
       '@theholocron/vitest-config':
         specifier: catalog:configs
-        version: 7.18.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
+        version: 7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.2
@@ -2548,12 +2656,16 @@ packages:
     peerDependencies:
       astro: '>=5.0.0'
 
-  '@theholocron/clerk-client@1.6.2':
-    resolution: {integrity: sha512-jtOPX7KpA3mcGpsNLeMzqbX4zw5cg/TdfqhA0cUf6RA528y24eAsEGAdVvaCKFWe7M4oJ1ssThZRgyNRmroKNg==}
+  '@theholocron/clerk-client@1.7.0':
+    resolution: {integrity: sha512-m3xvhFeJEIpjbP2XWku2ylP0yQLV7Ecms4ghj2OQQVKVqa0q16XoK8HcJfpag2eDVGeSdkrH8H+iUF+GzVDT4Q==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/commitlint-config@7.18.1':
-    resolution: {integrity: sha512-nc9bBf/AxT/SNLlihtJgjrhG60LZ2eUJ6PvkNx0xqB6YNRyrOfjP54bIPpuoZKNi94q+WkSEo0ILeL3iMz3jiQ==}
+  '@theholocron/cloudflare-client@1.7.0':
+    resolution: {integrity: sha512-jXGlDp0XUu3tJYyB8rRbvRSceaFt552wQ2P+SeV81woBNJ+6jz8baHkgvot/9Hi0qtjxJp5fJbqgEm1WV5rmZw==}
+    engines: {node: '>=22.0.0'}
+
+  '@theholocron/commitlint-config@7.19.1':
+    resolution: {integrity: sha512-3jbOnaRMJDdLSa9AjxE3gdtVkF6FrLaVePwHuzhb/xekZHWx7ORFPahYbW4CEg16EZgLs7lg9PkZ7esmHOsnDA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@commitlint/cli': ^21
@@ -2566,12 +2678,12 @@ packages:
       '@astrojs/starlight': '>=0.30.0'
       astro: '>=5.0.0'
 
-  '@theholocron/doppler-client@1.6.2':
-    resolution: {integrity: sha512-67WJbYEsd6OqbTOVzXrVJBls+fIMAZ17UXw/arifcwNFqk25oNwfN2seYCmixsBGvL/uOwJRUW41G2AXXe5gLA==}
+  '@theholocron/doppler-client@1.7.0':
+    resolution: {integrity: sha512-suYwBLQUjJynXoixyAwZiuvZs2X5R9A/GdbwD1JYipmisyDijnkXnJpAgtFarX6LELApugOPcGsiLFIWGuBvjA==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/eslint-config@7.16.0':
-    resolution: {integrity: sha512-6mctYbiUbo3gC50HyeJTxRvXn+2+7RXvTvvP/10aAfnNPh5HXxL0Jq5mrkkiCQsVF+Gi3xnHl/fsLE83JP3rCA==}
+  '@theholocron/eslint-config@7.19.1':
+    resolution: {integrity: sha512-/tkJGE4Hy+gxUHzAo+ewnUI49c2aeLE3xXo/dM8X9s7Dl6I2lTyaS3/IJUs8cTMSuPQcXxDxnXt0VOP30YVYhQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@eslint/js': ^10
@@ -2599,18 +2711,18 @@ packages:
       eslint-plugin-storybook:
         optional: true
 
-  '@theholocron/github-client@1.6.6':
-    resolution: {integrity: sha512-I9T+tadfVIph38IlN8N5GIY5giQ1tKK5TanYYHHQvmeqVJJI3hLBOh/fO3L7kY4ym0KdtOkEktTXA9/valr90g==}
+  '@theholocron/github-client@1.7.0':
+    resolution: {integrity: sha512-E39nDjNomCeC7xApEOq3L33R+6p213AIYFGoOv5ziILWzfqaycyuSO6dgYSRi77A9stCli5Y6ORoTXi1fUy1OA==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/holocron-config@7.18.1':
-    resolution: {integrity: sha512-uyj+e3lknRn6ijS2gohwXrzHizltaa891KwrnT6Xcif0wJa/khnceig5O2ZgtNhW20FtmrZhikTbh7H4V1hHIQ==}
+  '@theholocron/holocron-config@7.19.1':
+    resolution: {integrity: sha512-BDp2umeCi9Ti9NdNFLt6p/cI2FCzciZfIZ+mJbZFc4adJs93KDDFS14sWqWly6cggiSHvrseMP20VkMWTbgFHg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@theholocron/cli': '>=2.0.0-alpha.1'
 
-  '@theholocron/http-client@1.6.6':
-    resolution: {integrity: sha512-RcO3VmtRb9ds0beMeQI37T+Yy7gLI3RwRd7uB0NMT9ucMhmLRHa1tKkmk974rrBOg/Y1nms0hyMow9sccH6UXw==}
+  '@theholocron/http-client@1.7.0':
+    resolution: {integrity: sha512-ZaJcgY83qovJlmYx50D6CJ/3DHKsltDSKp69tvmA9zh0jhbnUqulz0VYbO+caaVG3M6AgMx0BFYBXc724wUOpA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       vitest: '>=4.0.0'
@@ -2618,12 +2730,12 @@ packages:
       vitest:
         optional: true
 
-  '@theholocron/infisical-client@1.6.2':
-    resolution: {integrity: sha512-ovfKse4DyiIodACxZi2qIP0vQsHxVU0ll7qlIT44nQvB+W9xmf9MySYj3lQs8CimpAoDFuFm27cQUlNsd5+trA==}
+  '@theholocron/infisical-client@1.7.0':
+    resolution: {integrity: sha512-TjlmJjzloqEE/bVJpyDYy22e2zJ3iEEuSco+2lKXgS07NV8fiS02ISHPxt8J4SluhEZjsfpFhT6l2YpJDBYz2w==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/lint-staged-config@7.18.1':
-    resolution: {integrity: sha512-nkvdmGD4tANniJsJw/ccJuZs7URHbVlTw7JSXKsrjFW07FOLIMdNsdqd38AeD8qobvYPxcSIcZGsK+YyCV8Stg==}
+  '@theholocron/lint-staged-config@7.19.1':
+    resolution: {integrity: sha512-SpLRN5wCxCdiVlkTPqbc5DNm3s0aLth+8HQDTW18T06Zh+y6Xn85uYyUahgv0Ct2bEzegvmvW1tdkOoxM0+HUQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       husky: ^9
@@ -2633,22 +2745,22 @@ packages:
       sort-package-json:
         optional: true
 
-  '@theholocron/neon-client@1.6.2':
-    resolution: {integrity: sha512-wsHCsdhDTvdSlDz/gnI5UW5LiJE4gAvKbIsCepJ9GfkQOJLTCWz3dMwRoaHEfsJ5tDPtVmJHNZsilR+UrzE8Nw==}
+  '@theholocron/neon-client@1.7.0':
+    resolution: {integrity: sha512-qybSjXnxbbG7cwAcNosOEjzjH9GuHomYolrBbnTNkHh6nulFkrayZlEe4f1u3vUiMDo2ZtEbttpJpfpwjF7jDQ==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/postman-client@1.6.2':
-    resolution: {integrity: sha512-pCqCPTtTHJ1/YcSwPYDAzbkhQyt6pvmOw0gsM98qwD/z5shiLjqw27q4OlRAjRy05pDa6UvAKCU0WBt3kHKmWw==}
+  '@theholocron/postman-client@1.7.0':
+    resolution: {integrity: sha512-368udhps3R0YrOF4Nw+yNPcdm9gmYRODJhWNLZYn0+Z3g+ud6Bqt73MUvBw3r7eWyE5rGuZ+cKaf3NkmtivfoQ==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/prettier-config@7.18.1':
-    resolution: {integrity: sha512-QAINSLxNodQK7eFp7/mq49wtmm9JGiRptIotXFf7S/vyhO0iU3z/evVk9to7oegb42v3+h2KIYxax3mmrCjfxg==}
+  '@theholocron/prettier-config@7.19.1':
+    resolution: {integrity: sha512-IU+gxQrmjvLls3P5avBiMCOjI6GBXtCvUx9vsE9cb7g6bmVmlz8zh3mkSBq4JnjwRvYxGM3HIOjzp+ERP5PdQA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       prettier: ^3
 
-  '@theholocron/semantic-release-config@7.18.1':
-    resolution: {integrity: sha512-FBOMCCpVcHBf/9//NiQCegmuA9A0ClAUrIq9iYhflOBK93H68XtyTkA+ppE3VlAPgJtRSP0TyI03gDHlsAQnFA==}
+  '@theholocron/semantic-release-config@7.19.1':
+    resolution: {integrity: sha512-nN6/hcrAgLDJUWkl+shJ/+Rz1bXenmaXL6KWkZ2HM2/gXWSNnuJ6+P881gl1nTYfVo/G0QQWo7rX0UFJZdrRBQ==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@semantic-release/changelog': ^6
@@ -2663,28 +2775,32 @@ packages:
       '@semantic-release/exec':
         optional: true
 
+  '@theholocron/sentry-client@1.7.0':
+    resolution: {integrity: sha512-i7bqary+mqS8VxIOOWWuZtzelBviVFgzeNsm5hxp6B6EQL7pFHpo36UxE7cIUOqu3lxFVLF8UDL8LsUm95z7HQ==}
+    engines: {node: '>=22.0.0'}
+
   '@theholocron/skills@1.3.2':
     resolution: {integrity: sha512-jjnezEdoMUraGe4vmffm51KHTefXFNaHr2XNzweQSGjuzpj+F+iaBu741zXpZDtG5VCsyo5gF/sUIhEtUcw5pg==}
     engines: {node: '>=22', pnpm: '>=10'}
 
-  '@theholocron/tsconfig@7.16.0':
-    resolution: {integrity: sha512-ADcaojCPvQE9G1qnmdLw7fERP/p4at/4n2tZELNpmDwDSjQpmBSDqjfUmcxzkxKtlBcVi06BYXRFlHQ2JLWKfA==}
+  '@theholocron/tsconfig@7.19.1':
+    resolution: {integrity: sha512-8nSd3UOsmpV3MdHw4zDbBkj4QbF70LCO/vj1MIDFuRv/K7PqA+tGAuTB4YGjodWLwdQBC6wjRMQo0lK9zI92sg==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       typescript: ^5
 
-  '@theholocron/tsdown-config@7.18.1':
-    resolution: {integrity: sha512-q+nmL6Ue2yVMT8FOgrjxwXcQ3fmVPz7wtbdEUUU01erbN03GzGBgM7UYDgSesIZuCZjGq8o62Z6GE78ilsTR3Q==}
+  '@theholocron/tsdown-config@7.19.1':
+    resolution: {integrity: sha512-tHLJVM/YDyt0PWNQNMwbmOS9BJpI3ZdWdCmh1g/2UOhZMnYUuqs5YhkANnRSaoIVOkwKtL23BKd3k+6TpMlZ3g==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       tsdown: ^0
 
-  '@theholocron/vercel-client@1.6.2':
-    resolution: {integrity: sha512-QwEPM8SS4KxCBa9LIFrMBSELJSy7T0hVuIXhvMjifszYuMwHnwV7EjsnUGwDmA//YeTfmqHWtcLaTMghLsYTQQ==}
+  '@theholocron/vercel-client@1.7.0':
+    resolution: {integrity: sha512-xH6qTyzCV3pSIJJgTB4Nlppo4jazZzBg7oVO7gOISaa938c0BMAKvpcxFtBIjJ447Hyk1w+RYZLVSuMC1k+zFA==}
     engines: {node: '>=22.0.0'}
 
-  '@theholocron/vitest-config@7.18.1':
-    resolution: {integrity: sha512-h5rdIWpS8NXiqkQMdGoIFkBks8lTu9NTpyAAPuaMNCyHX4kaxOo5TH6Wch8EqpuLdiDXkpMMTBaTNZE0MWx2jA==}
+  '@theholocron/vitest-config@7.19.1':
+    resolution: {integrity: sha512-vP7EUuqFhFizQdRsbzWmJfFUPAzIFfB4kqE2Jj40P0uIfAY3jGyJWQ/7kJ84y6P3XEeBozrpeyGKMvjpSu5tAw==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@storybook/addon-vitest': ^9
@@ -8300,13 +8416,19 @@ snapshots:
     dependencies:
       astro: 7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0)
 
-  '@theholocron/clerk-client@1.6.2(vitest@4.1.10)':
+  '@theholocron/clerk-client@1.7.0(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.6.6(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/commitlint-config@7.18.1(@commitlint/cli@19.8.1(@types/node@26.2.0)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)':
+  '@theholocron/cloudflare-client@1.7.0(vitest@4.1.10)':
+    dependencies:
+      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
+    transitivePeerDependencies:
+      - vitest
+
+  '@theholocron/commitlint-config@7.19.1(@commitlint/cli@19.8.1(@types/node@26.2.0)(typescript@5.9.3))(@commitlint/config-conventional@19.8.1)':
     dependencies:
       '@commitlint/cli': 19.8.1(@types/node@26.2.0)(typescript@5.9.3)
       '@commitlint/config-conventional': 19.8.1
@@ -8317,13 +8439,13 @@ snapshots:
       astro: 7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.1.2)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0)
       gray-matter: 4.0.3
 
-  '@theholocron/doppler-client@1.6.2(vitest@4.1.10)':
+  '@theholocron/doppler-client@1.7.0(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.6.6(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/eslint-config@7.16.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))':
+  '@theholocron/eslint-config@7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))':
     dependencies:
       '@eslint/compat': 2.1.0(eslint@10.8.1(jiti@2.7.0))
       '@eslint/js': 10.0.1(eslint@10.8.1(jiti@2.7.0))
@@ -8336,7 +8458,7 @@ snapshots:
       eslint-plugin-n: 18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
       eslint-plugin-react: 7.37.5(eslint@10.8.1(jiti@2.7.0))
 
-  '@theholocron/eslint-config@7.16.0(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))':
+  '@theholocron/eslint-config@7.19.1(@eslint/js@10.0.1(eslint@10.8.1(jiti@2.7.0)))(@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10))(eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@10.8.1(jiti@2.7.0)))(eslint-plugin-simple-import-sort@14.0.0(eslint@10.8.1(jiti@2.7.0)))(eslint@10.8.1(jiti@2.7.0))(globals@17.9.0)(typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))':
     dependencies:
       '@eslint/compat': 2.1.0(eslint@10.8.1(jiti@2.7.0))
       '@eslint/js': 10.0.1(eslint@10.8.1(jiti@2.7.0))
@@ -8349,48 +8471,48 @@ snapshots:
       eslint-plugin-n: 18.3.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)
       eslint-plugin-react: 7.37.5(eslint@10.8.1(jiti@2.7.0))
 
-  '@theholocron/github-client@1.6.6(vitest@4.1.10)':
+  '@theholocron/github-client@1.7.0(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.6.6(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/holocron-config@7.18.1(@theholocron/cli@packages+cli)':
+  '@theholocron/holocron-config@7.19.1(@theholocron/cli@packages+cli)':
     dependencies:
       '@theholocron/cli': link:packages/cli
 
-  '@theholocron/http-client@1.6.6(vitest@4.1.10)':
+  '@theholocron/http-client@1.7.0(vitest@4.1.10)':
     optionalDependencies:
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
-  '@theholocron/infisical-client@1.6.2(vitest@4.1.10)':
+  '@theholocron/infisical-client@1.7.0(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.6.6(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/lint-staged-config@7.18.1(husky@9.1.7)(lint-staged@16.4.0)':
+  '@theholocron/lint-staged-config@7.19.1(husky@9.1.7)(lint-staged@16.4.0)':
     dependencies:
       husky: 9.1.7
       lint-staged: 16.4.0
 
-  '@theholocron/neon-client@1.6.2(vitest@4.1.10)':
+  '@theholocron/neon-client@1.7.0(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.6.6(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/postman-client@1.6.2(vitest@4.1.10)':
+  '@theholocron/postman-client@1.7.0(vitest@4.1.10)':
     dependencies:
-      '@theholocron/http-client': 1.6.6(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/prettier-config@7.18.1(prettier@3.9.6)':
+  '@theholocron/prettier-config@7.19.1(prettier@3.9.6)':
     dependencies:
       prettier: 3.9.6
 
-  '@theholocron/semantic-release-config@7.18.1(@semantic-release/changelog@6.0.3(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.9(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.9(typescript@5.9.3))':
+  '@theholocron/semantic-release-config@7.19.1(@semantic-release/changelog@6.0.3(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/exec@7.1.0(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/git@10.0.1(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/github@12.0.9(semantic-release@25.0.9(typescript@5.9.3)))(@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.9(typescript@5.9.3)))(conventional-changelog-conventionalcommits@10.2.1)(semantic-release@25.0.9(typescript@5.9.3))':
     dependencies:
       '@semantic-release/changelog': 6.0.3(semantic-release@25.0.9(typescript@5.9.3))
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.9(typescript@5.9.3))
@@ -8402,29 +8524,35 @@ snapshots:
     optionalDependencies:
       '@semantic-release/exec': 7.1.0(semantic-release@25.0.9(typescript@5.9.3))
 
-  '@theholocron/skills@1.3.2': {}
-
-  '@theholocron/tsconfig@7.16.0(typescript@5.9.3)':
+  '@theholocron/sentry-client@1.7.0(vitest@4.1.10)':
     dependencies:
-      typescript: 5.9.3
-
-  '@theholocron/tsdown-config@7.18.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))':
-    dependencies:
-      tsdown: 0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
-
-  '@theholocron/tsdown-config@7.18.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.23.11)(typescript@5.9.3))':
-    dependencies:
-      tsdown: 0.22.14(oxc-resolver@11.24.2)(tsx@4.23.11)(typescript@5.9.3)
-
-  '@theholocron/vercel-client@1.6.2(vitest@4.1.10)':
-    dependencies:
-      '@theholocron/http-client': 1.6.6(vitest@4.1.10)
+      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
     transitivePeerDependencies:
       - vitest
 
-  '@theholocron/vitest-config@7.18.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
+  '@theholocron/skills@1.3.2': {}
+
+  '@theholocron/tsconfig@7.19.1(typescript@5.9.3)':
     dependencies:
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      typescript: 5.9.3
+
+  '@theholocron/tsdown-config@7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3))':
+    dependencies:
+      tsdown: 0.22.14(oxc-resolver@11.24.2)(tsx@4.22.4)(typescript@5.9.3)
+
+  '@theholocron/tsdown-config@7.19.1(tsdown@0.22.14(oxc-resolver@11.24.2)(tsx@4.23.11)(typescript@5.9.3))':
+    dependencies:
+      tsdown: 0.22.14(oxc-resolver@11.24.2)(tsx@4.23.11)(typescript@5.9.3)
+
+  '@theholocron/vercel-client@1.7.0(vitest@4.1.10)':
+    dependencies:
+      '@theholocron/http-client': 1.7.0(vitest@4.1.10)
+    transitivePeerDependencies:
+      - vitest
+
+  '@theholocron/vitest-config@7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
+    dependencies:
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
     optionalDependencies:
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
 
@@ -8735,7 +8863,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,6 +492,9 @@ importers:
       '@vitest/eslint-plugin':
         specifier: 'catalog:'
         version: 1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)
+      chalk:
+        specifier: 'catalog:'
+        version: 6.0.0
       eslint:
         specifier: 'catalog:'
         version: 10.8.1(jiti@2.7.0)
@@ -802,6 +805,9 @@ importers:
       '@vitest/eslint-plugin':
         specifier: 'catalog:'
         version: 1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)
+      chalk:
+        specifier: 'catalog:'
+        version: 6.0.0
       eslint:
         specifier: 'catalog:'
         version: 10.8.1(jiti@2.7.0)
@@ -8552,7 +8558,7 @@ snapshots:
 
   '@theholocron/vitest-config@7.19.1(@vitest/coverage-v8@4.1.10)(vitest@4.1.10)':
     dependencies:
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
 
@@ -8863,7 +8869,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.11)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.66.0(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,43 +6,43 @@ packages:
 # plugin packages grow.
 catalog:
   '@inquirer/prompts': ^8.5.2
+  '@sentry/node': ^10.69.0
+  '@types/node': ^26
+  '@types/yargs': ^17.0.35
   '@vitest/coverage-v8': ^4.1.10
   '@vitest/eslint-plugin': ^1.6.27
+  chalk: ^6.0.0
   eslint: ^10.8.1
   eslint-plugin-n: ^18.3.0
   eslint-plugin-simple-import-sort: ^14.0.0
   globals: ^17.9.0
-  chalk: ^6.0.0
   ora: ^9.4.1
   tsdown: ^0.22.14
-  turbo: ^2.10.9
   tsx: 4.22.4
-  vitest: ^4.1.10
+  turbo: ^2.10.9
   typescript: ^5.9.3
+  vitest: ^4.1.10
   yargs: ^18.1.0
-  '@sentry/node': ^10.69.0
-  '@types/node': ^26
-  '@types/yargs': ^17.0.35
 
 catalogs:
   # Shared clients — release in lockstep; bump all entries together.
   clients:
     '@theholocron/clerk-client': ^1.7.0
-    '@theholocron/cloudflare-client': ^1.7.0
+    '@theholocron/cloudflare-client': ^1.7.1
     '@theholocron/doppler-client': ^1.7.0
-    '@theholocron/github-client': ^1.6.7
-    '@theholocron/http-client': ^1.7.0
+    '@theholocron/github-client': ^1.7.1
+    '@theholocron/http-client': ^1.7.1
     '@theholocron/infisical-client': ^1.7.0
     '@theholocron/neon-client': ^1.7.0
     '@theholocron/postman-client': ^1.7.0
-    '@theholocron/sentry-client': ^1.7.0
+    '@theholocron/sentry-client': ^1.7.1
     '@theholocron/vercel-client': ^1.7.0
 
   # Shared configs — release in lockstep; bump all entries together.
   configs:
     '@theholocron/commitlint-config': ^7.19.1
-    '@theholocron/holocron-config': ^7.19.1
     '@theholocron/eslint-config': ^7.19.1
+    '@theholocron/holocron-config': ^7.19.1
     '@theholocron/lint-staged-config': ^7.19.1
     '@theholocron/prettier-config': ^7.19.1
     '@theholocron/semantic-release-config': ^7.19.1
@@ -54,5 +54,5 @@ catalogs:
 # same http-client instance — prevents instanceof ProviderApiError
 # dual-module hazard when github-client and cli both depend on it.
 overrides:
-  '@theholocron/http-client': ^1.7.0
+  '@theholocron/http-client': ^1.7.1
   tsx: 4.22.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,12 +28,14 @@ catalogs:
   # Shared clients — release in lockstep; bump all entries together.
   clients:
     '@theholocron/clerk-client': ^1.6.0
+    '@theholocron/cloudflare-client': ^1.6.7
     '@theholocron/doppler-client': ^1.6.0
     '@theholocron/github-client': ^1.6.2
     '@theholocron/http-client': ^1.6.6
     '@theholocron/infisical-client': ^1.6.0
     '@theholocron/neon-client': ^1.6.0
     '@theholocron/postman-client': ^1.6.0
+    '@theholocron/sentry-client': ^1.6.7
     '@theholocron/vercel-client': ^1.6.0
 
   # Shared configs — release in lockstep; bump all entries together.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,7 +30,7 @@ catalogs:
     '@theholocron/clerk-client': ^1.7.0
     '@theholocron/cloudflare-client': ^1.7.0
     '@theholocron/doppler-client': ^1.7.0
-    '@theholocron/github-client': ^1.7.0
+    '@theholocron/github-client': ^1.6.7
     '@theholocron/http-client': ^1.7.0
     '@theholocron/infisical-client': ^1.7.0
     '@theholocron/neon-client': ^1.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,32 +27,32 @@ catalog:
 catalogs:
   # Shared clients — release in lockstep; bump all entries together.
   clients:
-    '@theholocron/clerk-client': ^1.6.0
-    '@theholocron/cloudflare-client': ^1.6.7
-    '@theholocron/doppler-client': ^1.6.0
-    '@theholocron/github-client': ^1.6.2
-    '@theholocron/http-client': ^1.6.6
-    '@theholocron/infisical-client': ^1.6.0
-    '@theholocron/neon-client': ^1.6.0
-    '@theholocron/postman-client': ^1.6.0
-    '@theholocron/sentry-client': ^1.6.7
-    '@theholocron/vercel-client': ^1.6.0
+    '@theholocron/clerk-client': ^1.7.0
+    '@theholocron/cloudflare-client': ^1.7.0
+    '@theholocron/doppler-client': ^1.7.0
+    '@theholocron/github-client': ^1.7.0
+    '@theholocron/http-client': ^1.7.0
+    '@theholocron/infisical-client': ^1.7.0
+    '@theholocron/neon-client': ^1.7.0
+    '@theholocron/postman-client': ^1.7.0
+    '@theholocron/sentry-client': ^1.7.0
+    '@theholocron/vercel-client': ^1.7.0
 
   # Shared configs — release in lockstep; bump all entries together.
   configs:
-    '@theholocron/commitlint-config': ^7.16.0
-    '@theholocron/holocron-config': ^7.16.0
-    '@theholocron/eslint-config': ^7.16.0
-    '@theholocron/lint-staged-config': ^7.16.0
-    '@theholocron/prettier-config': ^7.16.0
-    '@theholocron/semantic-release-config': ^7.16.0
-    '@theholocron/tsconfig': ^7.16.0
-    '@theholocron/tsdown-config': ^7.16.0
-    '@theholocron/vitest-config': ^7.16.0
+    '@theholocron/commitlint-config': ^7.19.1
+    '@theholocron/holocron-config': ^7.19.1
+    '@theholocron/eslint-config': ^7.19.1
+    '@theholocron/lint-staged-config': ^7.19.1
+    '@theholocron/prettier-config': ^7.19.1
+    '@theholocron/semantic-release-config': ^7.19.1
+    '@theholocron/tsconfig': ^7.19.1
+    '@theholocron/tsdown-config': ^7.19.1
+    '@theholocron/vitest-config': ^7.19.1
 
 # Force all packages (including external transitive deps) to use the
 # same http-client instance — prevents instanceof ProviderApiError
 # dual-module hazard when github-client and cli both depend on it.
 overrides:
-  '@theholocron/http-client': ^1.6.6
+  '@theholocron/http-client': ^1.7.0
   tsx: 4.22.4


### PR DESCRIPTION
## Summary

- `capabilities/index.ts`: extends `Observability` and `Analytics` — `dsnEnvKey: string` → `envKeys: string[]`; adds optional `whoami?()` and `ensureProject?()` on both interfaces
- `holocron-plugin-cloudflare`: implements the `dns` capability against Cloudflare's v4 API — zone-walk resolution with per-instance cache, `upsertRecord` (update-or-create on type+name match), `deleteRecord`
- `holocron-plugin-sentry`: implements the `observability` capability against Sentry's management API — `ensureProject()` (GET-then-create), `describe()` returns `["SENTRY_DSN", "NEXT_PUBLIC_SENTRY_DSN"]`, `whoami()` via org lookup
- `pnpm-workspace.yaml`: adds `cloudflare-client` and `sentry-client` to the `clients` catalog (depends on theholocron/clients PR merging and publishing first)
- `codecov.yml`: adds component entries for both plugins
- `.notes/`: adds design spec for all four new capability plugins (observability, notifications, dns, analytics)

## Dependencies

Requires `@theholocron/cloudflare-client` and `@theholocron/sentry-client` to be published from theholocron/clients before this can be installed. The catalog versions in `pnpm-workspace.yaml` pin to `^1.6.7`.

## Test plan

- [ ] `pnpm --filter @theholocron/holocron-plugin-cloudflare test` — dns capability, zone resolution, verify-token
- [ ] `pnpm --filter @theholocron/holocron-plugin-sentry test` — observability, ensureProject, verify-token
- [ ] `pnpm typecheck` passes across the workspace
- [ ] `pnpm lint` passes across the workspace