### PR TITLE
fix(deploy): copy nameless storybook projects to sandbox/ not sandbox/null/

### DIFF
--- a/packages/cli/src/templates/workflows/deploy.yml
+++ b/packages/cli/src/templates/workflows/deploy.yml
@@ -14,9 +14,10 @@ on: # yamllint disable-line rule:truthy
         default: ""
       storybook-projects:
         description: >
-          JSON array of { "name", "workingDir", "outputDir"? } objects for monorepo multi-storybook
-          deploys. Each is built via `pnpm -C <workingDir> build:storybook` and assembled under
-          `sandbox/<name>/` alongside docs in a single deployment.
+          JSON array of { "name"?, "workingDir", "outputDir"? } objects for storybook deploys.
+          Each is built via `pnpm -C <workingDir> build:storybook`. If "name" is provided the
+          output is placed under `sandbox/<name>/`; omit "name" for single-repo deploys and the
+          output lands directly in `sandbox/`.
         type: string
         required: false
         default: "[]"
@@ -87,11 +88,16 @@ jobs:
           fi
           if [ "$PROJECTS" != "[]" ]; then
             echo "$PROJECTS" | jq -c '.[]' | while IFS= read -r project; do
-              name=$(echo "$project" | jq -r '.name')
+              name=$(echo "$project" | jq -r '.name // ""')
               workingDir=$(echo "$project" | jq -r '.workingDir')
               outputDir=$(echo "$project" | jq -r '.outputDir // "storybook-static"')
-              mkdir -p "_site/sandbox/${name}"
-              cp -r "${workingDir}/${outputDir}/." "_site/sandbox/${name}/"
+              if [ -n "$name" ]; then
+                target="_site/sandbox/${name}"
+              else
+                target="_site/sandbox"
+              fi
+              mkdir -p "$target"
+              cp -r "${workingDir}/${outputDir}/." "$target/"
             done
           elif [ "$DEPLOY_TYPE" = "storybook" ]; then
             mkdir -p _site/sandbox


### PR DESCRIPTION
## Summary

- For non-monorepo repos, storybook projects have no `name` in `storybook-projects`. Previously `jq -r '.name'` returned `null` (the string), so the output landed at `/sandbox/null/` — or with an explicit name like `"app"`, at `/sandbox/app/`.
- For single-repo deploys the storybook should be at `/sandbox/` directly.
- Fix: use `.name // ""` so an absent name gives an empty string, then branch on whether `$name` is non-empty to choose `sandbox/${name}` vs `sandbox`.
- Updated the input description to document the `name`-optional behaviour.