### PR TITLE
fix(sync-github): handle ...workflows spread in parseWorkflowsFromTs

### DIFF
--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -842,7 +842,7 @@ describe("generateThinCallerContent", () => {
 describe("parseWorkflowsFromTs", () => {
 	it("returns explicit string and object entries when no spread", () => {
 		const source = `export default defineConfig({
-  workflows: ["lint", { name: "release", with: { "run-build": true } }],
+	workflows: ["lint", { name: "release", with: { "run-build": true } }],
 });`;
 		const result = parseWorkflowsFromTs(source);
 		expect(result.map((e) => e.name)).toEqual(["lint", "release"]);
@@ -852,7 +852,7 @@ describe("parseWorkflowsFromTs", () => {
 	it("includes all known workflows when spread is present", () => {
 		const source = `const { workflows } = node();
 export default defineConfig({
-  workflows: [...workflows, "audit", { name: "deploy", with: { docs: true } }],
+	workflows: [...workflows, "audit", { name: "deploy", with: { docs: true } }],
 });`;
 		const result = parseWorkflowsFromTs(source);
 		const names = result.map((e) => e.name);
@@ -866,7 +866,7 @@ export default defineConfig({
 	it("explicit overrides take precedence over spread defaults when spread present", () => {
 		const source = `const { workflows } = node();
 export default defineConfig({
-  workflows: [...workflows, { name: "test", with: { "run-unit": false } }],
+	workflows: [...workflows, { name: "test", with: { "run-unit": false } }],
 });`;
 		const result = parseWorkflowsFromTs(source);
 		const testEntry = result.find((e) => e.name === "test");

--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import { generateThinCallerContent, WORKFLOW_TEMPLATES } from "../commands/setup-workflows.js";
-import { gitBlobSha as _gitBlobSha, runSyncGithub } from "../commands/sync-github.js";
+import { gitBlobSha as _gitBlobSha, parseWorkflowsFromTs, runSyncGithub } from "../commands/sync-github.js";
 import { ACTIONS, REUSABLE_WORKFLOWS, WORKFLOW_TEMPLATE_PROPERTIES } from "../templates/index.js";
 
 // Actions, reusable workflow definitions, and workflow-templates are only pushed
@@ -836,5 +836,40 @@ describe("generateThinCallerContent", () => {
 		} finally {
 			delete WORKFLOW_TEMPLATES[sentinel];
 		}
+	});
+});
+
+describe("parseWorkflowsFromTs", () => {
+	it("returns explicit string and object entries when no spread", () => {
+		const source = `export default defineConfig({
+  workflows: ["lint", { name: "release", with: { "run-build": true } }],
+});`;
+		const result = parseWorkflowsFromTs(source);
+		expect(result.map((e) => e.name)).toEqual(["lint", "release"]);
+		expect(result.find((e) => e.name === "release")?.with).toEqual({ "run-build": true });
+	});
+
+	it("includes all known workflows when spread is present", () => {
+		const source = `const { workflows } = node();
+export default defineConfig({
+  workflows: [...workflows, "audit", { name: "deploy", with: { docs: true } }],
+});`;
+		const result = parseWorkflowsFromTs(source);
+		const names = result.map((e) => e.name);
+		expect(names).toContain("lint");
+		expect(names).toContain("test");
+		expect(names).toContain("bookkeeping");
+		expect(names).toContain("audit");
+		expect(names).toContain("deploy");
+	});
+
+	it("explicit overrides take precedence over spread defaults when spread present", () => {
+		const source = `const { workflows } = node();
+export default defineConfig({
+  workflows: [...workflows, { name: "test", with: { "run-unit": false } }],
+});`;
+		const result = parseWorkflowsFromTs(source);
+		const testEntry = result.find((e) => e.name === "test");
+		expect(testEntry?.with).toEqual({ "run-unit": false });
 	});
 });

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -9,6 +9,7 @@ import { ACTIONS, REUSABLE_WORKFLOWS, WORKFLOW_TEMPLATE_PROPERTIES } from "../te
 import {
 	deriveDeployPaths,
 	generateThinCallerContent,
+	KNOWN_WORKFLOWS,
 	normalizeWorkflowWith,
 	WORKFLOW_TEMPLATES,
 } from "./setup-workflows.js";
@@ -62,7 +63,7 @@ type WorkflowEntry = { name: string; with?: Record<string, unknown> };
  * Handles both plain string entries and `{ name, with }` object entries.
  * Falls back to an empty array if the array cannot be found or parsed.
  */
-function parseWorkflowsFromTs(source: string): WorkflowEntry[] {
+export function parseWorkflowsFromTs(source: string): WorkflowEntry[] {
 	const keyMatch = source.match(/\bworkflows\s*:\s*\[/);
 	if (!keyMatch) return [];
 
@@ -77,7 +78,12 @@ function parseWorkflowsFromTs(source: string): WorkflowEntry[] {
 	}
 	const body = source.slice(start, i - 1);
 
-	const entries: Array<{ pos: number; entry: WorkflowEntry }> = [];
+	// Detect spread operators like ...workflows (from node() / react() presets).
+	// When present, all known workflows are included as defaults so the sync
+	// doesn't silently skip workflows that come from the preset.
+	const hasPresetSpread = /\.\.\.[a-zA-Z_$][a-zA-Z0-9_$]*/.test(body);
+
+	const explicit: Array<{ pos: number; entry: WorkflowEntry }> = [];
 	const objSpans: Array<[number, number]> = [];
 
 	// Pass 1: object entries — { name: "foo", with: { ... }, paths: [...] }
@@ -99,19 +105,29 @@ function parseWorkflowsFromTs(source: string): WorkflowEntry[] {
 				/* ignore malformed with: value */
 			}
 		}
-		entries.push({ pos: m.index, entry: { name: m[1], ...(withObj && { with: withObj }) } });
+		explicit.push({ pos: m.index, entry: { name: m[1], ...(withObj && { with: withObj }) } });
 	}
 
 	// Pass 2: simple string entries — "workflowname" — skip chars inside object spans
 	const strRe = /"([^"]+)"/g;
 	while ((m = strRe.exec(body)) !== null) {
 		if (!objSpans.some(([s, e]) => m!.index >= s && m!.index < e)) {
-			entries.push({ pos: m.index, entry: { name: m[1] } });
+			explicit.push({ pos: m.index, entry: { name: m[1] } });
 		}
 	}
 
-	entries.sort((a, b) => a.pos - b.pos);
-	return entries.map(({ entry }) => entry);
+	explicit.sort((a, b) => a.pos - b.pos);
+	const explicitEntries = explicit.map(({ entry }) => entry);
+
+	if (!hasPresetSpread) return explicitEntries;
+
+	// Spread detected: seed with all known workflows, then let explicit entries
+	// override (e.g. to carry their with: overrides).
+	const merged = new Map<string, WorkflowEntry>([...KNOWN_WORKFLOWS].map((name) => [name, { name }]));
+	for (const entry of explicitEntries) {
+		merged.set(entry.name, entry);
+	}
+	return [...merged.values()];
 }
 
 function reusableHeader(source: string): string {


### PR DESCRIPTION
## Summary

`parseWorkflowsFromTs` now detects spread operators (`...workflows`, `...presetWorkflows`, etc.) in a `holocron.config.ts` workflows array and seeds the allowed-workflow set with all `KNOWN_WORKFLOWS` before applying explicit overrides.

## Why

Repos that use the `node()` preset pattern:
```ts
const { repo, workflows, providers } = node();
export default defineConfig({
  workflows: [...workflows, { name: "deploy", with: { docs: true } }],
});
```
…were silently skipped by `sync-workflow-templates` because the regex parser couldn't see through the spread. Only the explicitly listed entries (`deploy`) were included in the allowed set, so `lint`, `test`, `bookkeeping`, and all other preset-provided workflows were never synced.

## Behaviour

- **No spread** → unchanged: only explicitly listed workflows are synced
- **Spread present** → all `KNOWN_WORKFLOWS` are included as defaults; any explicit entries with `with:` overrides take precedence

## Test plan

- [ ] `pnpm --filter @theholocron/cli test` passes (660/660)
- [ ] Merge → next `sync-workflow-templates` run propagates `bookkeeping`, `test`, `lint` thin-caller fixes to all repos using `...workflows`
