### PR TITLE
fix(sync-github): strip trailing commas before JSON.parse so nested TS objects parse correctly

### DIFF
--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -919,4 +919,34 @@ export default defineConfig({
 		const testEntry = result.find((e) => e.name === "test");
 		expect(testEntry?.with).toEqual({ "run-unit": false });
 	});
+
+	it("parses with: blocks that contain nested objects with unquoted keys and trailing commas", () => {
+		// Matches the real-world shape from react-template's holocron.config.ts where
+		// run-chromatic uses a nested { projects: [...] } TypeScript object literal.
+		// The key-quoting regex handles unquoted keys; trailing comma stripping is needed
+		// because TS allows trailing commas but JSON.parse does not.
+		const source = `export default defineConfig({
+	workflows: [
+		{
+			name: "test",
+			with: {
+				"run-unit": false,
+				"run-storybook": true,
+				"run-chromatic": {
+					projects: [{ tokenName: "default", workingDir: ".", buildScript: "build:storybook:chromatic" }],
+				},
+			},
+		},
+	],
+});`;
+		const result = parseWorkflowsFromTs(source);
+		const testEntry = result.find((e) => e.name === "test");
+		expect(testEntry?.with).toEqual({
+			"run-unit": false,
+			"run-storybook": true,
+			"run-chromatic": {
+				projects: [{ tokenName: "default", workingDir: ".", buildScript: "build:storybook:chromatic" }],
+			},
+		});
+	});
 });

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -126,9 +126,14 @@ export function parseWorkflowsFromTs(source: string): WorkflowEntry[] {
 			}
 			const withStr = objContent.slice(withOpen, k);
 			try {
-				// TS object literals use unquoted keys (docs: true); JSON requires quoted keys.
-				// Normalise before parsing so both forms work.
-				const jsonSafe = withStr.replace(/([{,]\s*)([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:/g, '$1"$2":');
+				// TS object literals differ from JSON in two ways:
+				//   1. Unquoted keys:      { docs: true }   → { "docs": true }
+				//   2. Trailing commas:    { a: 1, }        → { a: 1 }
+				// Normalise both before parsing so nested objects like
+				// run-chromatic: { projects: [...], } are handled correctly.
+				const jsonSafe = withStr
+					.replace(/([{,]\s*)([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:/g, '$1"$2":')
+					.replace(/,(\s*[}\]])/g, "$1");
 				withObj = JSON.parse(jsonSafe) as Record<string, unknown>;
 			} catch {
 				/* ignore malformed with: value */


### PR DESCRIPTION
TypeScript allows trailing commas in object literals (e.g. `projects: [...],`}) but `JSON.parse` does not. The `with:` block in `parseWorkflowsFromTs` was silently discarded whenever the config had a nested object with a trailing comma — causing sync to fall back to the bare default template and clobber custom workflow config like the Chromatic projects array in `react-template`. Adds trailing comma stripping to the same preprocessing step that already handles unquoted key quoting, and adds a test covering the exact `run-chromatic: { projects: [...], }` shape.