### PR TITLE
fix(sync-github): use bracket counting to parse with: blocks containing nested objects

### DIFF
--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -278,6 +278,53 @@ describe("runSyncGithub", () => {
 		expect(deployBlob?.body?.content).toContain("- docs/**");
 	});
 
+	it("parses with: blocks containing nested objects (e.g. storybook: [{ name: 'app' }])", async () => {
+		const configTs = `export default defineConfig({
+	workflows: [
+		{ name: "deploy", with: { docs: true, storybook: [{ name: "app" }] } },
+	],
+})`;
+		const { fn, calls } = makeFetch({}, undefined, configTs);
+		await runSyncGithub({
+			token: "ghp_test",
+			repo: "theholocron/.github-private",
+			branch: "chore/sync",
+			dryRun: false,
+			print: () => {},
+			fetch: fn,
+		});
+		const blobs = calls.filter((c) => c.method === "POST" && c.url.includes("/git/blobs"));
+		const deployBlob = blobs.find(
+			(c) => typeof c.body?.content === "string" && (c.body.content as string).includes("name: Deploy")
+		);
+		// docs: true → type: docs; storybook: [{ name: "app" }] → storybook-projects with name
+		expect(deployBlob?.body?.content).toContain("type: docs");
+		expect(deployBlob?.body?.content).toContain("storybook-projects:");
+		expect(deployBlob?.body?.content).toContain("name");
+	});
+
+	it("skips objects in the workflows array that have no name property", async () => {
+		const configTs = `export default defineConfig({
+	workflows: [
+		{ path: "." },
+		{ name: "lint" },
+	],
+})`;
+		const { fn, calls } = makeFetch({}, undefined, configTs);
+		await runSyncGithub({
+			token: "ghp_test",
+			repo: "theholocron/.github-private",
+			branch: "chore/sync",
+			dryRun: false,
+			print: () => {},
+			fetch: fn,
+		});
+		const blobs = calls.filter((c) => c.method === "POST" && c.url.includes("/git/blobs"));
+		// Only lint should be synced — the nameless object is skipped
+		expect(blobs).toHaveLength(1);
+		expect(blobs[0]?.body?.content).toContain("name: Lint");
+	});
+
 	it("parses name-only object entry with trailing comma", async () => {
 		const configTs = `export default defineConfig({
 	workflows: [

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -86,30 +86,58 @@ export function parseWorkflowsFromTs(source: string): WorkflowEntry[] {
 	const explicit: Array<{ pos: number; entry: WorkflowEntry }> = [];
 	const objSpans: Array<[number, number]> = [];
 
-	// Pass 1: object entries — { name: "foo", with: { ... }, paths: [...] }
-	// (?:\s*,[^}]*)? skips any additional properties (e.g. paths: [...]) whose
-	// values don't contain } — covers arrays and strings but not nested objects.
-	// The trailing ,? handles TS trailing commas: with: { ... },  }
-	const objRe = /\{\s*name\s*:\s*"([^"]+)"(?:\s*,\s*with\s*:\s*(\{[^}]*\}))?(?:\s*,[^}]*)?\s*,?\s*\}/g;
-	let m: RegExpExecArray | null;
-	while ((m = objRe.exec(body)) !== null) {
-		objSpans.push([m.index, m.index + m[0].length]);
+	// Pass 1: extract top-level { ... } objects using bracket counting so that
+	// nested braces inside with: values (e.g. storybook: [{ name: "app" }])
+	// are handled correctly. The previous regex approach stopped at the first }
+	// inside a nested object, causing JSON.parse to fail and with: to be silently
+	// dropped from the generated thin caller.
+	let j = 0;
+	while (j < body.length) {
+		if (body[j] !== "{") { j++; continue; }
+
+		const objStart = j;
+		let objDepth = 1;
+		j++;
+		while (j < body.length && objDepth > 0) {
+			if (body[j] === "{") objDepth++;
+			else if (body[j] === "}") objDepth--;
+			j++;
+		}
+		const objContent = body.slice(objStart, j);
+		objSpans.push([objStart, j]);
+
+		const nameMatch = objContent.match(/\bname\s*:\s*"([^"]+)"/);
+		if (!nameMatch) continue;
+		const name = nameMatch[1];
+
 		let withObj: Record<string, unknown> | undefined;
-		if (m[2]) {
+		const withKeyMatch = objContent.match(/\bwith\s*:\s*\{/);
+		if (withKeyMatch) {
+			const withOpen = withKeyMatch.index! + withKeyMatch[0].length - 1;
+			let withDepth = 1;
+			let k = withOpen + 1;
+			while (k < objContent.length && withDepth > 0) {
+				if (objContent[k] === "{") withDepth++;
+				else if (objContent[k] === "}") withDepth--;
+				k++;
+			}
+			const withStr = objContent.slice(withOpen, k);
 			try {
 				// TS object literals use unquoted keys (docs: true); JSON requires quoted keys.
 				// Normalise before parsing so both forms work.
-				const jsonSafe = m[2].replace(/([{,]\s*)([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:/g, '$1"$2":');
+				const jsonSafe = withStr.replace(/([{,]\s*)([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:/g, '$1"$2":');
 				withObj = JSON.parse(jsonSafe) as Record<string, unknown>;
 			} catch {
 				/* ignore malformed with: value */
 			}
 		}
-		explicit.push({ pos: m.index, entry: { name: m[1], ...(withObj && { with: withObj }) } });
+
+		explicit.push({ pos: objStart, entry: { name, ...(withObj && { with: withObj }) } });
 	}
 
 	// Pass 2: simple string entries — "workflowname" — skip chars inside object spans
 	const strRe = /"([^"]+)"/g;
+	let m: RegExpExecArray | null;
 	while ((m = strRe.exec(body)) !== null) {
 		if (!objSpans.some(([s, e]) => m!.index >= s && m!.index < e)) {
 			explicit.push({ pos: m.index, entry: { name: m[1] } });

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -93,7 +93,10 @@ export function parseWorkflowsFromTs(source: string): WorkflowEntry[] {
 	// dropped from the generated thin caller.
 	let j = 0;
 	while (j < body.length) {
-		if (body[j] !== "{") { j++; continue; }
+		if (body[j] !== "{") {
+			j++;
+			continue;
+		}
 
 		const objStart = j;
 		let objDepth = 1;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -207,7 +207,7 @@ export interface ChromaticProjectConfig {
  * `path` is the working directory relative to the repo root; defaults to `"."` (repo root) when omitted.
  */
 export interface StorybookDeployProject {
-	name: string;
+	name?: string;
 	path?: string;
 }
 


### PR DESCRIPTION
## Summary

`parseWorkflowsFromTs` used `/\{[^}]*\}/` to capture the `with:` value from `holocron.config.ts`. Any value containing nested braces (e.g. `storybook: [{ name: "app" }]`) caused the regex to stop at the first inner `}`, making JSON.parse fail silently — so `with` was dropped and every sync generated a bare thin caller with no `with:` block.

- Replaced the regex-based object + `with:` extraction with bracket counting
- Added a regression test covering nested objects in `with:` values
- Made `StorybookDeployProject.name` optional so single-repo configs (`storybook: [{}]`) pass typecheck