### PR TITLE
fix(setup): deduplicate workflow names before building required checks

### DIFF
--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -779,8 +779,9 @@ describe("runSetup", () => {
 
 		const rules = (rulesetPayload as unknown as { rules: Array<{ type: string; parameters?: unknown }> }).rules;
 		const checksRule = rules.find((r) => r.type === "required_status_checks");
-		const contexts = (checksRule?.parameters as { required_status_checks: Array<{ context: string }> })
-			?.required_status_checks.map((c) => c.context);
+		const contexts = (
+			checksRule?.parameters as { required_status_checks: Array<{ context: string }> }
+		)?.required_status_checks.map((c) => c.context);
 		expect(contexts?.filter((c) => c === "Test / Run tests and collect coverage")).toHaveLength(1);
 	});
 

--- a/packages/cli/src/__tests__/setup.test.ts
+++ b/packages/cli/src/__tests__/setup.test.ts
@@ -745,6 +745,45 @@ describe("runSetup", () => {
 		});
 	});
 
+	it("deduplicates workflow names when building required checks", async () => {
+		let rulesetPayload: Record<string, unknown> | null = null;
+		const loaded = loadedFrom({
+			name: "demo",
+			repo: { name: "theholocron/demo", protection: "strict" },
+			// "test" appears as both a plain string and an override object — simulates ...workflows spread + explicit override
+			workflows: ["test", { name: "test", with: { "run-unit": true } }],
+			providers: { vault: "1password", source: "github" },
+		});
+		const loader = makeLoaderWith(loaded, {
+			"@theholocron/holocron-plugin-1password": makePlugin("1p", {
+				vault: { list: async () => [] },
+			}),
+			"@theholocron/holocron-plugin-github": makePlugin("gh", {
+				source: {
+					enableVulnerabilityAlerts: async () => {},
+					enableAutomatedSecurityFixes: async () => {},
+					enableSecretScanning: async () => {},
+					enablePrivateVulnerabilityReporting: async () => {},
+					updateRepoSettings: async () => {},
+					listRulesets: async () => [],
+					createRuleset: async (p: Record<string, unknown>) => {
+						rulesetPayload = p;
+						return { id: 1, name: "holocron-default-branch", enforcement: "active" };
+					},
+					writeWorkflowFile: async () => {},
+				},
+			}),
+		});
+
+		await runSetup({ loaded, context: { repoRoot: "/tmp/test" }, loader, print: () => {} });
+
+		const rules = (rulesetPayload as unknown as { rules: Array<{ type: string; parameters?: unknown }> }).rules;
+		const checksRule = rules.find((r) => r.type === "required_status_checks");
+		const contexts = (checksRule?.parameters as { required_status_checks: Array<{ context: string }> })
+			?.required_status_checks.map((c) => c.context);
+		expect(contexts?.filter((c) => c === "Test / Run tests and collect coverage")).toHaveLength(1);
+	});
+
 	it("updates an existing ruleset instead of creating a new one", async () => {
 		const created: unknown[] = [];
 		const updated: unknown[] = [];

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -561,9 +561,11 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			);
 			print(formatStep(steps[steps.length - 1]!));
 
-			const configuredWorkflowNames = (config.workflows ?? []).map((entry) =>
-				typeof entry === "string" ? entry : entry.name
-			);
+			const configuredWorkflowNames = [
+				...new Set((config.workflows ?? []).map((entry) =>
+					typeof entry === "string" ? entry : entry.name
+				)),
+			];
 			const requiredChecks =
 				effectivePreset === "strict"
 					? [

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -562,9 +562,7 @@ export async function runSetup(input: RunSetupInput): Promise<SetupReport> {
 			print(formatStep(steps[steps.length - 1]!));
 
 			const configuredWorkflowNames = [
-				...new Set((config.workflows ?? []).map((entry) =>
-					typeof entry === "string" ? entry : entry.name
-				)),
+				...new Set((config.workflows ?? []).map((entry) => (typeof entry === "string" ? entry : entry.name))),
 			];
 			const requiredChecks =
 				effectivePreset === "strict"


### PR DESCRIPTION
## Summary

- When a config has both `"test"` (from `...workflows` spread) and `{ name: "test", with: ... }` (as an override), the workflow name appears twice in the list
- This caused duplicate entries in the ruleset's `required_status_checks` (e.g. `Test / Run tests and collect coverage` twice)
- Wraps the name extraction in `[...new Set(...)]` to deduplicate before looking up check contexts

## Test plan

- [ ] Run `holocron setup` on cli-template after merging — verify no duplicate required checks in the ruleset