### PR TITLE
fix: 🐛 unify workflow header between setup and sync-github

### DIFF
--- a/packages/cli/src/__tests__/sync-github.test.ts
+++ b/packages/cli/src/__tests__/sync-github.test.ts
@@ -919,4 +919,34 @@ export default defineConfig({
 		const testEntry = result.find((e) => e.name === "test");
 		expect(testEntry?.with).toEqual({ "run-unit": false });
 	});
+
+	it("parses with: blocks that contain nested objects with unquoted keys and trailing commas", () => {
+		// Matches the real-world shape from react-template's holocron.config.ts where
+		// run-chromatic uses a nested { projects: [...] } TypeScript object literal.
+		// The key-quoting regex handles unquoted keys; trailing comma stripping is needed
+		// because TS allows trailing commas but JSON.parse does not.
+		const source = `export default defineConfig({
+	workflows: [
+		{
+			name: "test",
+			with: {
+				"run-unit": false,
+				"run-storybook": true,
+				"run-chromatic": {
+					projects: [{ tokenName: "default", workingDir: ".", buildScript: "build:storybook:chromatic" }],
+				},
+			},
+		},
+	],
+});`;
+		const result = parseWorkflowsFromTs(source);
+		const testEntry = result.find((e) => e.name === "test");
+		expect(testEntry?.with).toEqual({
+			"run-unit": false,
+			"run-storybook": true,
+			"run-chromatic": {
+				projects: [{ tokenName: "default", workingDir: ".", buildScript: "build:storybook:chromatic" }],
+			},
+		});
+	});
 });

--- a/packages/cli/src/commands/setup-workflows.ts
+++ b/packages/cli/src/commands/setup-workflows.ts
@@ -21,13 +21,28 @@ import staleYml from "./workflows/stale.yml";
 import testYml from "./workflows/test.yml";
 import typecheckYml from "./workflows/typecheck.yml";
 
-/** Header prepended when holocron setup writes a generated file to a repo. */
-export function workflowHeader(source = "packages/cli/src/commands/setup-workflows.ts"): string {
+/**
+ * Header prepended to every auto-generated workflow thin caller.
+ *
+ * Used by both `holocron setup` (initial creation) and `holocron sync-github`
+ * (subsequent updates) so the header is always identical regardless of which
+ * command last wrote the file.
+ *
+ * @param source - path within theholocron/holocron that owns the template
+ * @param forPrimary - true only when writing to theholocron/.github itself
+ */
+export function workflowHeader(
+	source = "packages/cli/src/commands/setup-workflows.ts",
+	forPrimary = false,
+): string {
+	const doNotEdit = forPrimary
+		? `# AUTO-GENERATED — do not edit in theholocron/.github directly.`
+		: `# AUTO-GENERATED — do not edit directly.`;
 	return [
-		`# AUTO-GENERATED — do not edit directly.`,
+		doNotEdit,
 		`# Source:  theholocron/holocron · ${source}`,
-		`# Tool:    holocron setup`,
-		`# Changes: run \`holocron setup\` to regenerate.`,
+		`# Tool:    holocron sync-github`,
+		`# Changes: edit source in theholocron/holocron and push to alpha or main.`,
 		``,
 	].join("\n");
 }

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -126,9 +126,14 @@ export function parseWorkflowsFromTs(source: string): WorkflowEntry[] {
 			}
 			const withStr = objContent.slice(withOpen, k);
 			try {
-				// TS object literals use unquoted keys (docs: true); JSON requires quoted keys.
-				// Normalise before parsing so both forms work.
-				const jsonSafe = withStr.replace(/([{,]\s*)([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:/g, '$1"$2":');
+				// TS object literals differ from JSON in two ways:
+				//   1. Unquoted keys:      { docs: true }   → { "docs": true }
+				//   2. Trailing commas:    { a: 1, }        → { a: 1 }
+				// Normalise both before parsing so nested objects like
+				// run-chromatic: { projects: [...], } are handled correctly.
+				const jsonSafe = withStr
+					.replace(/([{,]\s*)([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:/g, '$1"$2":')
+					.replace(/,(\s*[}\]])/g, "$1");
 				withObj = JSON.parse(jsonSafe) as Record<string, unknown>;
 			} catch {
 				/* ignore malformed with: value */

--- a/packages/cli/src/commands/sync-github.ts
+++ b/packages/cli/src/commands/sync-github.ts
@@ -12,6 +12,7 @@ import {
 	KNOWN_WORKFLOWS,
 	normalizeWorkflowWith,
 	WORKFLOW_TEMPLATES,
+	workflowHeader,
 } from "./setup-workflows.js";
 
 const DEFAULT_REPO = "theholocron/.github";
@@ -177,18 +178,6 @@ function reusableHeader(source: string): string {
 	].join("\n");
 }
 
-function thinCallerHeader(forPrimary = false): string {
-	const doNotEdit = forPrimary
-		? `# AUTO-GENERATED — do not edit in theholocron/.github directly.`
-		: `# AUTO-GENERATED — do not edit directly.`;
-	return [
-		doNotEdit,
-		`# Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts`,
-		`# Tool:    holocron sync-github`,
-		`# Changes: edit source in theholocron/holocron and push to alpha or main.`,
-		``,
-	].join("\n");
-}
 
 function buildBatch(
 	repo: string,
@@ -218,7 +207,7 @@ function buildBatch(
 		for (const [name, content] of Object.entries(WORKFLOW_TEMPLATES)) {
 			files.push({
 				path: `workflow-templates/${name}.yml`,
-				content: thinCallerHeader(true) + content,
+				content: workflowHeader(undefined, true) + content,
 			});
 			const props = WORKFLOW_TEMPLATE_PROPERTIES[name];
 			if (props) {
@@ -238,7 +227,7 @@ function buildBatch(
 			if (!content) continue;
 			files.push({
 				path: `.github/workflows/${name}.yml`,
-				content: thinCallerHeader() + content,
+				content: workflowHeader() + content,
 			});
 		}
 	}


### PR DESCRIPTION
## Summary

`holocron setup` and `holocron sync-github` both write auto-generated header comments to thin caller workflow files, but they used two completely separate implementations that had diverged:

- `setup` called `workflowHeader()` in `setup-workflows.ts`, which labeled files with `# Tool: holocron setup` and `# Changes: run 'holocron setup' to regenerate.`
- `sync-github` called a local `thinCallerHeader()` defined only in `sync-github.ts`, which correctly labeled files with `# Tool: holocron sync-github` and `# Changes: edit source in theholocron/holocron and push to alpha or main.`

This meant every time `holocron setup` ran on a repo, it would overwrite the header that `sync-github` had previously written (and vice versa), producing confusing diffs where only the header changed.

## Fix

- Update `workflowHeader()` in `setup-workflows.ts` to produce the `sync-github` format — this is the correct long-term label since `sync-github` is the mechanism that keeps files current after initial setup
- Add `forPrimary` parameter to handle the `theholocron/.github` case (matching what `thinCallerHeader` already handled)
- Delete `thinCallerHeader()` from `sync-github.ts` — it duplicated `workflowHeader()` with no reason to exist separately
- Import and use `workflowHeader()` in both call sites in `sync-github.ts`

## Test plan

- [ ] `pnpm typecheck` passes in `packages/cli`
- [ ] Running `holocron setup` on a fresh repo produces the same header as a subsequent `holocron sync-github` run
- [ ] The `forPrimary = true` path still writes the correct `.github`-specific header
