### PR TITLE
fix(devmoji): remove --lint from prepare-commit-msg hook and template

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -17,4 +17,4 @@ git interpret-trailers --if-exists doNothing --trailer \
 	"Signed-off-by: $NAME <$EMAIL>" \
 	--in-place "$1"
 
-npx devmoji -e --lint
+npx devmoji -e

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -229,8 +229,10 @@ function devmojiConfigContent(): string {
 // ── .husky/prepare-commit-msg hook ───────────────────────────────────
 // 1. Validates that git user.name and user.email are configured.
 // 2. Appends the DCO Signed-off-by trailer (required on every commit).
-// 3. Runs devmoji to add an emoji to the commit subject and lint the
-//    conventional commit format.
+// 3. Runs devmoji to add an emoji to the commit subject.
+//    Note: --lint is intentionally omitted. prepare-commit-msg fires before
+//    the editor opens, so --lint would reject the still-empty message on
+//    interactive `git commit`. Validation is handled by commitlint in commit-msg.
 function prepareCommitMsgHookContent(): string {
 	return [
 		`#!/bin/sh`,
@@ -252,7 +254,7 @@ function prepareCommitMsgHookContent(): string {
 		`\t"Signed-off-by: $NAME <$EMAIL>" \\`,
 		`\t--in-place "$1"`,
 		``,
-		`npx devmoji -e --lint`,
+		`npx devmoji -e`,
 		``,
 	].join("\n");
 }


### PR DESCRIPTION
## Summary

Removes `--lint` from the `prepare-commit-msg` hook.

`prepare-commit-msg` fires **before** the editor opens on interactive `git commit` — the message is still empty at that point, so `--lint` rejects it. Commitlint in `commit-msg` handles validation after the message is written.

Fixes: `husky - prepare-commit-msg script failed (code 1)` when using `git commit` without `-m`.