### PR TITLE
docs: 📚 add cloudflare, discord, posthog, sentry, slack to plugin overview and capabilities

### DIFF
--- a/docs/src/content/docs/capabilities.md
+++ b/docs/src/content/docs/capabilities.md
@@ -146,7 +146,7 @@ Secret source-of-truth — read, write, list, and manage environments. Implement
 
 ### `dns`
 
-DNS record management. No first-party plugin ships yet — implement via a community plugin.
+DNS record management. Implemented by: [Cloudflare](./plugins/cloudflare).
 
 | Method                         | Description                       |
 | ------------------------------ | --------------------------------- |
@@ -169,16 +169,28 @@ Sync external tool state from the repo. Implemented by: [Postman](./plugins/post
 
 ### `notifications`
 
-Send messages. No first-party plugin ships yet.
+Send messages. Implemented by: [Discord](./plugins/discord), [Slack](./plugins/slack).
 
 | Method                   | Description                 |
 | ------------------------ | --------------------------- |
 | `send(channel, message)` | Send a message to a channel |
 
-### `analytics` / `observability`
+### `analytics`
 
-Describe the provider's DSN env key. No first-party plugin ships yet.
+Project provisioning and tracking token retrieval for product analytics. Implemented by: [PostHog](./plugins/posthog).
 
-| Method       | Description                      |
-| ------------ | -------------------------------- |
-| `describe()` | Return `{ provider, dsnEnvKey }` |
+| Method                | Description                                                      |
+| --------------------- | ---------------------------------------------------------------- |
+| `describe()`          | Return the provider name and required env var keys               |
+| `whoami()`            | Verify the personal API key                                      |
+| `ensureProject(name)` | Find or create a project, returning its tracking token           |
+
+### `observability`
+
+Error tracking — project provisioning and DSN retrieval. Implemented by: [Sentry](./plugins/sentry).
+
+| Method                  | Description                                                      |
+| ----------------------- | ---------------------------------------------------------------- |
+| `describe()`            | Return the provider name and required env var keys               |
+| `whoami()`              | Verify the token by fetching the organization                    |
+| `ensureProject(input)`  | Create or retrieve a project, returning its DSN                  |

--- a/docs/src/content/docs/capabilities.md
+++ b/docs/src/content/docs/capabilities.md
@@ -179,18 +179,18 @@ Send messages. Implemented by: [Discord](./plugins/discord), [Slack](./plugins/s
 
 Project provisioning and tracking token retrieval for product analytics. Implemented by: [PostHog](./plugins/posthog).
 
-| Method                | Description                                                      |
-| --------------------- | ---------------------------------------------------------------- |
-| `describe()`          | Return the provider name and required env var keys               |
-| `whoami()`            | Verify the personal API key                                      |
-| `ensureProject(name)` | Find or create a project, returning its tracking token           |
+| Method                | Description                                            |
+| --------------------- | ------------------------------------------------------ |
+| `describe()`          | Return the provider name and required env var keys     |
+| `whoami()`            | Verify the personal API key                            |
+| `ensureProject(name)` | Find or create a project, returning its tracking token |
 
 ### `observability`
 
 Error tracking — project provisioning and DSN retrieval. Implemented by: [Sentry](./plugins/sentry).
 
-| Method                  | Description                                                      |
-| ----------------------- | ---------------------------------------------------------------- |
-| `describe()`            | Return the provider name and required env var keys               |
-| `whoami()`              | Verify the token by fetching the organization                    |
-| `ensureProject(input)`  | Create or retrieve a project, returning its DSN                  |
+| Method                 | Description                                        |
+| ---------------------- | -------------------------------------------------- |
+| `describe()`           | Return the provider name and required env var keys |
+| `whoami()`             | Verify the token by fetching the organization      |
+| `ensureProject(input)` | Create or retrieve a project, returning its DSN    |

--- a/docs/src/content/docs/plugins/overview.md
+++ b/docs/src/content/docs/plugins/overview.md
@@ -37,11 +37,16 @@ Plugins are the adapters between the Holocron CLI's capability interfaces and re
 | [`@theholocron/holocron-plugin-github`](./github)       | source, ci, secrets, environments, issues | `HOLOCRON_*_TOKEN` (5 fine-grained PATs) |
 | [`@theholocron/holocron-plugin-vercel`](./vercel)       | deployment                                | `HOLOCRON_VERCEL_TOKEN`                  |
 | [`@theholocron/holocron-plugin-1password`](./1password) | vault                                     | `op` CLI auth (no stored token)          |
+| [`@theholocron/holocron-plugin-cloudflare`](./cloudflare) | dns                                     | `HOLOCRON_CLOUDFLARE_TOKEN`              |
+| [`@theholocron/holocron-plugin-discord`](./discord)     | notifications                             | `HOLOCRON_DISCORD_WEBHOOK`               |
 | [`@theholocron/holocron-plugin-doppler`](./doppler)     | vault                                     | `HOLOCRON_DOPPLER_TOKEN`                 |
 | [`@theholocron/holocron-plugin-infisical`](./infisical) | vault                                     | `HOLOCRON_INFISICAL_TOKEN`               |
 | [`@theholocron/holocron-plugin-clerk`](./clerk)         | auth                                      | `HOLOCRON_CLERK_SECRET_KEY`              |
 | [`@theholocron/holocron-plugin-neon`](./neon)           | storage                                   | `HOLOCRON_NEON_API_KEY`                  |
+| [`@theholocron/holocron-plugin-posthog`](./posthog)     | analytics                                 | `HOLOCRON_POSTHOG_TOKEN`                 |
 | [`@theholocron/holocron-plugin-postman`](./postman)     | tooling                                   | `HOLOCRON_POSTMAN_API_KEY`               |
+| [`@theholocron/holocron-plugin-sentry`](./sentry)       | observability                             | `HOLOCRON_SENTRY_TOKEN`                  |
+| [`@theholocron/holocron-plugin-slack`](./slack)         | notifications                             | `HOLOCRON_SLACK_TOKEN`                   |
 
 ## Writing a community plugin
 

--- a/docs/src/content/docs/plugins/overview.md
+++ b/docs/src/content/docs/plugins/overview.md
@@ -32,21 +32,21 @@ Plugins are the adapters between the Holocron CLI's capability interfaces and re
 
 ## First-party plugins
 
-| Plugin                                                  | Capability                                | Env var                                  |
-| ------------------------------------------------------- | ----------------------------------------- | ---------------------------------------- |
-| [`@theholocron/holocron-plugin-github`](./github)       | source, ci, secrets, environments, issues | `HOLOCRON_*_TOKEN` (5 fine-grained PATs) |
-| [`@theholocron/holocron-plugin-vercel`](./vercel)       | deployment                                | `HOLOCRON_VERCEL_TOKEN`                  |
-| [`@theholocron/holocron-plugin-1password`](./1password) | vault                                     | `op` CLI auth (no stored token)          |
-| [`@theholocron/holocron-plugin-cloudflare`](./cloudflare) | dns                                     | `HOLOCRON_CLOUDFLARE_TOKEN`              |
-| [`@theholocron/holocron-plugin-discord`](./discord)     | notifications                             | `HOLOCRON_DISCORD_WEBHOOK`               |
-| [`@theholocron/holocron-plugin-doppler`](./doppler)     | vault                                     | `HOLOCRON_DOPPLER_TOKEN`                 |
-| [`@theholocron/holocron-plugin-infisical`](./infisical) | vault                                     | `HOLOCRON_INFISICAL_TOKEN`               |
-| [`@theholocron/holocron-plugin-clerk`](./clerk)         | auth                                      | `HOLOCRON_CLERK_SECRET_KEY`              |
-| [`@theholocron/holocron-plugin-neon`](./neon)           | storage                                   | `HOLOCRON_NEON_API_KEY`                  |
-| [`@theholocron/holocron-plugin-posthog`](./posthog)     | analytics                                 | `HOLOCRON_POSTHOG_TOKEN`                 |
-| [`@theholocron/holocron-plugin-postman`](./postman)     | tooling                                   | `HOLOCRON_POSTMAN_API_KEY`               |
-| [`@theholocron/holocron-plugin-sentry`](./sentry)       | observability                             | `HOLOCRON_SENTRY_TOKEN`                  |
-| [`@theholocron/holocron-plugin-slack`](./slack)         | notifications                             | `HOLOCRON_SLACK_TOKEN`                   |
+| Plugin                                                    | Capability                                | Env var                                  |
+| --------------------------------------------------------- | ----------------------------------------- | ---------------------------------------- |
+| [`@theholocron/holocron-plugin-github`](./github)         | source, ci, secrets, environments, issues | `HOLOCRON_*_TOKEN` (5 fine-grained PATs) |
+| [`@theholocron/holocron-plugin-vercel`](./vercel)         | deployment                                | `HOLOCRON_VERCEL_TOKEN`                  |
+| [`@theholocron/holocron-plugin-1password`](./1password)   | vault                                     | `op` CLI auth (no stored token)          |
+| [`@theholocron/holocron-plugin-cloudflare`](./cloudflare) | dns                                       | `HOLOCRON_CLOUDFLARE_TOKEN`              |
+| [`@theholocron/holocron-plugin-discord`](./discord)       | notifications                             | `HOLOCRON_DISCORD_WEBHOOK`               |
+| [`@theholocron/holocron-plugin-doppler`](./doppler)       | vault                                     | `HOLOCRON_DOPPLER_TOKEN`                 |
+| [`@theholocron/holocron-plugin-infisical`](./infisical)   | vault                                     | `HOLOCRON_INFISICAL_TOKEN`               |
+| [`@theholocron/holocron-plugin-clerk`](./clerk)           | auth                                      | `HOLOCRON_CLERK_SECRET_KEY`              |
+| [`@theholocron/holocron-plugin-neon`](./neon)             | storage                                   | `HOLOCRON_NEON_API_KEY`                  |
+| [`@theholocron/holocron-plugin-posthog`](./posthog)       | analytics                                 | `HOLOCRON_POSTHOG_TOKEN`                 |
+| [`@theholocron/holocron-plugin-postman`](./postman)       | tooling                                   | `HOLOCRON_POSTMAN_API_KEY`               |
+| [`@theholocron/holocron-plugin-sentry`](./sentry)         | observability                             | `HOLOCRON_SENTRY_TOKEN`                  |
+| [`@theholocron/holocron-plugin-slack`](./slack)           | notifications                             | `HOLOCRON_SLACK_TOKEN`                   |
 
 ## Writing a community plugin
 


### PR DESCRIPTION
## Summary

- Added 5 missing first-party plugins (cloudflare, discord, posthog, sentry, slack) to the plugin overview table
- Updated `capabilities.md` to replace "No first-party plugin ships yet" stubs for `dns`, `notifications`, `analytics`, and `observability` with proper implementation references and method tables